### PR TITLE
Rainbow: Implement CIRAM chip selection for CHR patterns

### DIFF
--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -431,14 +431,14 @@ uint8_t Rainbow::MapperReadVram(uint16_t addr, MemoryOperationType memoryOperati
 			uint8_t windowScanline = (scanline + _windowScrollY) % 240;
 			if(_overrideTileFetch) {
 				uint32_t fetchAddr = (addr & 0xFF8) | (windowScanline & 0x07) | ((_extData & 0x3F) << 12) | (_bgExtModeOffset << 18);
-				return ReadChr(fetchAddr);
+				return ReadChr(fetchAddr, addr);
 			} else {
 				uint32_t fetchAddr = (addr & 0x1FF8) | (windowScanline & 0x07);
 				return InternalReadVram(fetchAddr);
 			}
 		} else if(_overrideTileFetch && isBgFetch) {
 			uint32_t fetchAddr = (addr & 0xFFF) | ((_extData & 0x3F) << 12) | (_bgExtModeOffset << 18);
-			return ReadChr(fetchAddr);
+			return ReadChr(fetchAddr, addr);
 		} else if(_spriteExtMode && !isBgFetch) {
 			uint8_t spriteIndex = _oamMappings[_ntFetchCounter - 33];
 			uint32_t fetchAddr;
@@ -447,7 +447,7 @@ uint8_t Rainbow::MapperReadVram(uint16_t addr, MemoryOperationType memoryOperati
 			} else {
 				fetchAddr = (_spriteExtBank << 20) | (_spriteExtData[spriteIndex] << 12) | (addr & 0xFFF);
 			}
-			return ReadChr(fetchAddr);
+			return ReadChr(fetchAddr, addr);
 		}
 	}
 
@@ -467,14 +467,14 @@ void Rainbow::MapperWriteVram(uint16_t addr, uint8_t value)
 	InternalWriteVram(addr, value);
 }
 
-uint8_t Rainbow::ReadChr(uint32_t addr)
+uint8_t Rainbow::ReadChr(uint32_t fetchAddr, uint16_t ppuAddr)
 {
 	switch(_chrSource) {
 		default:
-		case 0: return _chrRomSize ? _chrRom[addr & (_chrRomSize - 1)] : 0;
-		case 1: return _chrRamSize ? _chrRam[addr & (_chrRamSize - 1)] : 0;
-		case 2: return _mapperRam[addr & 0x1FFF];
-		case 3: return InternalReadVram(addr & 0x7FF);
+		case 0: return _chrRomSize ? _chrRom[fetchAddr & (_chrRomSize - 1)] : 0;
+		case 1: return _chrRamSize ? _chrRam[fetchAddr & (_chrRamSize - 1)] : 0;
+		case 2: return _mapperRam[fetchAddr & 0x1FFF];
+		case 3: return InternalReadVram(ppuAddr & 0x7FF);
 	}
 }
 

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -474,7 +474,7 @@ uint8_t Rainbow::ReadChr(uint32_t fetchAddr, uint16_t ppuAddr)
 		case 0: return _chrRomSize ? _chrRom[fetchAddr & (_chrRomSize - 1)] : 0;
 		case 1: return _chrRamSize ? _chrRam[fetchAddr & (_chrRamSize - 1)] : 0;
 		case 2: return _mapperRam[fetchAddr & 0x1FFF];
-		case 3: return InternalReadVram(ppuAddr & 0x7FF);
+		case 3: return GetNametable((ppuAddr & 0x400) >> 10)[ppuAddr & 0x3FF];
 	}
 }
 
@@ -960,10 +960,8 @@ uint8_t Rainbow::DebugReadChr(ExtModeConfig& cfg, uint32_t addr)
 		default:
 		case 0: return _chrRomSize ? _chrRom[addr & (_chrRomSize - 1)] : 0;
 		case 1: return _chrRamSize ? _chrRam[addr & (_chrRamSize - 1)] : 0;
