### PR TITLE
Debugger: Assume SPC memory based on segment name, not type

### DIFF
--- a/UI/Debugger/Integration/DbgImporter.cs
+++ b/UI/Debugger/Integration/DbgImporter.cs
@@ -918,7 +918,7 @@ namespace Mesen.Debugger.Integration
 		{
 			DbgImporter? importer = romFormat switch {
 				RomFormat.Sfc => new SnesDbgImporter(romFormat),
-				RomFormat.iNes or RomFormat.Nsf or RomFormat.VsSystem or RomFormat.VsDualSystem => new NesDbgImporter(romFormat),
+				RomFormat.iNes or RomFormat.Nsf or RomFormat.VsSystem or RomFormat.VsDualSystem or RomFormat.Fds => new NesDbgImporter(romFormat),
 				RomFormat.Pce or RomFormat.PceHes => new PceDbgImporter(romFormat),
 				_ => null
 			};

--- a/UI/Debugger/Integration/DbgImporter.cs
+++ b/UI/Debugger/Integration/DbgImporter.cs
@@ -319,11 +319,13 @@ namespace Mesen.Debugger.Integration
 					isRam = false;
 
 					if(row.Contains("type=rw")) {
-						//TODOv2 fix this
-						//Assume a RW segment inside the .sfc file is SPC code
 						isRam = true;
-						memType = MemoryType.SpcRam;
 					}
+				}
+
+				//Assume that segments with names containing "SPC" are in audio RAM
+				if(row.Contains("SPC")) {
+					memType = MemoryType.SpcRam;
 				}
 
 				SegmentInfo segment = new SegmentInfo(id, start, size, isRam, fileOffset, memType);


### PR DESCRIPTION
When Mesen imports dbg files, it assumes that all segments that are marked as read/write and have a file address are SPC700 memory. This means that you won't get labels and comments when debugging code that has been copied to RAM, and this affects NES too.

There's another issue where variables in SPC700 space get treated as being in the SNES's main RAM, which results in behavior where (at least with lorom-template's build setup) a SPC700 variable having the same address as a 65c816 variable causes the SPC700 variable's name to show instead, and you don't actually get variable names in the SPC700 debugger.

I think the best way to solve this is to check for `SPC` in the segment name. This fits with lorom-template's `SPCIMAGE`, `SPCZEROPAGE`, `SPCBSS` names.

Here's PinoBatch's nrom-template and lorom-template with modifications to copy a large amount of their code to RAM and run it from there, as well as ROMs and dbg files:
[nes-code-in-ram-test.zip](https://github.com/user-attachments/files/26696717/nes-code-in-ram-test.zip)
[snes-code-in-ram-test.zip](https://github.com/user-attachments/files/26696753/snes-code-in-ram-test.zip)

You can test this change by opening these ROMs and then opening the debugger afterwards. You should see comments and labels, and the SPC700 debugger should have variable names. If you set the modified lorom-template to break on WDM instructions, it will take you to some code that incorrectly has audio driver variable names without the patch, and correct names with it.