### PR TITLE
Fix Namco 340 nametable mirroring

### DIFF
--- a/Core/NES/Mappers/Namco/Namco163.h
+++ b/Core/NES/Mappers/Namco/Namco163.h
@@ -250,8 +250,8 @@ protected:
 					switch((value & 0xC0) >> 6) {
 						case 0: SetMirroringType(MirroringType::ScreenAOnly); break;
 						case 1: SetMirroringType(MirroringType::Vertical); break;
-						case 2: SetMirroringType(MirroringType::Horizontal); break;
-						case 3: SetMirroringType(MirroringType::ScreenBOnly); break;
+						case 2: SetMirroringType(MirroringType::ScreenBOnly); break;
+						case 3: SetMirroringType(MirroringType::Horizontal); break;
 					}
 				} else if(_variant == NamcoVariant::Namco163) {
 					_audio->WriteRegister(addr, value);


### PR DESCRIPTION
The description of the Namco 340 (Mapper 210) mirroring settings on the NESDev wiki was wrong for a long time and many emulators including Mesen have incorporated the incorrect information.