### PR TITLE
Various accuracy improvements

### DIFF
--- a/Core/NES/BaseNesPpu.h
+++ b/Core/NES/BaseNesPpu.h
@@ -103,7 +103,9 @@ protected:
 	bool _needVideoRamIncrement = false;
 	bool _allowFullPpuAccess = false;
 
-	uint8_t _ppuMemoryDataStateMachine = 0;
+	uint8_t _ppuMemoryDataReadStateMachine = 0;
+	uint8_t _ppuMemoryDataWriteStateMachine = 0;
+	uint8_t _ppuMemoryDataWriteLatch = 0;
 	uint8_t _memoryReadBuffer = 0;
 	PPUStatusFlags _statusFlags = {};
 

--- a/Core/NES/BaseNesPpu.h
+++ b/Core/NES/BaseNesPpu.h
@@ -103,6 +103,7 @@ protected:
 	bool _needVideoRamIncrement = false;
 	bool _allowFullPpuAccess = false;
 
+	uint8_t _ppuMemoryDataStateMachine = 0;
 	uint8_t _memoryReadBuffer = 0;
 	PPUStatusFlags _statusFlags = {};
 

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -523,7 +523,6 @@ private:
 	}
 
 	void RTS() {
-		DummyRead();
 		MemoryRead(0x100 + SP(), MemoryOperationType::DummyRead);
 		uint16_t addr = PopWord();
 		SetPC(addr);

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -440,7 +440,7 @@ private:
 			DummyRead();
 
 			if(CheckPageCrossed(PC(), offset)) {
-				MemoryRead(((PC()&0xFF00)|((PC()+offset)&0xFF)), MemoryOperationType::DummyRead);
+				MemoryRead(((PC() & 0xFF00) | ((PC() + offset) & 0xFF)), MemoryOperationType::DummyRead);
 			}
 
 			SetPC(PC() + offset);
@@ -524,6 +524,7 @@ private:
 
 	void RTS() {
 		DummyRead();
+		MemoryRead(0x100 + SP(), MemoryOperationType::DummyRead);
 		uint16_t addr = PopWord();
 		SetPC(addr);
 		DummyRead();

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -440,7 +440,7 @@ private:
 			DummyRead();
 
 			if(CheckPageCrossed(PC(), offset)) {
-				DummyRead();
+				MemoryRead(((PC()&0xFF00)|((PC()+offset)&0xFF)), MemoryOperationType::DummyRead);
 			}
 
 			SetPC(PC() + offset);
@@ -525,6 +525,7 @@ private:
 	void RTS() {
 		DummyRead();
 		uint16_t addr = PopWord();
+		SetPC(addr);
 		DummyRead();
 		SetPC(addr + 1);
 	}

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -1587,6 +1587,10 @@ template<class T> void NesPpu<T>::Serialize(Serializer& s)
 
 		SV(_allowFullPpuAccess);
 
+		SV(_ppuMemoryDataReadStateMachine);
+		SV(_ppuMemoryDataWriteStateMachine);
+		SV(_ppuMemoryDataWriteLatch);
+
 		for(int i = 0; i < _spriteCount; i++) {
 			SVI(_spriteTiles[i].SpriteX); SVI(_spriteTiles[i].LowByte); SVI(_spriteTiles[i].HighByte); SVI(_spriteTiles[i].PaletteOffset); SVI(_spriteTiles[i].HorizontalMirror); SVI(_spriteTiles[i].BackgroundPriority);
 		}

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -1494,15 +1494,21 @@ template<class T> void NesPpu<T>::UpdateState()
 		}
 	}
 
+	if(_needVideoRamIncrement) {
+		//Delay vram address increment by 1 ppu cycle after a read/write to 2007
+		//This allows the full_palette tests to properly display single-pixel glitches 
+		//that display the "wrong" color on the screen until the increment occurs (matches hardware)
+		_needVideoRamIncrement = false;
+		UpdateVideoRamAddr();
+	}
+
 	if(_ppuMemoryDataReadStateMachine > 0) {
 		_ppuMemoryDataReadStateMachine--;
 		if(_ppuMemoryDataReadStateMachine == 0) {
 			_memoryReadBuffer = ReadVram(_ppuBusAddress & 0x3FFF, MemoryOperationType::Read);
 			_needVideoRamIncrement = true;
 		}
-		else {
 			_needStateUpdate = true;
-		}
 	}
 
 	if(_ppuMemoryDataWriteStateMachine > 0) {
@@ -1522,17 +1528,7 @@ template<class T> void NesPpu<T>::UpdateState()
 			}
 			_needVideoRamIncrement = true;
 		}
