### PR TITLE
Super Game Boy: $7001-$700F should not acknowledge packets

### DIFF
--- a/Core/SNES/Coprocessors/SGB/SuperGameboy.cpp
+++ b/Core/SNES/Coprocessors/SGB/SuperGameboy.cpp
@@ -74,7 +74,9 @@ uint8_t SuperGameboy::Read(uint32_t addr)
 	addr &= 0xF80F;
 	
 	if(addr >= 0x7000 && addr <= 0x700F) {
-		_packetReady = false;
+		if(addr == 0x7000) {
+			_packetReady = false;
+		}
 		return _packetData[addr & 0x0F];
 	} else if(addr >= 0x7800 && addr <= 0x780F) {
 		if(_readPosition >= 320) {


### PR DESCRIPTION
I have tested on a real Super Game Boy (US cartridge, Japanese cartridge, and Super Game Boy 2) and I've confirmed [what fullsnes documents](https://problemkaputt.de/fullsnes.htm#snescartsupergameboy) where only $7000 acknowledges packets, and $7001-$700F does not.

Test ROM with source code included:
[Super Game Boy $6002 test.zip](https://github.com/user-attachments/files/26576739/Super.Game.Boy.6002.test.zip)
