### PR TITLE
Readme: Fixes the macOS Intel link and improves .NET descripton.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,26 @@ These builds don't require .NET to be installed. They load more quickly and are 
 * [Windows 10 / 11](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Windows%20-%20net8.0%20-%20AoT%29.zip)  
 * [Linux x64](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04%20-%20clang_aot%29.zip)  (requires **SDL2**)  
 * [Linux ARM64](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang_aot%29.zip)  (requires **SDL2**)  
-* [macOS - Intel](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28macOS%20-%20macos-15%20-%20clang_aot%29.zip)  (requires **SDL2**)  
+* [macOS - Intel](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28macOS%20-%20macos-15-intel%20-%20clang_aot%29.zip)  (requires **SDL2**)  
 * [macOS - Apple Silicon](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28macOS%20-%20macos-15%20-%20clang_aot%29.zip)  (requires **SDL2**)  
 
 #### <ins>.NET builds</ins> ####
 
-These builds require **.NET 8** to be installed (except the Windows 7 build, which requires .NET 6).  
-For Linux and macOS, **SDL2** must also be installed.
+These builds use .NET, which for some builds comes bundled and for others must be installed.  
+They all require **.NET 8** except the Windows 7 / 8 build, which requires **.NET 6**.  
+For Linux and macOS, **SDL2** must also be installed. For AppImage builds, **FUSE** (such as libfuse2) must be installed.
 
-* [Windows 7 / 8 (.NET 6)](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)  
-* [Linux x64 - AppImage](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  
-* [Linux ARM64](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)  
-* [Linux ARM64 - AppImage](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)  
+* [Windows 7 / 8](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Windows%20-%20net6.0%29.zip)  (requires **.NET 6**)
+* [Linux x64 - AppImage](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20(Linux%20x64%20-%20AppImage).zip)  (requires **FUSE** and **SDL2**)
+* [Linux ARM64](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20%28Linux%20-%20ubuntu-22.04-arm%20-%20clang%29.zip)  (requires **.NET 8** and **SDL2**)
+* [Linux ARM64 - AppImage](https://nightly.link/nesdev-org/MesenCE/workflows/build/master/Mesen%20(Linux%20ARM64%20-%20AppImage).zip)  (requires **FUSE** and **SDL2**)
 
 
 #### <ins>Notes</ins> ####
 
 Other builds are also available in the [Actions](https://github.com/nesdev-org/MesenCE/actions) tab.
 
-* **MacOS**: Development builds are self-signed, and will require approval via Gatekeeper before they are able to be run.  
+* **MacOS**: Development builds are self-signed and will require approval via Gatekeeper before they are able to be run.  
 * **SteamOS**: See [SteamOS.md](SteamOS.md)  
 
 ## Compiling


### PR DESCRIPTION
The .NET build section hasn't been the most clear. The .NET builds don't all require .NET to be installed (many do), but they all do use .NET and thus run slower than the AOT builds. This update tries to add more clarity around what each build requires, noting .NET, SDL2, and FUSE requirements as applicable. Hopefully we'll cut down on these requirements with further improvements to the builds.