### PR TITLE
GBA/SNES: Fix RTC to ignore DST.

### DIFF
--- a/Core/GBA/Cart/GbaRtc.cpp
+++ b/Core/GBA/Cart/GbaRtc.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "GBA/Cart/GbaRtc.h"
 #include "Utilities/Serializer.h"
+#include "Utilities/TimeUtilities.h"
 #include "Shared/Emulator.h"
 #include "Shared/BatteryManager.h"
 
@@ -180,7 +181,7 @@ void GbaRtc::UpdateTime()
 	tm.tm_mon = (month & 0x0F) + ((month >> 4) * 10);
 	tm.tm_year = 100 + (_state.Year & 0x0F) + ((_state.Year >> 4) * 10);
 
-	std::time_t tt = mktime(&tm);
+	std::time_t tt = TimeUtilities::TmToUtc(&tm);
 	if(tt == -1) {
 		//Invalid time
 		_lastUpdateTime = currentTime;
@@ -200,9 +201,9 @@ void GbaRtc::UpdateTime()
 	std::time_t newTime = system_clock::to_time_t(timePoint);
 	std::tm newTm;
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-	localtime_s(&newTm, &newTime);
+	gmtime_s(&newTm, &newTime);
 #else
-	localtime_r(&newTime, &newTm);
+	gmtime_r(&newTime, &newTm);
 #endif
 
 	_state.Second = (newTm.tm_sec % 10) + ((newTm.tm_sec / 10) << 4);

--- a/Core/SNES/Coprocessors/SPC7110/Rtc4513.cpp
+++ b/Core/SNES/Coprocessors/SPC7110/Rtc4513.cpp
@@ -6,6 +6,7 @@
 #include "Shared/BatteryManager.h"
 #include "Utilities/HexUtilities.h"
 #include "Utilities/Serializer.h"
+#include "Utilities/TimeUtilities.h"
 
 //TODO: Partial implementation
 //Missing stuff: most flags e.g: 30ADJ, 24/12, CAL/HW, WRAP, etc.
@@ -78,7 +79,7 @@ void Rtc4513::UpdateTime()
 	tm.tm_mon = GetMonth() - 1;
 	tm.tm_year = (GetYear() >= 90 ? 0 : 100) + GetYear();
 
-	std::time_t tt = mktime(&tm);
+	std::time_t tt = TimeUtilities::TmToUtc(&tm);
 	if(tt == -1 || GetMonth() == 0) {
 		_lastTime = currentTime;
 		return;
@@ -97,9 +98,9 @@ void Rtc4513::UpdateTime()
 	std::time_t newTime = system_clock::to_time_t(timePoint);
 	std::tm newTm;
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-	localtime_s(&newTm, &newTime);
+	gmtime_s(&newTm, &newTime);
 #else
-	localtime_r(&newTime, &newTm);
+	gmtime_r(&newTime, &newTm);
 #endif
 
 	_regs[0] = newTm.tm_sec % 10;

--- a/Utilities/TimeUtilities.h
+++ b/Utilities/TimeUtilities.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <cstdint>
+#include <ctime>
+
+class TimeUtilities
+{
+public:
+	//Returns a UTC result and updates the tm input's wday variable.
+	static time_t TmToUtc(std::tm* tm)
+	{
+		int64_t year = tm->tm_year + 1900;
+		int64_t month = tm->tm_mon;
+
+		//Normalize months and years.
+		if(month < 0 || month >= 12) {
+			year += (month < 0 ? (month - 11) / 12 : month / 12); //Adjust years by however far off months is.
+			month = (month % 12 + 12) % 12; //Normalize months to positive 0-11.
+		}
+
+		//We put February at the end of the year to make it easy to add 1 for leap years.
+		month -= 2;
+		if(month < 0) {
+			year -= 1;
+			month += 12;
+		}
+
+		//These don't need to be normalized; any extra will be included directly.
+		int64_t day = tm->tm_mday;
+		int64_t hour = tm->tm_hour;
+		int64_t minute = tm->tm_min;
+		int64_t second = tm->tm_sec;
+
+		//The number of days prior to the epoch (from 0000-03-01 (because of the month adjustment) to 1970-01-01).
+		static constexpr int64_t epoch_adjust = (1969 * 365) + (1969 / 4) - (1969 / 100) + (1969 / 400) + 306;
+
+		int64_t days = (day - 1) +
+			((month * 306 + 5) / 10) + //This algorithm produces the 31 and 30 pattern for the length of each month.
+			(year * 365) + (year / 4) - (year / 100) + (year / 400) -
+			epoch_adjust;
+
+		//Update the weekday. 0 = Sunday. The epoch was Thursday (4).
+		int wday = (int)((((days + 4) % 7) + 7) % 7);
+		tm->tm_wday = wday;
+
+		return (days * 86400) + (hour * 3600) + (minute * 60) + second;
+	}
+};

--- a/Utilities/Utilities.vcxproj
+++ b/Utilities/Utilities.vcxproj
@@ -245,6 +245,7 @@
     <ClInclude Include="StaticFor.h" />
     <ClInclude Include="StringUtilities.h" />
     <ClInclude Include="SZReader.h" />
+    <ClInclude Include="TimeUtilities.h" />
     <ClInclude Include="UPnPPortMapper.h" />
     <ClInclude Include="SimpleLock.h" />
     <ClInclude Include="Socket.h" />

--- a/Utilities/Utilities.vcxproj.filters
+++ b/Utilities/Utilities.vcxproj.filters
@@ -212,6 +212,7 @@
     <ClInclude Include="Audio\ymfm\ymfm_adpcm.h">
       <Filter>Audio\ymfm</Filter>
     </ClInclude>
+    <ClInclude Include="TimeUtilities.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="xBRZ\xbrz.cpp">


### PR DESCRIPTION
The SNES Rtc4513 and GBA RTC have a bug where during DST, they increment the hour every single second. This is because they use local time and the mktime function adjusts for DST every call. We can fix that by changing tm.is_dst to -1, but then will still presumably adjust the time at DST boundaries, which we probably don't want.

This commit changes it to use UTC instead of local time. Unfortunately, there doesn't seem to be a portable UTC function we can call instead of mktime, so this implements one. If we used C++20, then apparently <chrono> provides functionality that can do much of this work, so we may want to switch to that if we upgrade to C++20. But for this, this local implementation may be the best approach.

This change was tested with Rockman EXE 4.5.