### PR TITLE
NES: HD Packs - FIx broken audio when runahead is enabled

### DIFF
--- a/Core/NES/HdPacks/HdAudioDevice.cpp
+++ b/Core/NES/HdPacks/HdAudioDevice.cpp
@@ -18,7 +18,7 @@ HdAudioDevice::HdAudioDevice(Emulator* emu, HdPackData* hdData)
 	_sfxVolume = 128;
 	_bgmVolume = 128;
 
-	_oggMixer.reset(new OggMixer());
+	_oggMixer.reset(new OggMixer(emu));
 	_oggMixer->SetBgmVolume(_bgmVolume);
 	_oggMixer->SetSfxVolume(_sfxVolume);
 	_emu->GetSoundMixer()->RegisterAudioProvider(_oggMixer.get());
@@ -40,12 +40,15 @@ void HdAudioDevice::Serialize(Serializer& s)
 		SV(_album); SV(_lastBgmTrack); SV(trackOffset); SV(_sfxVolume); SV(_bgmVolume); SV(_playbackOptions);
 	} else {
 		SV(_album); SV(_lastBgmTrack); SV(trackOffset); SV(_sfxVolume); SV(_bgmVolume); SV(_playbackOptions);
-		if(_lastBgmTrack != -1 && trackOffset > 0) {
-			PlayBgmTrack(_lastBgmTrack, trackOffset);
+		
+		if(!_emu->IsRunAheadFrame()) {
+			if(_lastBgmTrack != -1 && trackOffset > 0) {
+				PlayBgmTrack(_lastBgmTrack, trackOffset);
+			}
+			_oggMixer->SetBgmVolume(_bgmVolume);
+			_oggMixer->SetSfxVolume(_sfxVolume);
+			_oggMixer->SetPlaybackOptions(_playbackOptions);
 		}
-		_oggMixer->SetBgmVolume(_bgmVolume);
-		_oggMixer->SetSfxVolume(_sfxVolume);
-		_oggMixer->SetPlaybackOptions(_playbackOptions);
 	}
 }
 

--- a/Core/NES/HdPacks/OggMixer.cpp
+++ b/Core/NES/HdPacks/OggMixer.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include "NES/HdPacks/OggReader.h"
 #include "NES/HdPacks/OggMixer.h"
+#include "Shared/Emulator.h"
 
 enum class OggPlaybackOptions
 {
@@ -9,8 +10,9 @@ enum class OggPlaybackOptions
 	Loop = 0x01
 };
 
-OggMixer::OggMixer()
+OggMixer::OggMixer(Emulator* emu)
 {
+	_emu = emu;
 }
 
 void OggMixer::Reset(uint32_t sampleRate)
