### PR TITLE
GB: Use correct BIOS when switching between GB and SGB.

### DIFF
--- a/Core/Debugger/DebugUtilities.h
+++ b/Core/Debugger/DebugUtilities.h
@@ -222,12 +222,11 @@ public:
 		}
 	}
 
-	static constexpr bool IsRom(MemoryType memType)
+	static constexpr bool IsCartRom(MemoryType memType)
 	{
 		switch(memType) {
 			case MemoryType::SnesPrgRom:
 			case MemoryType::GbPrgRom:
-			case MemoryType::GbBootRom:
 			case MemoryType::NesPrgRom:
 			case MemoryType::NesChrRom:
 			case MemoryType::PcePrgRom:
@@ -235,14 +234,30 @@ public:
 			case MemoryType::DspProgramRom:
 			case MemoryType::St018PrgRom:
 			case MemoryType::St018DataRom:
-			case MemoryType::SufamiTurboFirmware:
 			case MemoryType::SufamiTurboSecondCart:
-			case MemoryType::SpcRom:
 			case MemoryType::SmsPrgRom:
-			case MemoryType::SmsBootRom:
 			case MemoryType::GbaPrgRom:
-			case MemoryType::GbaBootRom:
 			case MemoryType::WsPrgRom:
+				return true;
+
+			default:
+				return false;
+		}
+	}
+
+	static constexpr bool IsRom(MemoryType memType)
+	{
+		if(IsCartRom(memType)) {
+			return true;
+		}
+
+		switch(memType) {
+			case MemoryType::GbBootRom:
+			case MemoryType::SufamiTurboFirmware:
+			case MemoryType::SpcRom:
+			case MemoryType::SmsBootRom:
+			case MemoryType::GbaBootRom:
+			case MemoryType::WsBootRom:
 				return true;
 
 			default:

--- a/Core/Shared/Emulator.cpp
+++ b/Core/Shared/Emulator.cpp
@@ -545,7 +545,7 @@ void Emulator::InitConsole(unique_ptr<IConsole>& newConsole, ConsoleMemoryInfo o
 	if(preserveRom && _console) {
 		//When power cycling, copy over the content of any ROM memory from the previous instance
 		magic_enum::enum_for_each<MemoryType>([&](MemoryType memType) {
-			if(DebugUtilities::IsRom(memType)) {
+			if(DebugUtilities::IsCartRom(memType)) {
 				uint32_t orgSize = originalConsoleMemory[(int)memType].Size;
 				if(orgSize > 0 && GetMemory(memType).Size == orgSize) {
 					memcpy(_consoleMemory[(int)memType].Memory, originalConsoleMemory[(int)memType].Memory, orgSize);


### PR DESCRIPTION
When switching between GB and SGB models and then power cycling, the old BIOS would continue being used for the new model. This fixes that for GB and any other firmware where a similar problem may have come up.

Thanks to Sour for this fix.