### PR TITLE
RAMBO-1 rework to fix initial state

### DIFF
--- a/Core/NES/Mappers/Tengen/Rambo1.h
+++ b/Core/NES/Mappers/Tengen/Rambo1.h
@@ -18,11 +18,20 @@ protected:
 	uint8_t _irqReloadValue = 0;
 	uint8_t _cpuClockCounter = 0;
 	A12Watcher _a12Watcher;
-
+	
+	uint8_t _prgMode = 0;
+	uint8_t _chrMode = 0;
 	uint8_t _currentRegister = 0;
 	uint8_t _registers[16] = {};
 	uint8_t _needIrqDelay = 0;
 	bool _forceClock = false;
+	
+	struct Rambo1State
+	{
+		uint8_t Reg8000;
+		uint8_t RegA000;
+		//uint8_t RegA001; // unknown
+	} _state = {};
 
 protected:
 	uint16_t GetPrgPageSize() override { return 0x2000; }
@@ -32,8 +41,40 @@ protected:
 
 	void InitMapper() override
 	{
+		_state.Reg8000 = GetPowerOnByte();
+		_state.RegA000 = GetPowerOnByte();
+		//_state.RegA001 = GetPowerOnByte();
+
+		_chrMode = GetPowerOnByte() & 0x01;
+		_prgMode = GetPowerOnByte() & 0x01;
+		
+		_currentRegister = GetPowerOnByte();
+		
+		// First 8 are shared with MMC3
 		memset(_registers, 0, sizeof(_registers));
-		SelectPrgPage(3, -1);
+		_registers[0] = GetPowerOnByte(0);
+		_registers[1] = GetPowerOnByte(2);
+		_registers[2] = GetPowerOnByte(4);
+		_registers[3] = GetPowerOnByte(5);
+		_registers[4] = GetPowerOnByte(6);
+		_registers[5] = GetPowerOnByte(7);
+		_registers[6] = GetPowerOnByte(0);
+		_registers[7] = GetPowerOnByte(1);
+		
+		// RAMBO-1 exclusive
+		_registers[8] = GetPowerOnByte(8);
+		_registers[9] = GetPowerOnByte(9);
+		
+		// Police Academy prototype relies on initial $C000 bank selection
+		_registers[15] = GetPowerOnByte(2);
+
+		_irqCounter = GetPowerOnByte();
+		_irqReloadValue = GetPowerOnByte();
+		_needReload = GetPowerOnByte() & 0x01;
+		_irqEnabled = GetPowerOnByte() & 0x01;
+		
+		UpdateState();
+		UpdateMirroring();
 	}
 
 	void Serialize(Serializer& s) override
@@ -41,6 +82,12 @@ protected:
 		BaseMapper::Serialize(s);
 		SVArray(_registers, 16);
 		SV(_a12Watcher);
+		SV(_state.Reg8000);
+		SV(_state.RegA000);
+		//SV(_state.RegA001);
+		SV(_currentRegister);
+		SV(_chrMode);
+		SV(_prgMode);
 		SV(_irqEnabled);
 		SV(_irqCycleMode);
 		SV(_needReload);
@@ -48,7 +95,6 @@ protected:
 		SV(_irqCounter);
 		SV(_irqReloadValue);
 		SV(_cpuClockCounter);
-		SV(_currentRegister);
 		SV(_forceClock);
 	}
 
@@ -93,19 +139,29 @@ protected:
 		}
 	}
 
