### PR TITLE
Debugger: WS - Fixed I/O port script memory callbacks not working

### DIFF
--- a/Core/WS/WsConsole.cpp
+++ b/Core/WS/WsConsole.cpp
@@ -413,7 +413,11 @@ AddressInfo WsConsole::GetAbsoluteAddress(uint32_t relAddress)
 
 AddressInfo WsConsole::GetAbsoluteAddress(AddressInfo& relAddress)
 {
-	return GetAbsoluteAddress(relAddress.Address);
+	if(relAddress.Type == MemoryType::WsPort) {
+		return { relAddress.Address & 0xFFFF, MemoryType::WsPort };
+	} else {
+		return GetAbsoluteAddress(relAddress.Address);
+	}
 }
 
 AddressInfo WsConsole::GetRelativeAddress(AddressInfo& absAddress, CpuType cpuType)


### PR DESCRIPTION
Reproduction case:

```lua
function testFunc(address, value)
        emu.log(address)
end

emu.addMemoryCallback(testFunc, emu.callbackType.read, 0xB5, 0xB5, emu.cpuType.ws, emu.memType.wsPort)
```

I'm not sure if this is the correct fix, but it doesn't seem to cause regressions in my limited testing, and shouldn't affect non-WS cores.