### PR TITLE
SNES: Fixed hi-res mode output when color math is enabled

### DIFF
--- a/Core/SNES/SnesPpu.cpp
+++ b/Core/SNES/SnesPpu.cpp
@@ -1285,7 +1285,8 @@ void SnesPpu::ApplyColorMath()
 			//Keep original subscreen color, which is used to apply color math to the main screen after
 			uint16_t subPixel = _subScreenBuffer[x];
 			//Apply the color math based on the previous main pixel
-			uint16_t prevMainPixel = x > 0 ? _mainScreenBuffer[x - 1] : 0;
+			uint16_t prevMainPixel = x > 0 ? _prevMainPixel : 0;
+			_prevMainPixel = _mainScreenBuffer[x];
 			int prevX = x > 0 ? x - 1 : 0;
 			ApplyColorMathToPixel(_subScreenBuffer[x], prevMainPixel, prevX, isInsideWindow);
 

--- a/Core/SNES/SnesPpu.h
+++ b/Core/SNES/SnesPpu.h
@@ -105,6 +105,8 @@ private:
 	uint16_t _latchRequestX = 0;
 	uint16_t _latchRequestY = 0;
 
+	uint16_t _prevMainPixel = 0;
+
 	Timer _frameSkipTimer;
 	bool _skipRender = false;
 	uint8_t _configVisibleLayers = 0xFF;


### PR DESCRIPTION
Fixes the behavior of tepples' "actualmix" test rom when "pseudo-hires" is enabled. Color math for the next subpixel needs to use the previous main pixel's original color, not the post-color math result.