-
-		case 2:
-		case 3:
-			return cfg.ExtRam[addr & 0x1FFF];
+		case 2: return cfg.ExtRam[addr & 0x1FFF];
+		case 3: return GetNametable((addr & 0x400) >> 10)[addr & 0x3FF];
 	}
 }
 

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -212,7 +212,12 @@ void Rainbow::SelectLowBank(uint16_t start, uint16_t size, uint8_t reg)
 
 void Rainbow::SelectChrBank(uint16_t start, uint16_t size, uint8_t reg)
 {
-	if(_chrSource >= 2) {
+	if (_chrSource == 3) {
+		SetPpuMemoryMapping(0x0000, 0x07FF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
+		SetPpuMemoryMapping(0x0800, 0x0FFF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
+		SetPpuMemoryMapping(0x1000, 0x17FF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
+		SetPpuMemoryMapping(0x1800, 0x1FFF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
+	} else if(_chrSource == 2) {
 		SetPpuMemoryMapping(0x0000, 0x0FFF, ChrMemoryType::MapperRam, 0, MemoryAccessType::ReadWrite);
 		SetPpuMemoryMapping(0x1000, 0x1FFF, ChrMemoryType::MapperRam, 0, MemoryAccessType::ReadWrite);
 	} else {
@@ -468,10 +473,8 @@ uint8_t Rainbow::ReadChr(uint32_t addr)
 		default:
 		case 0: return _chrRomSize ? _chrRom[addr & (_chrRomSize - 1)] : 0;
 		case 1: return _chrRamSize ? _chrRam[addr & (_chrRamSize - 1)] : 0;
-
-		case 2:
-		case 3:
-			return _mapperRam[addr & 0x1FFF];
+		case 2: return _mapperRam[addr & 0x1FFF];
+		case 3: return InternalReadVram(addr);
 	}
 }
 
@@ -828,7 +831,11 @@ vector<MapperStateEntry> Rainbow::GetMapperStateEntries()
 	entries.push_back(MapperStateEntry("$4120.0-2", "CHR Banking Mode", _chrMode, MapperStateValueType::Number16));
 	entries.push_back(MapperStateEntry("$4120.4", "Window Split Mode", _windowEnabled));
 	entries.push_back(MapperStateEntry("$4120.5", "Sprite Extended Mode", _spriteExtMode));
-	entries.push_back(MapperStateEntry("$4120.6-7", "CHR Source", string(_chrSource ? "RAM" : "ROM"), _chrSource));
+	entries.push_back(MapperStateEntry("$4120.6-7", "CHR Source", string(
+		_chrSource == 0 ? "CHR ROM" : 
+		_chrSource == 1 ? "CHR RAM" : 
+		_chrSource == 2 ? "FPGA RAM" : 
+		                  "Nametable RAM"), _chrSource));
 	entries.push_back(MapperStateEntry("$4121.0-5", "Extended BG CHR Bank", _bgExtModeOffset, MapperStateValueType::Number8));
 
 	entries.push_back(MapperStateEntry("", "Fill Mode"));

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -474,7 +474,7 @@ uint8_t Rainbow::ReadChr(uint32_t addr)
 		case 0: return _chrRomSize ? _chrRom[addr & (_chrRomSize - 1)] : 0;
 		case 1: return _chrRamSize ? _chrRam[addr & (_chrRamSize - 1)] : 0;
 		case 2: return _mapperRam[addr & 0x1FFF];
-		case 3: return InternalReadVram(addr);
+		case 3: return InternalReadVram(addr & 0x7FF);
 	}
 }
 

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -212,7 +212,7 @@ void Rainbow::SelectLowBank(uint16_t start, uint16_t size, uint8_t reg)
 
 void Rainbow::SelectChrBank(uint16_t start, uint16_t size, uint8_t reg)
 {
-	if (_chrSource == 3) {
+	if(_chrSource == 3) {
 		SetPpuMemoryMapping(0x0000, 0x07FF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
 		SetPpuMemoryMapping(0x0800, 0x0FFF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);
 		SetPpuMemoryMapping(0x1000, 0x17FF, ChrMemoryType::NametableRam, 0, MemoryAccessType::ReadWrite);

--- a/Core/NES/Mappers/Homebrew/Rainbow.h
+++ b/Core/NES/Mappers/Homebrew/Rainbow.h
@@ -121,7 +121,7 @@ private:
 	uint8_t _sendSrcAddr = 0;
 	uint8_t _recvDstAddr = 0;
 
-	uint8_t ReadChr(uint32_t addr);
+	uint8_t ReadChr(uint32_t fetchAddr, uint16_t ppuAddr);
 	void UpdateInWindowFlag();
 	void UpdateIrqStatus();
 	void AckCpuIrq();


### PR DESCRIPTION
This feature is somewhat newish and documented here: https://github.com/BrokeStudio/rainbow-net/blob/master/NES/mapper-doc.md#chr-configuration

When CIRAM is selected for pattern data, the mapper can only provide CIRAM /CE and CIRAM /A10, which means all other banking is ignored and the PPUADDR is used (and mirrored) along that range. Pattern banking _does_ function normally in this implementation, though with only 2k of memory total, there isn't much practical use for the feature.

To facilitate testing, please enjoy this WIP, early demo build of Tactus, which uses CIRAM for its in-game dialog system. (Just start a game and interact with the left totem.) Verified working on N8 Pro and on real Rainbow hardware, courtesy of Broke Studio.

(Tactus is my own game, to be clear. I own the copyright. This is a public demo, which you may freely distribute with attribution.)

[tactus-ciram-demo.tar.gz](https://github.com/user-attachments/files/26629231/tactus-ciram-demo.tar.gz)