### PR TITLE
NES: Mapper 132: Fixes read mask for $4100 register.

### DIFF
--- a/Core/NES/Mappers/Txc/Txc22211A.h
+++ b/Core/NES/Mappers/Txc/Txc22211A.h
@@ -39,7 +39,7 @@ protected:
 	{
 		uint8_t openBus = _console->GetMemoryManager()->GetOpenBus();
 		uint8_t value = openBus;
-		if((addr & 0x103) == 0x100) {
+		if((addr & 0x100) == 0x100) {
 			value = (openBus & 0xF0) | (_txc.Read() & 0x0F);
 		}
 		UpdateState();


### PR DESCRIPTION
This new mask matches the current state of the mapper 132 documentation on the NESdev wiki. This fixes Creatom.

Tested with Creatom by pressing start during the falling cube demo, succeeding at the cube rotation puzzle, and then moving the cube in the falling cube game. Without this fix, the cube would get stuck.

Thanks to infval for finding the cause of this bug.