@@ -82,7 +84,7 @@ void OggMixer::SetSampleRate(int sampleRate)
 
 bool OggMixer::Play(string filename, bool isSfx, uint32_t startOffset, uint32_t loopPosition)
 {
-	shared_ptr<OggReader> reader(new OggReader());
+	shared_ptr<OggReader> reader(new OggReader(_emu));
 	bool loop = !isSfx && (_options & (int)OggPlaybackOptions::Loop) != 0;
 	if(reader->Init(filename, loop, _sampleRate, startOffset, loopPosition)) {
 		if(isSfx) {

--- a/Core/NES/HdPacks/OggMixer.cpp
+++ b/Core/NES/HdPacks/OggMixer.cpp
@@ -87,6 +87,16 @@ bool OggMixer::Play(string filename, bool isSfx, uint32_t startOffset, uint32_t 
 	shared_ptr<OggReader> reader(new OggReader(_emu));
 	bool loop = !isSfx && (_options & (int)OggPlaybackOptions::Loop) != 0;
 	if(reader->Init(filename, loop, _sampleRate, startOffset, loopPosition)) {
+		if(_emu->IsRunAheadFrame()) {
+			//If this was done on runahead frames, SFX/BGM will attempt to start playing multiple times (once per runahead frame)
+			//This causes all sound effects to be duplicated.
+			//Skipping the processing on runahead here is an imperfect workaround - it allows 1 runahead frame to usually work properly
+			//but attempting to use over 1 frame of runahead will instead cause SFX to not play properly at times.
+			//Ideally, the exact state of the BGM/SFX (what is playing exactly, and at which part of their playback they are) should
+			//be part of the save state data and restored like any other state (but this isn't trivial to implement at the moment)
+			return true;
+		}
+
 		if(isSfx) {
 			_sfx.push_back(reader);
 		} else {

--- a/Core/NES/HdPacks/OggMixer.h
+++ b/Core/NES/HdPacks/OggMixer.h
@@ -3,6 +3,7 @@
 #include "Shared/Interfaces/IAudioProvider.h"
 
 class OggReader;
+class Emulator;
 
 class OggMixer : public IAudioProvider
 {
@@ -10,6 +11,7 @@ private:
 	shared_ptr<OggReader> _bgm;
 	vector<shared_ptr<OggReader>> _sfx;
 
+	Emulator* _emu = nullptr;
 	uint32_t _sampleRate = 0;
 	uint8_t _bgmVolume = 0;
 	uint8_t _sfxVolume = 0;
@@ -17,7 +19,7 @@ private:
 	bool _paused = false;
 
 public:
-	OggMixer();
+	OggMixer(Emulator* emu);
 	virtual ~OggMixer() = default;
 
 	void SetSampleRate(int sampleRate);

--- a/Core/NES/HdPacks/OggReader.cpp
+++ b/Core/NES/HdPacks/OggReader.cpp
@@ -1,9 +1,11 @@
 #include "pch.h"
+#include "Shared/Emulator.h"
 #include "NES/HdPacks/OggReader.h"
 #include "Utilities/Audio/stb_vorbis.h"
 
-OggReader::OggReader()
+OggReader::OggReader(Emulator* emu)
 {
+	_emu = emu;
 	_done = false;
 	_oggBuffer = new int16_t[10000];
 	_outputBuffer = new int16_t[2000];
@@ -63,6 +65,10 @@ void OggReader::SetLoopFlag(bool loop)
 
 void OggReader::ApplySamples(int16_t* buffer, size_t sampleCount, uint8_t volume)
 {
+	if(_emu->IsRunAheadFrame()) {
+		return;
+	}
+
 	int32_t samplesNeeded = (int32_t)sampleCount - _resampler.GetPendingCount();
 	uint32_t samplesRead = 0;
 	if(samplesNeeded > 0) {
@@ -88,5 +94,5 @@ void OggReader::ApplySamples(int16_t* buffer, size_t sampleCount, uint8_t volume
 
 uint32_t OggReader::GetOffset()
 {
-	return stb_vorbis_get_file_offset(_vorbis);
+	return stb_vorbis_get_sample_offset(_vorbis);
 }

--- a/Core/NES/HdPacks/OggReader.h
+++ b/Core/NES/HdPacks/OggReader.h
@@ -4,6 +4,7 @@
 #include "Utilities/Audio/HermiteResampler.h"
 
 struct stb_vorbis;
+class Emulator;
 
 class OggReader
 {
@@ -13,6 +14,7 @@ private:
 	int16_t* _oggBuffer = nullptr;
 
 	HermiteResampler _resampler;
+	Emulator* _emu = nullptr;
 
 	bool _loop = false;
 	bool _done = false;
@@ -25,7 +27,7 @@ private:
 	vector<uint8_t> _fileData;
 
 public:
-	OggReader();
+	OggReader(Emulator* emu);
 	~OggReader();
 
 	bool Init(string filename, bool loop, uint32_t sampleRate, uint32_t startOffset = 0, uint32_t loopPosition = 0);


### PR DESCRIPTION
Skip audio processing for HD packs (BGM & SFX) during runahead frames. Also fixes OggReader::GetOffset calling the wrong stb_vorbis function (and always getting an incorrect offset as a result), but the fix does not depend on this.