### PR TITLE
NES: Fix MMC3 mirroring state in register viewer

### DIFF
--- a/Core/NES/Mappers/Nintendo/MMC3.h
+++ b/Core/NES/Mappers/Nintendo/MMC3.h
@@ -268,7 +268,13 @@ protected:
 		entries.push_back(MapperStateEntry("$8000.6", "PRG Banking Mode", (_state.Reg8000 & 0x40) != 0));
 		entries.push_back(MapperStateEntry("$8000.7", "CHR Banking Mode", (_state.Reg8000 & 0x80) != 0));
 
-		entries.push_back(MapperStateEntry("$A000.0", "Mirroring", GetMirroringType() == MirroringType::Horizontal ? "Horizontal" : "Vertical", GetMirroringType() == MirroringType::Horizontal ? 1 : 0));
+		string mirroring = (_state.RegA000 & 0x01 ? "Horizontal" : "Vertical");
+		if(GetMirroringType() == MirroringType::FourScreens) {
+			mirroring += " (4-screen)";
+		} else if(_romInfo.MapperID == 118) {
+			mirroring += " (Ignored)";
+		}
+		entries.push_back(MapperStateEntry("$A000.0", "Mirroring", mirroring, _state.RegA000 & 0x01));
 
 		if(isMmc6) {
 			entries.push_back(MapperStateEntry("$A001.4", "Work RAM Bank 0 Write Enabled", (_state.RegA001 & 0x10) != 0));

--- a/Core/NES/Mappers/Nintendo/MMC3.h
+++ b/Core/NES/Mappers/Nintendo/MMC3.h
@@ -268,7 +268,7 @@ protected:
 		entries.push_back(MapperStateEntry("$8000.6", "PRG Banking Mode", (_state.Reg8000 & 0x40) != 0));
 		entries.push_back(MapperStateEntry("$8000.7", "CHR Banking Mode", (_state.Reg8000 & 0x80) != 0));
 
-		entries.push_back(MapperStateEntry("$A000.0", "Mirroring", _state.RegA000 & 0x01 ? "Horizontal" : "Vertical"));
+		entries.push_back(MapperStateEntry("$A000.0", "Mirroring", GetMirroringType() == MirroringType::Horizontal ? "Horizontal" : "Vertical", GetMirroringType() == MirroringType::Horizontal ? 1 : 0));
 
 		if(isMmc6) {
 			entries.push_back(MapperStateEntry("$A001.4", "Work RAM Bank 0 Write Enabled", (_state.RegA001 & 0x10) != 0));


### PR DESCRIPTION
Reported by paulb_nl: https://forums.nesdev.org/viewtopic.php?p=308166&sid=54e85eea94fc05f7a58993e089912e06#p308166
> I noticed that the NES Register viewer displays the Mirroring register of the MMC3 mapper as a bool that is always true.
It seems there is a 0/1 value missing if I compare it to the FDS entry.

This PR fixes the cart register view to use the actual mirroring state instead of $A000.D0 (a la the working FDS one), in order to have its state display correctly for fixed-mirroring mappers which inherit from MMC3 (e.g. iNES mapper 206). I'm aware it's not the ideal solution when the register doesn't exist in some cases but that's a problem for later.

This has been tested on Super Mario Bros. 3, Joy Mech Fight (switches mirroring), and the Popils prototype (mapper 206). I've yet to check any 4-screen mirroring variations, so tweaks might be needed there.