### PR TITLE
Fix SMS/GG debugger step-back non-determinism bug

### DIFF
--- a/Core/SMS/SmsVdp.cpp
+++ b/Core/SMS/SmsVdp.cpp
@@ -1561,6 +1561,8 @@ void SmsVdp::Serialize(Serializer& s)
 		SV(_bgTileIndex);
 		SV(_bgPatternData);
 		SV(_textModeStep);
+		
+		SVArray(_memAccess, sizeof(_memAccess));
 
 		SV(_needCramDot);
 		SV(_cramDotColor);


### PR DESCRIPTION
i had originally found this bug on mesen 2.1.1 on 2025-10-20
heres what i had written back then on the snesdev discord:

_i have found a non-determinism bug with the step-back function of the mesen debugger
i have coded a homebrew rom to isolate and demonstrate this bug
[stepback.gg.zip](https://github.com/user-attachments/files/26358085/stepback.gg.zip)_

_steps to reproduce:_

_1. place breakpoint at game gear memory 0x00B2 (instruction should be ld b, a)
2. continue execution until the breakpoint. notice that A register is $55
3. continue execution past the breakpoint. this $55 is used to make the background dark gray.
4. reset the rom and run rom until the breakpoint
5. this time, use the step-back function (shift+f10) until pc is 0x00a9 (this should be the first of eight nop)
6. continue execution until the breakpoint again. notice that A register is now $AA
7. continue execution past the breakpoint. this $AA is used to make the background light gray._

_this is a bug because the value of A register at step 2 and the value of A register at step 6 should be the same value_

root cause for the bug:

in Core/SMS/SmsVdp.cpp, some calls to `SmsVdp::ProcessVramAccess` only occur when `_memAccess[cyc] == SmsVdpMemAccess::None`
going forward normally, the `_memAccess[cyc]` would be `SmsVdpMemAccess::None`, and then inside `SmsVdp::ProcessVramAccess`, it would be set to `SmsVdpMemAccess::CpuSlot`, and would eventually get cleared when the scanline ends
but if instead of letting the scanline end, i step-back to before the `SmsVdp::ProcessVramAccess` call, since `_memAccess` is not serialized, `_memAccess[cyc]` remains `SmsVdpMemAccess::CpuSlot` instead of returning to `SmsVdpMemAccess::None` as would be expected
this makes the call to `SmsVdp::ProcessVramAccess` fail to occur as it had the first time around, because `_memAccess[cyc] == SmsVdpMemAccess::None` is no longer true
because the vram access now fails to occur, stale values remain in the `_state.VramBuffer` for longer than they should (this is the $AA in my example)

my solution:

i serialized the `_memAccess` array
this way, stepping-back restores the previous values of `_memAccess` correctly, thus allowing all `SmsVdp::ProcessVramAccess` calls that depend on `_memAccess` to remain consistent, whether or not step-back is used