### PR TITLE
GB: Fix serial clocking regression.

### DIFF
--- a/Core/Gameboy/GbMemoryManager.cpp
+++ b/Core/Gameboy/GbMemoryManager.cpp
@@ -102,7 +102,7 @@ void GbMemoryManager::ExecMasterCycle()
 {
 	uint64_t& cycleCount = _cpu->GetState().CycleCount;
 	cycleCount++;
-	if(cycleCount & 1) {
+	if(!(cycleCount & 1)) {
 		ExecTimerDmaSerial();
 	}
 	_ppu->Exec<true>();


### PR DESCRIPTION
Commit 36d23cc inverted the condition for calling ExecTimerDmaSerial, swapping the cycle parity so that ExecTimerDmaSerial could no longer handle serial data. This broke Shin Megami Tensei: Devil Children: Kuro no Sho in GB and SGB modes.

Tested with automated tests (no change) and Shin Megami Tensei: Devil Children: Kuro no Sho (no longer broken).

Thanks to paulb_nl for finding the cause of this issue and Sour for reviewing the commit that introduced the issue.