-		else {
 			_needStateUpdate = true;
-		}
-	}
-
-	if(_needVideoRamIncrement) {
-		//Delay vram address increment by 1 ppu cycle after a read/write to 2007
-		//This allows the full_palette tests to properly display single-pixel glitches 
-		//that display the "wrong" color on the screen until the increment occurs (matches hardware)
-		_needVideoRamIncrement = false;
-		UpdateVideoRamAddr();
 	}
 }
 

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -664,9 +664,10 @@ template<class T> void NesPpu<T>::LoadTileInfo()
 				_previousTilePalette = _currentTilePalette;
 				_currentTilePalette = _tile.PaletteOffset;
 
-				_lowBitShift |= _tile.LowByte;
-				_highBitShift &= 0xFF00;
+				_highBitShift &= 0xFF00; // This shift register pulls in 1's, so we need to mask away the lower 8 bits before bringing in the data from the tile fetch.
 				_highBitShift |= _tile.HighByte;
+				_lowBitShift &= 0xFF00; // Similar to the high bit plane, it's possible there are 1's in the lower 8 bits if you toggle rendering at the right time.
+				_lowBitShift |= _tile.LowByte;
 
 				uint8_t tileIndex = ReadVram(GetNameTableAddr());
 				_tile.TileAddr = (tileIndex << 4) | (_videoRamAddr >> 12) | _control.BackgroundPatternAddr;

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -675,6 +675,7 @@ template<class T> void NesPpu<T>::LoadTileInfo()
 				_currentTilePalette = _tile.PaletteOffset;
 
 				_lowBitShift |= _tile.LowByte;
+				_highBitShift &= 0xFF00;
 				_highBitShift |= _tile.HighByte;
 
 				uint8_t tileIndex = ReadVram(GetNameTableAddr());
@@ -812,6 +813,7 @@ template<class T> void NesPpu<T>::ShiftTileRegisters()
 {
 	_lowBitShift <<= 1;
 	_highBitShift <<= 1;
+	_highBitShift |= 1;
 }
 
 template<class T> uint8_t NesPpu<T>::GetPixelColor()
@@ -880,8 +882,9 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 
 		if(_scanline >= 0) {
 			((T*)this)->DrawPixel();
-			ShiftTileRegisters();
-
+			if(IsRenderingEnabled()) {
+				ShiftTileRegisters();
+			}
 			//"Secondary OAM clear and sprite evaluation do not occur on the pre-render line"
 			ProcessSpriteEvaluation();
 		} else if(_cycle < 9) {

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -378,7 +378,8 @@ template<class T> uint8_t NesPpu<T>::ReadRam(uint16_t addr)
 				openBusMask = 0xFF;
 			} else {
 				returnValue = _memoryReadBuffer;
-				_memoryReadBuffer = ReadVram(_ppuBusAddress & 0x3FFF, MemoryOperationType::Read);
+				// The PPU Read Buffer is not updated until the CPU read ends, and 2 more ppu cycles have passed.
+				_ppuMemoryDataStateMachine = 6;
 
 				if((_ppuBusAddress & 0x3FFF) >= 0x3F00 && !_console->GetNesConfig().DisablePaletteRead) {
 					//Note: When grayscale is turned on, the read values also have the grayscale mask applied to them
@@ -395,7 +396,6 @@ template<class T> uint8_t NesPpu<T>::ReadRam(uint16_t addr)
 
 				_ignoreVramRead = 6;
 				_needStateUpdate = true;
-				_needVideoRamIncrement = true;
 			}
 			break;
 
@@ -444,7 +444,7 @@ template<class T> void NesPpu<T>::WriteRam(uint16_t addr, uint8_t value)
 			} else {
 				//"Writes to OAMDATA during rendering (on the pre-render line and the visible lines 0-239, provided either sprite or background rendering is enabled) do not modify values in OAM, 
 				//but do perform a glitchy increment of OAMADDR, bumping only the high 6 bits"
-				_spriteRamAddr = (_spriteRamAddr + 4) & 0xFF;
+				_spriteRamAddr = (_spriteRamAddr + 4) & 0xFC;
 				_emu->BreakIfDebugging(CpuType::Nes, BreakSource::NesInvalidOamWrite);
 			}
 			break;
