### PR TITLE
Linux: Fix AOT builds crashing on newer distributions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,6 @@ jobs:
           {os: ubuntu-22.04, path: x64},
           {os: ubuntu-22.04-arm, path: arm64}
         ]
-        exclude:
-          # ARM64 AOT build doesn't seem to work properly (crashes when launched)
-          - platform: { os: ubuntu-22.04-arm, path: arm64 }
-            compiler: clang_aot
         include:
           - compiler: gcc
             make_flags: "USE_GCC=true"

--- a/makefile
+++ b/makefile
@@ -103,7 +103,7 @@ ifeq ($(PGO),optimize)
 endif
 
 ifneq ($(STATICLINK),false)
-	LINKOPTIONS += -static-libgcc -static-libstdc++ 
+	LINKOPTIONS += -static-libgcc -static-libstdc++ -Wl,--export-dynamic,--exclude-libs=libstdc++.a
 endif
 
 ifeq ($(MESENOS),osx)


### PR DESCRIPTION
See https://github.com/godotengine/webrtc-native/issues/127 for more information. It's not a perfect fix, but should last for a while.