### PR TITLE
Adds a new, default GB option to prefer the best model the game suppo…

### DIFF
--- a/Core/Gameboy/Gameboy.cpp
+++ b/Core/Gameboy/Gameboy.cpp
@@ -446,7 +446,13 @@ LoadRomResult Gameboy::LoadRom(VirtualFile& romFile)
 		}
 
 		GbCart* cart = GbCartFactory::CreateCart(_emu, header, gbxFooter, romData);
-		
+
+		switch(_model) {
+			case GameboyModel::Gameboy: MessageManager::Log("Game Boy model selected: Game Boy"); break;
+			case GameboyModel::SuperGameboy: MessageManager::Log("Game Boy model selected: Super Game Boy"); break;
+			case GameboyModel::GameboyColor: MessageManager::Log("Game Boy model selected: Game Boy Color"); break;
+		}
+
 		MessageManager::Log("-----------------------------");
 
 		if(cart) {
@@ -531,6 +537,16 @@ GameboyModel Gameboy::GetEffectiveModel(GameboyHeader& header)
 				model = GameboyModel::SuperGameboy;
 			} else {
 				model = GameboyModel::GameboyColor;
+			}
+			break;
+
+		case GameboyModel::AutoFavorBest:
+			if(cgbFlag == CgbCompat::GameboyColorExclusive || cgbFlag == CgbCompat::GameboyColorSupport) {
+				model = GameboyModel::GameboyColor;
+			} else if(supportsSgb) {
+				model = GameboyModel::SuperGameboy;
+			} else {
+				model = GameboyModel::Gameboy;
 			}
 			break;
 	}

--- a/Core/Shared/SettingTypes.h
+++ b/Core/Shared/SettingTypes.h
@@ -368,6 +368,7 @@ enum class ConsoleType
 
 enum class GameboyModel
 {
+	AutoFavorBest,
 	AutoFavorGbc,
 	AutoFavorSgb,
 	AutoFavorGb,

--- a/UI/Config/GameboyConfig.cs
+++ b/UI/Config/GameboyConfig.cs
@@ -15,7 +15,7 @@ namespace Mesen.Config
 
 		[Reactive] public ControllerConfig Controller { get; set; } = new();
 
-		[Reactive] public GameboyModel Model { get; set; } = GameboyModel.AutoFavorGbc;
+		[Reactive] public GameboyModel Model { get; set; } = GameboyModel.AutoFavorBest;
 		[Reactive] public bool UseSgb2 { get; set; } = true;
 
 		[Reactive] public bool BlendFrames { get; set; } = true;
@@ -107,6 +107,7 @@ namespace Mesen.Config
 
 	public enum GameboyModel
 	{
+		AutoFavorBest,
 		AutoFavorGbc,
 		AutoFavorSgb,
 		AutoFavorGb,

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -2853,6 +2853,7 @@ E
 			<Value ID="None">None</Value>
 		</Enum>
 		<Enum ID="GameboyModel">
+			<Value ID="AutoFavorBest">Auto (prefer best)</Value>
 			<Value ID="AutoFavorGbc">Auto (prefer Game Boy Color)</Value>
 			<Value ID="AutoFavorSgb">Auto (prefer Super Game Boy)</Value>
 			<Value ID="AutoFavorGb">Auto (prefer Game Boy)</Value>


### PR DESCRIPTION
…rts.

There was previously no auto option that would select the best model a game has any support for and which falls back to the original Game Boy if that's all the game can do. The "Auto (prefer Game Boy)" option would select Game Boy except when given a GBC-exclusive game. The new "Auto (prefer best)" option selects GBC if the game has any GBC support, SGB if it has any SGB support, and GB otherwise. This option is now selected by default.