-	void UpdateState()
+	void UpdateMirroring()
 	{
-		if(_currentRegister & 0x40) {
-			SelectPrgPage(0, _registers[15]);
-			SelectPrgPage(1, _registers[6]);
-			SelectPrgPage(2, _registers[7]);
-		} else {
+		SetMirroringType(((_state.RegA000 & 0x01) == 0x01) ? MirroringType::Horizontal : MirroringType::Vertical);
+	}
+
+	void UpdatePrgMapping()
+	{
+		if(_prgMode == 0) {
 			SelectPrgPage(0, _registers[6]);
 			SelectPrgPage(1, _registers[7]);
 			SelectPrgPage(2, _registers[15]);
+			SelectPrgPage(3, -1);
+		} else if(_prgMode == 1){
+			SelectPrgPage(0, _registers[15]);
+			SelectPrgPage(1, _registers[7]);
+			SelectPrgPage(2, _registers[6]);
+			SelectPrgPage(3, -1);
 		}
+	}
 
-		uint8_t a12Inversion = _currentRegister & 0x80 ? 0x04 : 0x00;
+	void UpdateChrMapping()
+	{
+		uint8_t a12Inversion = _chrMode << 6;
 		SelectChrPage(0 ^ a12Inversion, _registers[0]);
 		SelectChrPage(2 ^ a12Inversion, _registers[1]);
 		SelectChrPage(4 ^ a12Inversion, _registers[2]);
@@ -113,29 +169,40 @@ protected:
 		SelectChrPage(6 ^ a12Inversion, _registers[4]);
 		SelectChrPage(7 ^ a12Inversion, _registers[5]);
 
-		if(_currentRegister & 0x20) {
+		if(_state.Reg8000 & 0x20) {
 			SelectChrPage(1 ^ a12Inversion, _registers[8]);
 			SelectChrPage(3 ^ a12Inversion, _registers[9]);
 		} else {
-			SelectChrPage(1 ^ a12Inversion, _registers[0]+1);
-			SelectChrPage(3 ^ a12Inversion, _registers[1]+1);
-		}		
+			SelectChrPage(1 ^ a12Inversion, _registers[0] | 0x01);
+			SelectChrPage(3 ^ a12Inversion, _registers[1] | 0x01);
+		}
+	}
+
+	void UpdateState()
+	{
+		_currentRegister = _state.Reg8000 & 0x0F;
+		_chrMode = (_state.Reg8000 & 0x80) >> 7;
+		_prgMode = (_state.Reg8000 & 0x40) >> 6;
+		UpdatePrgMapping();
+		UpdateChrMapping();
 	}
 
 	void WriteRegister(uint16_t addr, uint8_t value) override
 	{
 		switch(addr & 0xE001) {
 			case 0x8000: 
-				_currentRegister = value;
+				_state.Reg8000 = value;
+				UpdateState();
 				break;
 
 			case 0x8001:
-				_registers[_currentRegister & 0x0F] = value;
+				_registers[_currentRegister] = value;
 				UpdateState();
 				break;
 			
 			case 0xA000: 
-				SetMirroringType(value & 0x01 ? MirroringType::Horizontal : MirroringType::Vertical); 
+				_state.RegA000 = value;
+				UpdateMirroring();
 				break;
 
 			case 0xC000: 

--- a/Core/NES/Mappers/Tengen/Rambo1_158.h
+++ b/Core/NES/Mappers/Tengen/Rambo1_158.h
@@ -8,8 +8,8 @@ class Rambo1_158 : public Rambo1
 	{
 		if((addr & 0xE001) == 0x8001) {
 			uint8_t nametable = value >> 7;
-
-			if(_currentRegister & 0x80) {
+			// note: registers 8 & 9 are not implemented
+			if(_chrMode == 1) {
 				switch(_currentRegister & 0x07) {
 					case 2: SetNametable(0, nametable); break;
 					case 3: SetNametable(1, nametable); break;


### PR DESCRIPTION
This PR reworks the RAMBO-1 handling to fix its initial state and bring its overall code structure closer to MMC3. Previously, all the registers were set to 0 and only the fixed bank was mapped on startup (i.e. other PRG sections were erroneously unmapped instead of following the initial state setting).

The most apparent change is that register 15 ($C000 bank selection in PRG mode 0) is now set to 2 when the mapper state is not randomised. This is for compatibility with the Police Academy prototype, which calls sound driver routines before setting the correct bank.

I have only verified that all known RAMBO-1 titles boot and display any attract modes. (IRQ behaviour is unaltered) Thorough testing is appreciated, especially for PRG mode 1 (where Mesen2 originally had the register 6/7 order swapped).

P.S.: The mapper 158 variant seemingly does not implement registers 8 or 9, probably because the only game which uses it (NES Alien Syndrome) never accesses them. It may be worth looking into for a future PR.

Patches are public domain, MIT-0, or anything else Sour wishes.