### PR TITLE
Fixes EPSM so that it works correctly after reset.

### DIFF
--- a/Core/NES/Epsm.cpp
+++ b/Core/NES/Epsm.cpp
@@ -18,6 +18,11 @@ Epsm::~Epsm()
 	_emu->GetSoundMixer()->UnregisterAudioProvider(this);
 }
 
+void Epsm::Reset()
+{
+	_clockCounter = 0;
+}
+
 void Epsm::Write(uint8_t dataBus, uint8_t outPins)
 {
 	//4016 writes

--- a/Core/NES/Epsm.h
+++ b/Core/NES/Epsm.h
@@ -32,6 +32,7 @@ public:
 	Epsm(Emulator* emu, NesConsole* console, vector<uint8_t>& adpcmRom);
 	~Epsm();
 
+	void Reset();
 	void Write(uint8_t dataBus, uint8_t outPins);
 	void WriteRam(uint16_t addr, uint8_t value) override;
 	void Exec();

--- a/Core/NES/NesConsole.cpp
+++ b/Core/NES/NesConsole.cpp
@@ -135,6 +135,9 @@ void NesConsole::Reset()
 		_vsSubConsole->Reset();
 	}
 	_mapper->OnAfterResetPowerOn();
+	if(_mapper->GetEpsm()) {
+		_mapper->GetEpsm()->Reset();
+	}
 }
 
 LoadRomResult NesConsole::LoadRom(VirtualFile& romFile)


### PR DESCRIPTION
Resetting the emulator would cause the EPSM to not function for a while. This was because the EPSM implementation was not reset-aware. While the console clock it's comparing against would be reset to 0, its own internal clock would not, and so it would have to wait for the console clock to catch back up.

Thanks to Sour for finding the cause and suggesting the fix.