### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,31 @@ The latest stable version is available from the [releases on GitHub](https://git
 
 ## Development Builds
 
-[![Mesen](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml/badge.svg)](https://github.com/SourMesen/Mesen2/actions/workflows/build.yml)
+[![Mesen](https://github.com/nesdev-org/Mesen2/actions/workflows/build.yml/badge.svg)](https://github.com/nesdev-org/Mesen2/actions/workflows/build.yml)
 
 #### <ins>Native builds</ins> (recommended) ####
 
 These builds don't require .NET to be installed.  
 
-* [Windows 10 / 11](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net8.0%20-%20AoT%29.zip)  
-* [Linux x64](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04%20-%20clang_aot%29.zip)  (requires **SDL2**)
-* [macOS - Intel](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-13%20-%20clang_aot%29.zip)  (requires **SDL2**)
-* [macOS - Apple Silicon](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-14%20-%20clang_aot%29.zip)  (requires **SDL2**)
+* [Windows 10 / 11](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net8.0%20-%20AoT%29.zip)
+* [Linux x64 - AppImage](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)
+* [Linux ARM64 - AppImage](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)
+* [macOS - Intel](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-15-intel%20-%20clang_aot%29.zip)  (requires **SDL2**)
+* [macOS - Apple Silicon](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28macOS%20-%20macos-15%20-%20clang_aot%29.zip)  (requires **SDL2**)
 
 #### <ins>.NET builds</ins> ####
 
 These builds require **.NET 8** to be installed (except the Windows 7 build which requires .NET 6).  
 For Linux and macOS, **SDL2** must also be installed.
 
-* [Windows 7 / 8 (.NET 6)](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)  
-* [Linux x64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  
-* [Linux ARM64](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)  
-* [Linux ARM64 - AppImage](https://nightly.link/SourMesen/Mesen2/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)
+* [Windows 7 / 8 (.NET 6)](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)
+* [Linux x64](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04%20-%20clang_aot%29.zip)  (requires **SDL2**)
+* [Linux ARM64](https://nightly.link/nesdev-org/Mesen2/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)
 
 
 #### <ins>Notes</ins> ####
 
-Other builds are also available in the [Actions](https://github.com/SourMesen/Mesen2/actions) tab.
+Other builds are also available in the [Actions](https://github.com/nesdev-org/Mesen2/actions) tab.
 
 **SteamOS**: See [SteamOS.md](SteamOS.md)
 


### PR DESCRIPTION
* Updated the development builds to point to this repository instead so users can download latest builds easily
* Moved the Linux x64 AppImage to native builds (does not require .net)
* Moved Linux x64 to .NET builds
* Updated macOS - Intel to point to Intel builds
* Updated other builds link to point to this repository instead
* Updated GitHub badge for development releases to point to this repository instead