### PR TITLE
Improves SMS input latency.

### DIFF
--- a/Core/SMS/SmsVdp.cpp
+++ b/Core/SMS/SmsVdp.cpp
@@ -651,8 +651,8 @@ void SmsVdp::ProcessEndOfScanline()
 
 		UpdateConfig();
 
-		_console->ProcessEndOfFrame();
 		_emu->ProcessEndOfFrame();
+		_console->ProcessEndOfFrame();
 	} else if(_state.Scanline >= _scanlineCount) {
 		_state.Scanline = 0;
 		_state.VerticalScrollLatch = _state.VerticalScroll;


### PR DESCRIPTION
The SMS core's emu and console versions of ProcessEndOfFrame were called in the wrong order. The console version updates input and was being called first, while the emu version is what sleeps between frames. Fixing this causes input to be updated after the sleep, improving latency by approximately one frame.

Thanks to Sour for noticing this mistake.