### PR TITLE
WS: Improve initialization logic.

### DIFF
--- a/Core/WS/WsConsole.cpp
+++ b/Core/WS/WsConsole.cpp
@@ -219,7 +219,6 @@ void WsConsole::InitPostBootRomState()
 
 	//Init port state
 	WsCpuState& cpu = _cpu->GetState();
-	cpu.DS = 0xFE00;
 	cpu.CS = 0xFFFF;
 	cpu.SP = 0x2000;
 
@@ -229,6 +228,7 @@ void WsConsole::InitPostBootRomState()
 		cpu.DX = 0x0005;
 		cpu.SI = 0x023D;
 		cpu.DI = 0x040D;
+		cpu.DS = 0xFF00;
 		cpu.Flags.Sign = true;
 	} else {
 		cpu.AX = 0xFF87;
@@ -236,6 +236,7 @@ void WsConsole::InitPostBootRomState()
 		cpu.DX = 0x0001;
 		cpu.SI = 0x0435;
 		cpu.DI = 0x040B;
+		cpu.DS = 0xFE00;
 		cpu.Flags.Sign = true;
 		cpu.Flags.Parity = true;
 	}
@@ -264,13 +265,15 @@ void WsConsole::InitPostBootRomState()
 
 	_ppu->SetOutputToBgColor();
 
+	_controlManager->Write(0x40);
+
 	WsMemoryManagerState& mm = _memoryManager->GetState();
 	mm.BootRomDisabled = true;
-	mm.CartWordBus = true;
-	if(_model != WsModel::Monochrome) {
-		mm.SlowSram = true;
-		mm.SlowPort = true;
-	}
+
+	//Apply flags from rom header
+	_verticalMode = (_prgRom[_prgRomSize - 4] & 0x01) != 0;
+	mm.CartWordBus = (_prgRom[_prgRomSize - 4] & 0x04) != 0;
+	mm.SlowRom = (_prgRom[_prgRomSize - 4] & 0x08) != 0;
 
 	WsApuState& apu = _apu->GetState();
 	if(_model == WsModel::Monochrome) {

--- a/Core/WS/WsTypes.h
+++ b/Core/WS/WsTypes.h
@@ -236,11 +236,11 @@ struct WsMemoryManagerState
 	bool Enable4bppPacked;
 	
 	bool BootRomDisabled;
-	bool CartWordBus;
+	bool CartWordBus = true;
 	bool SlowRom;
 
-	bool SlowSram;
-	bool SlowPort;
+	bool SlowSram = true;
+	bool SlowPort = true;
 
 	bool EnableLowBatteryNmi;
 	bool PowerOffRequested;


### PR DESCRIPTION
- Games expecting vertical mode are now correctly auto-rotated on start when the boot ROM is not present.
- Cartridge SRAM and I/O port timings are now correctly slowed down when emulating the monochrome console model.
- Other minor improvements to initialization accuracy when the boot ROM is not present.