@@ -897,14 +897,6 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 			}
 		}
 	} else if(_cycle >= 257 && _cycle <= 320) {
-		if(_cycle == 257) {
-			_spriteIndex = 0;
-			memset(_hasSprite, 0, sizeof(_hasSprite));
-			if(_prevRenderingEnabled) {
-				//copy horizontal scrolling value from t
-				_videoRamAddr = (_videoRamAddr & ~0x041F) | (_tmpVideoRamAddr & 0x041F);
-			}
-		}
 		if(IsRenderingEnabled()) {
 			//"OAMADDR is set to 0 during each of ticks 257-320 (the sprite tile loading interval) of the pre-render and visible scanlines." (When rendering)
 			_spriteRamAddr = 0;
@@ -913,8 +905,8 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 				//Garbage NT sprite fetch (257, 265, 273, etc.) - Required for proper MC-ACC IRQs (MMC3 clone)
 				case 0: ReadVram(GetNameTableAddr()); break;
 
-				//Garbage AT sprite fetch
-				case 2: ReadVram(GetAttributeAddr()); break;
+				//Garbage NT sprite fetch
+				case 2: ReadVram(GetNameTableAddr()); break;
 
 				//Cycle 260, 268, etc.  This is an approximation (each tile is actually loaded in 8 steps (e.g from 257 to 264))
 				case 4: LoadSpriteTileInfo(); break;
@@ -929,6 +921,14 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 			// and the extra sprites will potentially read from the wrong banks
 			if(_cycle == 320) {
 				LoadExtraSprites();
+			}
+		}
+		if(_cycle == 257) {
+			_spriteIndex = 0;
+			memset(_hasSprite, 0, sizeof(_hasSprite));
+			if(_prevRenderingEnabled) {
+				//copy horizontal scrolling value from t
+				_videoRamAddr = (_videoRamAddr & ~0x041F) | (_tmpVideoRamAddr & 0x041F);
 			}
 		}
 	} else if(_cycle >= 321 && _cycle <= 336) {
@@ -1023,10 +1023,9 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 
 				if(_oamCopyDone && !_settings->GetNesConfig().EnablePpuSpriteEvalBug) {
 					_spriteAddrH = (_spriteAddrH + 1) & 0x3F;
-					if(_secondaryOamAddr >= 0x20) {
-						//"As seen above, a side effect of the OAM write disable signal is to turn writes to the secondary OAM into reads from it."
-						_oamCopybuffer = _secondarySpriteRam[_secondaryOamAddr & 0x1F];
-					}
+					//"As seen above, a side effect of the OAM write disable signal is to turn writes to the secondary OAM into reads from it."
+					_oamCopybuffer = _secondarySpriteRam[_secondaryOamAddr & 0x1F];
+					
 				} else {
 					if(!_spriteInRange && _scanline >= _oamCopybuffer && _scanline < _oamCopybuffer + (_control.LargeSprites ? 16 : 8)) {
 						_spriteInRange = !_oamCopyDone;
@@ -1499,6 +1498,14 @@ template<class T> void NesPpu<T>::UpdateState()
 		_ignoreVramRead--;
 		if(_ignoreVramRead > 0) {
 			_needStateUpdate = true;
+		}
+	}
+
+	if(_ppuMemoryDataStateMachine > 0) {
+		_ppuMemoryDataStateMachine--;
+		if(_ppuMemoryDataStateMachine == 0) {
+			_memoryReadBuffer = ReadVram(_ppuBusAddress & 0x3FFF, MemoryOperationType::Read);
+			_needVideoRamIncrement = true;
 		}
 	}
 

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -379,7 +379,7 @@ template<class T> uint8_t NesPpu<T>::ReadRam(uint16_t addr)
 			} else {
 				returnValue = _memoryReadBuffer;
 				// The PPU Read Buffer is not updated until the CPU read ends, and 2 more ppu cycles have passed.
-				_ppuMemoryDataStateMachine = 6;
+				_ppuMemoryDataReadStateMachine = 5;
 
 				if((_ppuBusAddress & 0x3FFF) >= 0x3F00 && !_console->GetNesConfig().DisablePaletteRead) {
 					//Note: When grayscale is turned on, the read values also have the grayscale mask applied to them
@@ -485,20 +485,10 @@ template<class T> void NesPpu<T>::WriteRam(uint16_t addr, uint8_t value)
 			break;
 
 		case PpuRegisters::VideoMemoryData:
-			if((_ppuBusAddress & 0x3FFF) >= 0x3F00) {
-				WritePaletteRam(_ppuBusAddress, value);
-				_emu->ProcessPpuWrite<CpuType::Nes>(_ppuBusAddress, value, MemoryType::NesPpuMemory);
-			} else {
-				if(_scanline >= 240 || !IsRenderingEnabled()) {
-					_mapper->WriteVram(_ppuBusAddress & 0x3FFF, value);
-				} else {
-					//During rendering, the value written is ignored, and instead the address' LSB is used (not confirmed, based on Visual NES)
-					_mapper->WriteVram(_ppuBusAddress & 0x3FFF, _ppuBusAddress & 0xFF);
-					_emu->BreakIfDebugging(CpuType::Nes, BreakSource::NesInvalidVramAccess);
-				}
-			}
+			// The write to VRAM does not occur until the CPU write ends, and 2 more ppu cycles have passed.
+			_ppuMemoryDataWriteStateMachine = 5;
+			_ppuMemoryDataWriteLatch = value;
 			_needStateUpdate = true;
-			_needVideoRamIncrement = true;
 			break;
 
 		case PpuRegisters::SpriteDMA:
@@ -1504,11 +1494,36 @@ template<class T> void NesPpu<T>::UpdateState()
 		}
 	}
 
-	if(_ppuMemoryDataStateMachine > 0) {
-		_ppuMemoryDataStateMachine--;
-		if(_ppuMemoryDataStateMachine == 0) {
+	if(_ppuMemoryDataReadStateMachine > 0) {
+		_ppuMemoryDataReadStateMachine--;
+		if(_ppuMemoryDataReadStateMachine == 0) {
 			_memoryReadBuffer = ReadVram(_ppuBusAddress & 0x3FFF, MemoryOperationType::Read);
 			_needVideoRamIncrement = true;
+		}
+		else {
+			_needStateUpdate = true;
+		}
+	}
+
+	if(_ppuMemoryDataWriteStateMachine > 0) {
+		_ppuMemoryDataWriteStateMachine--;
+		if(_ppuMemoryDataWriteStateMachine == 0) {
+			if((_ppuBusAddress & 0x3FFF) >= 0x3F00) {
+				WritePaletteRam(_ppuBusAddress, _ppuMemoryDataWriteLatch);
+				_emu->ProcessPpuWrite<CpuType::Nes>(_ppuBusAddress, _ppuMemoryDataWriteLatch, MemoryType::NesPpuMemory);
+			} else {
+				if(_scanline >= 240 || !IsRenderingEnabled()) {
+					_mapper->WriteVram(_ppuBusAddress & 0x3FFF, _ppuMemoryDataWriteLatch);
+				} else {
+					//During rendering, the value written is ignored, and instead the address' LSB is used (not confirmed, based on Visual NES)
+					_mapper->WriteVram(_ppuBusAddress & 0x3FFF, _ppuBusAddress & 0xFF);
+					_emu->BreakIfDebugging(CpuType::Nes, BreakSource::NesInvalidVramAccess);
+				}
+			}
+			_needVideoRamIncrement = true;
+		}
+		else {
+			_needStateUpdate = true;
 		}
 	}
 

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -1509,7 +1509,7 @@ template<class T> void NesPpu<T>::UpdateState()
 			_memoryReadBuffer = ReadVram(_ppuBusAddress & 0x3FFF, MemoryOperationType::Read);
 			_needVideoRamIncrement = true;
 		}
-			_needStateUpdate = true;
+		_needStateUpdate = true;
 	}
 
 	if(_ppuMemoryDataWriteStateMachine > 0) {
@@ -1529,7 +1529,7 @@ template<class T> void NesPpu<T>::UpdateState()
 			}
 			_needVideoRamIncrement = true;
 		}
