### PR TITLE
Updated Rainbow Mapper Nametable Fetch counter

### DIFF
--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -317,14 +317,14 @@ void Rainbow::UpdateInWindowFlag()
 	bool yMatch;
 	bool xMatch;
 
-	uint8_t scanline = _ntFetchCounter >= 41 ? _scanlineCounter + 1 : _scanlineCounter;
+	uint8_t scanline = _ntFetchCounter >= 49 ? _scanlineCounter + 1 : _scanlineCounter;
 	if(_windowY1 >= _windowY2) {
 		yMatch = scanline <= _windowY2 || scanline > _windowY1;
 	} else {
 		yMatch = scanline >= _windowY1 && scanline <= _windowY2;
 	}
 
-	uint8_t column = (_ntFetchCounter + 1) % 42;
+	uint8_t column = (_ntFetchCounter + 1) % 50;
 	if(_windowX1 >= _windowX2) {
 		xMatch = column <= _windowX2 || column > _windowX1;
 	} else {
@@ -379,9 +379,9 @@ uint8_t Rainbow::MapperReadVram(uint16_t addr, MemoryOperationType memoryOperati
 
 		uint8_t shift = 0;
 		if(_inWindow) {
-			uint8_t scanline = _ntFetchCounter >= 41 ? _scanlineCounter + 1 : _scanlineCounter;
+			uint8_t scanline = _ntFetchCounter >= 49 ? _scanlineCounter + 1 : _scanlineCounter;
 			uint8_t windowScanline = (scanline + _windowScrollY) % 240;
-			uint8_t column = (_ntFetchCounter + 1) % 42;
+			uint8_t column = (_ntFetchCounter + 1) % 50;
 			uint16_t ntAddr = ((windowScanline / 8 * 32) + ((column + _windowScrollX) & 0x1F));
 			if(!isAttributeFetch) {
 				addr = ntAddr;
@@ -421,9 +421,9 @@ uint8_t Rainbow::MapperReadVram(uint16_t addr, MemoryOperationType memoryOperati
 		}
 	} else {
 		//Tile data fetches
-		bool isBgFetch = _ntFetchCounter < 33 || _ntFetchCounter >= 41;
+		bool isBgFetch = _ntFetchCounter < 33 || _ntFetchCounter >= 49;
 		if(_inWindow && isBgFetch) {
-			uint8_t scanline = _ntFetchCounter >= 41 ? _scanlineCounter + 1 : _scanlineCounter;
+			uint8_t scanline = _ntFetchCounter >= 49 ? _scanlineCounter + 1 : _scanlineCounter;
 			uint8_t windowScanline = (scanline + _windowScrollY) % 240;
 			if(_overrideTileFetch) {
 				uint32_t fetchAddr = (addr & 0xFF8) | (windowScanline & 0x07) | ((_extData & 0x3F) << 12) | (_bgExtModeOffset << 18);


### PR DESCRIPTION
With recent changes to the sprite fetch replacing an erroneous dummy-attribute-table fetch to a dummy-nametable-fetch, the Rainbow mapper's counter was hitting key values too early! This change fixed that.