### PR TITLE
Add "Vertical" tile layout option to the Tile Viewer

### DIFF
--- a/Core/Debugger/DebugTypes.h
+++ b/Core/Debugger/DebugTypes.h
@@ -210,7 +210,8 @@ enum class TileLayout
 {
 	Normal,
 	SingleLine8x16,
-	SingleLine16x16
+	SingleLine16x16,
+	Vertical
 };
 
 enum class TileBackground

--- a/Core/Debugger/PpuTools.cpp
+++ b/Core/Debugger/PpuTools.cpp
@@ -141,13 +141,14 @@ void PpuTools::InternalGetTileView(GetTileViewOptions options, uint8_t *source, 
 	int rowCount = (int)std::ceil((double)tileCount / options.Width);
 
 	for(int row = 0; row < rowCount; row++) {
-		uint32_t baseOffset = row * bytesPerTile * options.Width;
+		uint32_t baseOffset = (options.Layout == TileLayout::Vertical) ? (row * bytesPerTile) : (row * bytesPerTile * options.Width);
+		
 		if(baseOffset >= srcSize) {
 			break;
 		}
 
 		for(int column = 0; column < options.Width; column++) {
-			uint32_t addr = baseOffset + bytesPerTile * column;
+			uint32_t addr = (options.Layout == TileLayout::Vertical) ? (baseOffset + bytesPerTile * column * options.Height) : (baseOffset + bytesPerTile * column);
 
 			int baseOutputOffset;
 			if(options.Layout == TileLayout::SingleLine8x16) {

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -362,6 +362,11 @@ namespace Mesen.Debugger.ViewModels
 					return new PixelPoint(displayColumn, displayRow);
 				}
 
+				case TileLayout.Vertical: {
+					int index = row * ColumnCount + column;
+					return new PixelPoint(index / RowCount, index % RowCount);
+				}
+
 				case TileLayout.Normal:
 					return pos;
 
@@ -392,6 +397,11 @@ namespace Mesen.Debugger.ViewModels
 					int displayColumn = ((column & ~0x01) * 2 + ((row & 0x01) != 0 ? 2 : 0) + (column & 0x01)) % ColumnCount;
 					int displayRow = (row & ~0x01) + ((column >= ColumnCount / 2) ? 1 : 0);
 					return new PixelPoint(displayColumn, displayRow);
+				}
+
+				case TileLayout.Vertical: {
+					int index = column * RowCount + row;
+					return new PixelPoint(index % ColumnCount, index / ColumnCount);
 				}
 
 				case TileLayout.Normal:

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -1422,7 +1422,8 @@ namespace Mesen.Interop
 	{
 		Normal,
 		SingleLine8x16,
-		SingleLine16x16
+		SingleLine16x16,
+		Vertical
 	};
 
 	[Serializable]

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -2898,6 +2898,7 @@ E
 			<Value ID="Normal">Normal</Value>
 			<Value ID="SingleLine8x16">8x16 (same line)</Value>
 			<Value ID="SingleLine16x16">16x16 (same line)</Value>
+			<Value ID="Vertical">Vertical</Value>
 		</Enum>
 		<Enum ID="TileFilter">
 			<Value ID="None">None</Value>


### PR DESCRIPTION
Many HAL games (Kirby's Adventure, Rollerball, the Lolo series, Metal Slader Glory, etc.) arrange their graphics in a column major format, instead of the usual row major. Additionally, I've seen several SNES games use column major for software rendered bitmaps, like Stunt Race FX, Star Fox, Bust-A-Move, so this helps out with reverse engineering those games and viewing those bitmaps in the process of being made.

These changes are simple enough that it probably doesn't matter, but just to be explicit, I waive any copyright protection I may have to the changes and I'm okay with them being relicensed.