### PR TITLE
GBC: Clear HDMA pending flag before processing DMA block

### DIFF
--- a/Core/Gameboy/GbDmaController.cpp
+++ b/Core/Gameboy/GbDmaController.cpp
@@ -163,11 +163,13 @@ void GbDmaController::ProcessHdma()
 	_state.CgbHdmaTrigger = trigger;
 
 	if(_state.CgbHdmaPending && !_cpu->IsHalted()) {
+		// prevent DMA blocks from being processed again when an hblank transfer crosses a scanline boundary
+		// fixes hangs and grapics corruption in "Championship Motocross 2001 featuring Ricky Carmichael"
+		_state.CgbHdmaPending = false;
 		//4 cycles for setup
 		_memoryManager->Exec();
 		_memoryManager->Exec();
 		ProcessDmaBlock();
-		_state.CgbHdmaPending = false;
 	}
 }
 


### PR DESCRIPTION
Fix reported by paulb_nl: https://forums.nesdev.org/viewtopic.php?p=308166&sid=54e85eea94fc05f7a58993e089912e06#p308166

Previously, an HDMA hblank transfer straddling along a scanline boundary would erroneously cause an extra 16-byte block to be transferred. This broke Championship Motocross 2001 Featuring Ricky Carmicheal (GBC), which spinwaits on `[$FF55] & $7F == 0` (i.e. 16 bytes too early) to finish the HDMA transfer instead of `[$FF55] == $FF`, thus causing a hang with HDMA length = 1 (32 bytes) in this scenario.

The fix avoids hangs and graphics corruption when accessing menu items in the aforementioned game. Thorough testing would be appreciated.