### PR TITLE
Fix GBA tilemap viewer wrong address for 512x256px no transform layers

### DIFF
--- a/Core/GBA/Debugger/GbaPpuTools.cpp
+++ b/Core/GBA/Debugger/GbaPpuTools.cpp
@@ -296,7 +296,7 @@ DebugTilemapTileInfo GbaPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 				uint16_t columnCount = screenSize >> 3;
 				tilemapAddr = offset + row * columnCount + column;
 			} else {
-				tilemapAddr = offset + (((row & 0x1F) << 5) + column) * 2;
+				tilemapAddr = offset + (((row & 0x1F) << 5) + (column & 0x1F)) * 2;
 				if(column >= 32) {
 					tilemapAddr += 0x800;
 				}


### PR DESCRIPTION
in the tilemap viewer on gba, for background layers which are 512 pixels wide and do not use matrix transformation, there is a discrepancy between certain tiles displayed in the tilemap view and the information about those tiles provided in both the right sidebar and the tooltip

the way i noticed this was by moving my mouse cursor over the top row of tiles in the tilemap
example:
the addresses that should be displayed are:
$3000, $3002, $3004, ..., $303C, $303E, $3800, $3802, ..., $383C, $383E.
but the addresses that are displayed are:
$3000, $3002, $3004, ..., $303C, $303E, $3840, $3842, ..., $387C, $387E.

to generalize, all addresses of all tiles in the right half of the tilemap are $40 too high, and as such, all information that depends on that address is incorrect for those tiles

my solution:

i changed the way `GbaPpuTools::GetTilemapTileInfo` calculated the tilemap address for layers with no `transformEnabled` to better match the correct tilemap address calculation from `GbaPpuTools::GetTilemap` at line 86
now both calculations are correct, and the info that depended on the address is now correct as well