### PR TITLE
NES: Changes various dummy PC reads to stack reads.

### DIFF
--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -191,8 +191,8 @@ void NesCpu::IRQ()
 		ProcessPendingDma(_state.PC, MemoryOperationType::ExecOpCode);
 	}
 
-	DummyRead();  //fetch opcode (and discard it - $00 (BRK) is forced into the opcode register instead)
-	DummyRead();  //read next instruction byte (actually the same as above, since PC increment is suppressed. Also discarded.)
+	DummyPcRead();  //fetch opcode (and discard it - $00 (BRK) is forced into the opcode register instead)
+	DummyPcRead();  //read next instruction byte (actually the same as above, since PC increment is suppressed. Also discarded.)
 	Push((uint16_t)(PC()));
 
 	if(_needNmi) {
@@ -271,7 +271,7 @@ uint16_t NesCpu::FetchOperand()
 {
 	switch(_instAddrMode) {
 		case NesAddrMode::Acc:
-		case NesAddrMode::Imp: DummyRead(); return 0;
+		case NesAddrMode::Imp: DummyPcRead(); return 0;
 		case NesAddrMode::Imm:
 		case NesAddrMode::Rel: return GetImmediate();
 		case NesAddrMode::Zero: return GetZeroAddr();

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -76,11 +76,16 @@ private:
 		return opCode;
 	}
 
-	void DummyRead()
+	void DummyPcRead()
 	{
 		MemoryRead(_state.PC, MemoryOperationType::DummyRead);
 	}
-	
+
+	void DummyStackRead()
+	{
+		MemoryRead(0x100 + SP(), MemoryOperationType::DummyRead);
+	}
+
 	uint8_t ReadByte()
 	{
 		uint8_t value = MemoryRead(_state.PC, MemoryOperationType::ExecOperand);
@@ -437,7 +442,7 @@ private:
 			if(_runIrq && !_prevRunIrq) {
 				_runIrq = false;
 			}
-			DummyRead();
+			DummyPcRead();
 
 			if(CheckPageCrossed(PC(), offset)) {
 				MemoryRead(((PC() & 0xFF00) | ((PC() + offset) & 0xFF)), MemoryOperationType::DummyRead);
@@ -483,11 +488,11 @@ private:
 		Push((uint8_t)flags);
 	}
 	void PLA() { 
-		DummyRead();
+		DummyStackRead();
 		SetA(Pop()); 
 	}
 	void PLP() { 
-		DummyRead();
+		DummyStackRead();
 		SetPS(Pop()); 
 	}
 
@@ -516,17 +521,17 @@ private:
 
 	void JSR() {
 		uint8_t lo = ReadByte();
-		DummyRead();
+		DummyStackRead();
 		Push(PC());
 		uint16_t addr = (ReadByte() << 8) | lo;
 		JMP(addr);
 	}
 
 	void RTS() {
-		MemoryRead(0x100 + SP(), MemoryOperationType::DummyRead);
+		DummyStackRead();
 		uint16_t addr = PopWord();
 		SetPC(addr);
-		DummyRead();
+		DummyPcRead();
 		SetPC(addr + 1);
 	}
 
@@ -573,7 +578,7 @@ private:
 	void BRK();
 	
 	void RTI() {
-		DummyRead();
+		DummyStackRead();
 		SetPS(Pop());
 		SetPC(PopWord());
 	}


### PR DESCRIPTION
Many 6502 instructions read from memory and discard the value, called dummy reads. Mesen implemented many of these with a DummyRead function that reads from PC. However, many of these should actually read from the stack, instead. This change changes DummyRead to DummyPcRead, adds a DummyStackRead function, and fixes instructions to use the stack version where relevant.

Tested: No change in current AccuracyCoin. No change in Mesen automated test results.