### PR TITLE
NES: Predictive breakpoints can ack $4015 frame counter IRQ.

### DIFF
--- a/Core/NES/APU/ApuFrameCounter.h
+++ b/Core/NES/APU/ApuFrameCounter.h
@@ -226,6 +226,17 @@ public:
 		return _irqFlag;
 	}
 
+	bool PeekIrqFlag()
+	{
+		if(_irqFlag && _irqFlagClearClock != 0) {
+			uint64_t clock = _console->GetMasterClock();
+			if(clock >= _irqFlagClearClock) {
+				return false;
+			}
+		}
+		return _irqFlag;
+	}
+
 	ApuFrameCounterState GetState()
 	{
 		ApuFrameCounterState state;

--- a/Core/NES/APU/NesApu.cpp
+++ b/Core/NES/APU/NesApu.cpp
@@ -71,6 +71,7 @@ void NesApu::FrameCounterTick(FrameType type)
 	}
 }
 
+template<bool isPeek>
 uint8_t NesApu::GetStatus()
 {
 	uint8_t status = 0;
@@ -79,7 +80,11 @@ uint8_t NesApu::GetStatus()
 	status |= _triangle->GetStatus() ? 0x04 : 0x00;
 	status |= _noise->GetStatus() ? 0x08 : 0x00;
 	status |= _dmc->GetStatus() ? 0x10 : 0x00;
-	status |= _frameCounter->GetIrqFlag() ? 0x40 : 0x00;
+	if constexpr(isPeek) {
+		status |= _frameCounter->PeekIrqFlag() ? 0x40 : 0x00;
+	} else {
+		status |= _frameCounter->GetIrqFlag() ? 0x40 : 0x00;
+	}
 	status |= _console->GetCpu()->HasIrqSource(IRQSource::DMC) ? 0x80 : 0x00;
 
 	return status;
@@ -119,7 +124,7 @@ uint8_t NesApu::PeekRam(uint16_t addr)
 		//Only run the Apu (to catch up) if we're running this in the emulation thread (not 100% accurate, but we can't run the Apu from any other thread without locking)
 		Run();
 	}
-	return GetStatus();
+	return GetStatus<true>();
 }
 
 void NesApu::WriteRam(uint16_t addr, uint8_t value)

--- a/Core/NES/APU/NesApu.h
+++ b/Core/NES/APU/NesApu.h
@@ -45,6 +45,8 @@ private:
 	__forceinline bool NeedToRun(uint32_t currentCycle);
 
 	void FrameCounterTick(FrameType type);
+
+	template<bool isPeek = false>
 	uint8_t GetStatus();
 
 public:

--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -184,12 +184,12 @@ void NesCpu::IRQ()
 {
 #ifndef DUMMYCPU
 	uint16_t originalPc = PC();
-#endif
 
 	if(_console->GetRegion() == ConsoleRegion::Pal) {
 		//On PAL, IRQ/NMI sequence also checks for DMA on the first read
 		ProcessPendingDma(_state.PC, MemoryOperationType::ExecOpCode);
 	}
+#endif
 
 	DummyPcRead();  //fetch opcode (and discard it - $00 (BRK) is forced into the opcode register instead)
 	DummyPcRead();  //read next instruction byte (actually the same as above, since PC increment is suppressed. Also discarded.)


### PR DESCRIPTION
Predictive breakpoints use a dummy CPU for prediction, and that dummy CPU needs to not cause side effects. However, there was no way to peek at the state of the frame counter IRQ, so prediction could cause this flag to be unexpectedly cleared.

This change adds peeking. It has a limitation in that it may mispredict the value of the flag on double reads and break when it shouldn't.

This change also fixes a related issue on PAL with dummy CPUs processing DMA.

Thanks to Sour for identifying the code for both issues.