-			_needStateUpdate = true;
+		_needStateUpdate = true;
 	}
 }
 


### PR DESCRIPTION
These changes make Mesen pass the following tests in the AccuracyCoin test ROM:  
Implied Dummy Reads (RTS now dummy reads during the final CPU cycle.)  
Branch Dummy Reads (Branches properly dummy read from the pre-incremented-PCH Address)  
Address $2004 Behavior (Writes to $2004 during a visible scanline cause OAMADDR to be bitwise ANDed with $FC)  
$2004 Stress Test (All OAM2 writes become reads after the OAM Address wraps around from $FF to $00)  
$2007 Stress Test (Added a small delay to the PPU Read Buffer being updated, Sprite Fetch performs a second Nametable Fetch instead of an Attribute Table Fetch, The Dummy Nametable Fetch on dot 257 uses the correct value of the v register)  

In theory, these changes should also be passing "BG Serial IN", (The pattern high bitplane shift register now brings in a 1 to bit 0 while being shifted) but something appears to be causing the visual artifacts produced by this test to be off by a scanline, causing the sprite zero hit to miss. I have not looked into the cause yet.

### Before
<img width="566" height="418" alt="Mesen_Before" src="https://github.com/user-attachments/assets/b327258c-49b4-47ee-8548-6244b9f6d37a" />

### After
<img width="587" height="416" alt="Mesen_After" src="https://github.com/user-attachments/assets/66cad9af-c70b-4598-9b86-dfd38d950626" />