### PR TITLE
Debugger: Lua - Added new APIs: getCpuState, setCpuState, getMasterClock, getCpuCycleCount

### DIFF
--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -166,6 +166,11 @@ DebuggerType* Debugger::GetDebugger()
 	return (DebuggerType*)_debuggers[(int)type].Debugger.get();
 }
 
+IDebugger* Debugger::GetCpuDebugger(CpuType cpuType)
+{
+	return _debuggers[(int)cpuType].Debugger.get();
+}
+
 IDebugger* Debugger::GetMainDebugger()
 {
 	return _debuggers[(int)_mainCpuType].Debugger.get();
@@ -869,6 +874,14 @@ void Debugger::SetCpuState(BaseState& srcState, CpuType cpuType)
 		case CpuType::Gba: memcpy(&dstState, &srcState, sizeof(GbaCpuState)); break;
 		case CpuType::Ws: memcpy(&dstState, &srcState, sizeof(WsCpuState)); break;
 	}
+}
+
+ISerializable* Debugger::GetSerializableCpu(CpuType cpuType)
+{
+	if(_debuggers[(int)cpuType].Debugger) {
+		 return _debuggers[(int)cpuType].Debugger->GetSerializableCpu();
+	}
+	return nullptr;
 }
 
 BaseState& Debugger::GetCpuStateRef(CpuType cpuType)

--- a/Core/Debugger/Debugger.h
+++ b/Core/Debugger/Debugger.h
@@ -36,6 +36,7 @@ class IDebugger;
 class ITraceLogger;
 class TraceLogFileSaver;
 class FrozenAddressManager;
+class ISerializable;
 
 struct TraceRow;
 struct BaseState;
@@ -150,6 +151,7 @@ public:
 
 	void GetCpuState(BaseState& dstState, CpuType cpuType);
 	void SetCpuState(BaseState& srcState, CpuType cpuType);
+	ISerializable* GetSerializableCpu(CpuType cpuType);
 	BaseState& GetCpuStateRef(CpuType cpuType);
 
 	void GetPpuState(BaseState& state, CpuType cpuType);
@@ -182,6 +184,7 @@ public:
 	uint32_t GetExecutionTrace(TraceRow output[], uint32_t startOffset, uint32_t maxLineCount);
 	
 	CpuType GetMainCpuType() { return _mainCpuType; }
+	IDebugger* GetCpuDebugger(CpuType cpuType);
 	IDebugger* GetMainDebugger();
 
 	TraceLogFileSaver* GetTraceLogFileSaver() { return _traceLogSaver.get(); }

--- a/Core/Debugger/IDebugger.h
+++ b/Core/Debugger/IDebugger.h
@@ -66,6 +66,7 @@ public:
 	virtual void SetProgramCounter(uint32_t addr, bool updateDebuggerOnly = false) = 0;
 
 	virtual uint8_t GetCpuFlags(uint32_t addr) { return 0; }
+	virtual ISerializable* GetSerializableCpu() { return nullptr; }
 
 	virtual BreakpointManager* GetBreakpointManager() = 0;
 	virtual CallstackManager* GetCallstackManager() = 0;

--- a/Core/Debugger/LuaApi.cpp
+++ b/Core/Debugger/LuaApi.cpp
@@ -3,6 +3,7 @@
 #include "Lua/lua.hpp"
 #include "Debugger/LuaCallHelper.h"
 #include "Debugger/Debugger.h"
+#include "Debugger/IDebugger.h"
 #include "Debugger/MemoryDumper.h"
 #include "Debugger/ScriptingContext.h"
 #include "Debugger/MemoryAccessCounter.h"
@@ -58,6 +59,7 @@ Debugger* LuaApi::_debugger = nullptr;
 Emulator* LuaApi::_emu = nullptr;
 MemoryDumper* LuaApi::_memoryDumper = nullptr;
 ScriptingContext* LuaApi::_context = nullptr;
+Serializer LuaApi::_serializer(0, true, SerializeFormat::Map);
 
 enum class AccessCounterType
 {
@@ -152,6 +154,12 @@ int LuaApi::GetLibrary(lua_State *lua)
 
 		{ "getState", LuaApi::GetState },
 		{ "setState", LuaApi::SetState },
+		{ "getCpuState", LuaApi::GetCpuState },
+		{ "setCpuState", LuaApi::SetCpuState },
+
+		{ "getCpuCycleCount", LuaApi::GetCpuCycleCount },
+		{ "getMasterClock", LuaApi::GetMasterClock },
+
 
 		{ "selectDrawSurface", LuaApi::SelectDrawSurface },
 
@@ -1073,7 +1081,8 @@ int LuaApi::GetState(lua_State *lua)
 	LuaCallHelper l(lua);
 	checkparams();
 
-	Serializer s(0, true, SerializeFormat::Map);
+	Serializer& s = _serializer;
+	s.Reset();
 	s.Stream(*_emu->GetConsole().get(), "", -1);
 
 	//Add some more Lua-specific values
@@ -1088,20 +1097,26 @@ int LuaApi::GetState(lua_State *lua)
 	SV(region);
 	SV(frameCount);
 	SV(masterClock);
+	
+	GenerateStateTable(s, lua);
 
-	unordered_map<string, SerializeMapValue>& values = s.GetMapValues();
+	return 1;
+}
 
-	lua_newtable(lua);
-	for(auto& kvp : values) {
-		lua_pushlstring(lua, kvp.first.c_str(), kvp.first.size());
-		switch(kvp.second.Format) {
-			case SerializeMapValueFormat::Integer: lua_pushinteger(lua, kvp.second.Value.Integer); break;
-			case SerializeMapValueFormat::Double: lua_pushnumber(lua, kvp.second.Value.Double); break;
-			case SerializeMapValueFormat::Bool: lua_pushboolean(lua, kvp.second.Value.Bool); break;
-			case SerializeMapValueFormat::String: lua_pushlstring(lua, kvp.second.StringValue.c_str(), kvp.second.StringValue.size()); break;
-		}
-		lua_settable(lua, -3);
+int LuaApi::GetCpuState(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	l.ForceParamCount(1);
+	CpuType cpuType = (CpuType)l.ReadInteger((uint32_t)_context->GetDefaultCpuType());
+	checkEnum(CpuType, cpuType, "invalid cpu type");
+
+	Serializer& s = _serializer;
+	s.Reset();
+	ISerializable* cpu = _debugger->GetSerializableCpu(cpuType);
+	if(cpu) {
+		s.Stream(*cpu, "", -1);
 	}
+	GenerateStateTable(s, lua);
 	return 1;
 }
 
@@ -1110,6 +1125,52 @@ int LuaApi::SetState(lua_State* lua)
 	lua_settop(lua, 1);
 	luaL_checktype(lua, -1, LUA_TTABLE);
 
+	Serializer s(0, false, SerializeFormat::Map);
+	ReadStateTable(s, lua);
+	s.Stream(*_emu->GetConsole().get(), "", -1);
+	return 0;
+}
+
+int LuaApi::SetCpuState(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	l.ForceParamCount(2);
+
+	CpuType cpuType = (CpuType)l.ReadInteger((uint32_t)_context->GetDefaultCpuType());
+	checkEnum(CpuType, cpuType, "invalid cpu type");
+
+	ISerializable* cpu = _debugger->GetSerializableCpu(cpuType);
+	if(cpu) {
+		lua_settop(lua, 1);
+		luaL_checktype(lua, -1, LUA_TTABLE);
+
+		Serializer s(0, false, SerializeFormat::Map);
+		ReadStateTable(s, lua);
+
+		s.Stream(*cpu, "", -1);
+	}
+	return 0;
+}
+
+void LuaApi::GenerateStateTable(Serializer& s, lua_State* lua)
+{
+	vector<string>& keys = s.GetMapKeys();
+	vector<SerializeMapValue>& values = s.GetMapValues();
+
+	lua_createtable(lua, 0, (int)values.size());
+	for(size_t i = 0, len = values.size(); i < len; i++) {
+		switch(values[i].Format) {
+			case SerializeMapValueFormat::Integer: lua_pushinteger(lua, values[i].Value.Integer); break;
+			case SerializeMapValueFormat::Double: lua_pushnumber(lua, values[i].Value.Double); break;
+			case SerializeMapValueFormat::Bool: lua_pushboolean(lua, values[i].Value.Bool); break;
+			case SerializeMapValueFormat::String: lua_pushlstring(lua, values[i].StringValue.c_str(), values[i].StringValue.size()); break;
+		}
+		lua_setfield(lua, -2, keys[i].c_str());
+	}
+}
+
+void LuaApi::ReadStateTable(Serializer& s, lua_State* lua)
+{
 	unordered_map<string, SerializeMapValue> map;
 
 	lua_pushnil(lua);  /* first key */
@@ -1141,9 +1202,25 @@ int LuaApi::SetState(lua_State* lua)
 		lua_pop(lua, 1);
 	}
 
-	Serializer s(0, false, SerializeFormat::Map);
 	s.LoadFromMap(map);
+}
 
-	s.Stream(*_emu->GetConsole().get(), "", -1);
-	return 0;
+int LuaApi::GetCpuCycleCount(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	l.ForceParamCount(1);
+	CpuType cpuType = (CpuType)l.ReadInteger((uint32_t)_context->GetDefaultCpuType());
+	checkEnum(CpuType, cpuType, "invalid cpu type");
+
+	IDebugger* debugger = _debugger->GetCpuDebugger(cpuType);
+	l.Return(debugger ? debugger->GetCpuCycleCount() : 0);
+	return l.ReturnCount();
+}
+
+int LuaApi::GetMasterClock(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	checkparams();
+	l.Return(_emu->GetMasterClock());
+	return l.ReturnCount();
 }

--- a/Core/Debugger/LuaApi.h
+++ b/Core/Debugger/LuaApi.h
@@ -11,6 +11,7 @@ class Emulator;
 class MemoryDumper;
 class DebugHud;
 class BaseVideoFilter;
+class Serializer;
 
 class LuaApi
 {
@@ -84,8 +85,17 @@ public:
 	static int GetRomInfo(lua_State *lua);
 	static int GetLogWindowLog(lua_State *lua);
 
-	static int SetState(lua_State *lua);
+	static void GenerateStateTable(Serializer& s, lua_State* lua);
+	static void ReadStateTable(Serializer& s, lua_State* lua);
+
+	static int GetCpuCycleCount(lua_State* lua);
+	static int GetMasterClock(lua_State* lua);
+
 	static int GetState(lua_State *lua);
+	static int GetCpuState(lua_State* lua);
+
+	static int SetState(lua_State *lua);
+	static int SetCpuState(lua_State* lua);
 
 	static int GetAccessCounters(lua_State *lua);
 	static int ResetAccessCounters(lua_State *lua);
@@ -99,6 +109,7 @@ private:
 	static Debugger* _debugger;
 	static MemoryDumper* _memoryDumper;
 	static ScriptingContext* _context;
+	static Serializer _serializer;
 	
 	static std::pair<unique_ptr<BaseVideoFilter>, FrameInfo> GetRenderedFrame();
 	template<typename T> static void GenerateEnumDefinition(lua_State* lua, string enumName, unordered_set<T> excludedValues = {});

--- a/Core/Debugger/LuaCallHelper.cpp
+++ b/Core/Debugger/LuaCallHelper.cpp
@@ -135,6 +135,12 @@ void LuaCallHelper::Return(uint32_t value)
 	_returnCount++;
 }
 
+void LuaCallHelper::Return(uint64_t value)
+{
+	lua_pushinteger(_lua, value);
+	_returnCount++;
+}
+
 void LuaCallHelper::Return(string value)
 {
 	lua_pushlstring(_lua, value.c_str(), value.size());

--- a/Core/Debugger/LuaCallHelper.h
+++ b/Core/Debugger/LuaCallHelper.h
@@ -35,6 +35,7 @@ public:
 	void Return(bool value);
 	void Return(int value);
 	void Return(uint32_t value);
+	void Return(uint64_t value);
 	void Return(string value);
 
 	int ReturnCount();

--- a/Core/GBA/Debugger/GbaDebugger.cpp
+++ b/Core/GBA/Debugger/GbaDebugger.cpp
@@ -426,6 +426,11 @@ PpuTools* GbaDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* GbaDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool GbaDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/GBA/Debugger/GbaDebugger.h
+++ b/Core/GBA/Debugger/GbaDebugger.h
@@ -92,6 +92,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 	void GetPpuState(BaseState& state) override;

--- a/Core/Gameboy/Debugger/GbDebugger.cpp
+++ b/Core/Gameboy/Debugger/GbDebugger.cpp
@@ -436,6 +436,11 @@ PpuTools* GbDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* GbDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool GbDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/Gameboy/Debugger/GbDebugger.h
+++ b/Core/Gameboy/Debugger/GbDebugger.h
@@ -89,6 +89,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 	void GetPpuState(BaseState& state) override;

--- a/Core/NES/Debugger/NesDebugger.cpp
+++ b/Core/NES/Debugger/NesDebugger.cpp
@@ -482,6 +482,11 @@ PpuTools* NesDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* NesDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool NesDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/NES/Debugger/NesDebugger.h
+++ b/Core/NES/Debugger/NesDebugger.h
@@ -23,6 +23,7 @@ class DummyNesCpu;
 class BaseNesPpu;
 class BaseMapper;
 class NesMemoryManager;
+class ISerializable;
 
 enum class MemoryOperationType;
 
@@ -93,6 +94,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 	bool SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption);
 	void GetRomHeader(uint8_t* headerData, uint32_t& size) override;
 	CallstackManager* GetCallstackManager() override;

--- a/Core/PCE/Debugger/PceDebugger.cpp
+++ b/Core/PCE/Debugger/PceDebugger.cpp
@@ -446,6 +446,11 @@ PpuTools* PceDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* PceDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool PceDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/PCE/Debugger/PceDebugger.h
+++ b/Core/PCE/Debugger/PceDebugger.h
@@ -94,6 +94,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 	bool SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption);
 	void ProcessInputOverrides(DebugControllerState inputOverrides[8]) override;
 	CallstackManager* GetCallstackManager() override;

--- a/Core/SMS/Debugger/SmsDebugger.cpp
+++ b/Core/SMS/Debugger/SmsDebugger.cpp
@@ -435,6 +435,11 @@ PpuTools* SmsDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* SmsDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool SmsDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/SMS/Debugger/SmsDebugger.h
+++ b/Core/SMS/Debugger/SmsDebugger.h
@@ -95,6 +95,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 	void GetPpuState(BaseState& state) override;

--- a/Core/SNES/Debugger/Cx4Debugger.cpp
+++ b/Core/SNES/Debugger/Cx4Debugger.cpp
@@ -235,3 +235,8 @@ ITraceLogger* Cx4Debugger::GetTraceLogger()
 {
 	return _traceLogger.get();
 }
+
+ISerializable* Cx4Debugger::GetSerializableCpu()
+{
+	return _cx4;
+}

--- a/Core/SNES/Debugger/Cx4Debugger.h
+++ b/Core/SNES/Debugger/Cx4Debugger.h
@@ -56,6 +56,7 @@ public:
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
 	ITraceLogger* GetTraceLogger() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 };

--- a/Core/SNES/Debugger/GsuDebugger.cpp
+++ b/Core/SNES/Debugger/GsuDebugger.cpp
@@ -194,3 +194,8 @@ ITraceLogger* GsuDebugger::GetTraceLogger()
 {
 	return _traceLogger.get();
 }
+
+ISerializable* GsuDebugger::GetSerializableCpu()
+{
+	return _gsu;
+}

--- a/Core/SNES/Debugger/GsuDebugger.h
+++ b/Core/SNES/Debugger/GsuDebugger.h
@@ -53,6 +53,7 @@ public:
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
 	ITraceLogger* GetTraceLogger() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 };

--- a/Core/SNES/Debugger/NecDspDebugger.cpp
+++ b/Core/SNES/Debugger/NecDspDebugger.cpp
@@ -207,3 +207,8 @@ ITraceLogger* NecDspDebugger::GetTraceLogger()
 {
 	return _traceLogger.get();
 }
+
+ISerializable* NecDspDebugger::GetSerializableCpu()
+{
+	return _dsp;
+}

--- a/Core/SNES/Debugger/NecDspDebugger.h
+++ b/Core/SNES/Debugger/NecDspDebugger.h
@@ -53,6 +53,7 @@ public:
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
 	ITraceLogger* GetTraceLogger() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 };

--- a/Core/SNES/Debugger/SnesDebugger.cpp
+++ b/Core/SNES/Debugger/SnesDebugger.cpp
@@ -529,6 +529,15 @@ PpuTools* SnesDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* SnesDebugger::GetSerializableCpu()
+{
+	if(_cpuType == CpuType::Snes) {
+		return _cpu;
+	} else {
+		return _sa1;
+	}
+}
+
 BaseState& SnesDebugger::GetState()
 {
 	return GetCpuState();

--- a/Core/SNES/Debugger/SnesDebugger.h
+++ b/Core/SNES/Debugger/SnesDebugger.h
@@ -117,6 +117,7 @@ public:
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 	void GetPpuState(BaseState& state) override;

--- a/Core/SNES/Debugger/SpcDebugger.cpp
+++ b/Core/SNES/Debugger/SpcDebugger.cpp
@@ -274,6 +274,11 @@ ITraceLogger* SpcDebugger::GetTraceLogger()
 	return _traceLogger.get();
 }
 
+ISerializable* SpcDebugger::GetSerializableCpu()
+{
+	return _spc;
+}
+
 template void SpcDebugger::ProcessRead<MemoryAccessFlags::None>(uint32_t addr, uint8_t value, MemoryOperationType opType);
 template void SpcDebugger::ProcessRead<MemoryAccessFlags::DspAccess>(uint32_t addr, uint8_t value, MemoryOperationType opType);
 

--- a/Core/SNES/Debugger/SpcDebugger.h
+++ b/Core/SNES/Debugger/SpcDebugger.h
@@ -66,6 +66,7 @@ public:
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
 	ITraceLogger* GetTraceLogger() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 };

--- a/Core/SNES/Debugger/St018Debugger.cpp
+++ b/Core/SNES/Debugger/St018Debugger.cpp
@@ -284,6 +284,11 @@ ITraceLogger* St018Debugger::GetTraceLogger()
 	return _traceLogger.get();
 }
 
+ISerializable* St018Debugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 IAssembler* St018Debugger::GetAssembler()
 {
 	throw std::runtime_error("Assembler not supported for ST018");

--- a/Core/SNES/Debugger/St018Debugger.h
+++ b/Core/SNES/Debugger/St018Debugger.h
@@ -68,6 +68,7 @@ public:
 	ITraceLogger* GetTraceLogger() override;
 	IAssembler* GetAssembler() override;
 	BaseEventManager* GetEventManager() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 };

--- a/Core/WS/Debugger/WsDebugger.cpp
+++ b/Core/WS/Debugger/WsDebugger.cpp
@@ -459,6 +459,11 @@ PpuTools* WsDebugger::GetPpuTools()
 	return _ppuTools.get();
 }
 
+ISerializable* WsDebugger::GetSerializableCpu()
+{
+	return _cpu;
+}
+
 bool WsDebugger::SaveRomToDisk(string filename, bool saveAsIps, CdlStripOption stripOption)
 {
 	vector<uint8_t> output;

--- a/Core/WS/Debugger/WsDebugger.h
+++ b/Core/WS/Debugger/WsDebugger.h
@@ -98,6 +98,7 @@ public:
 	BreakpointManager* GetBreakpointManager() override;
 	ITraceLogger* GetTraceLogger() override;
 	PpuTools* GetPpuTools() override;
+	ISerializable* GetSerializableCpu() override;
 
 	BaseState& GetState() override;
 	void GetPpuState(BaseState& state) override;

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -154,6 +154,24 @@
 	"returnValue": { "type": "Array", "description": "Array of bytes" }
 },
 {
+	"name": "getCpuState",
+	"category": "Emulation",
+	"description": "Returns a table containing key-value pairs that describe the CPU's current state.\n\nNote: The name of the values returned may change from one version to another. Some values may represent the emulator's internal state and may not be useful (these will be hidden in future versions.)",
+	"parameters": [
+		{ "name": "cpuType", "type": "Enum", "enumName": "cpuType", "description": "CPU type", "defaultValue": "main CPU" }
+	],
+	"returnValue": { "type": "Table", "description": "Content is CPU-specific" }
+},
+{
+	"name": "getCpuCycleCount",
+	"category": "Emulation",
+	"description": "Returns the number of elapsed CPU cycles since power on/reset (for the specified CPU)",
+	"parameters": [
+		{ "name": "cpuType", "type": "Enum", "enumName": "cpuType", "description": "CPU type", "defaultValue": "main CPU" }
+	],
+	"returnValue": { "type": "Int", "description": "Number of CPU cycles" }
+},
+{
 	"name": "getDrawSurfaceSize",
 	"category": "Drawing",
 	"description": "Returns a table containing the full size, visible size and overscan size for the selected draw surface.",
@@ -186,6 +204,12 @@
 	"category": "Logging",
 	"description": "Returns the same text as what is shown in the emulator's log window.",
 	"returnValue": { "type": "String", "description": "A string containing the log shown in the log window" }
+},
+{
+	"name": "getMasterClock",
+	"category": "Emulation",
+	"description": "Returns the number of elapsed master clocks since power on/reset for the console.",
+	"returnValue": { "type": "Int", "description": "Number of master clock cycles" }
 },
 {
 	"name": "getMemorySize",
@@ -344,6 +368,15 @@
 	"parameters": [
 		{ "name": "surface", "type": "Enum", "enumName": "drawSurface", "description": "Draw surface" },
 		{ "name": "scale", "type": "Int", "description": "Scale to use for the \"scriptHud\" surface (max: 4)", "defaultValue": "current scale" }
+	]
+},
+{
+	"name": "setCpuState",
+	"category": "Emulation",
+	"description": "Changes the state of the CPU to match the values provided in the \"state\" parameter.\n\nNote: The name of the values returned may change from one version to another. Some values may represent the emulator's internal state and should not be changed (access to these will be removed in future versions.)",
+	"parameters": [
+		{ "name": "state", "type": "Table", "description": "A key-value table containing the CPU state to be applied." },
+		{ "name": "cpuType", "type": "Enum", "enumName": "cpuType", "description": "CPU type", "defaultValue": "main CPU" }
 	]
 },
 {

--- a/Utilities/Serializer.cpp
+++ b/Utilities/Serializer.cpp
@@ -12,7 +12,7 @@ Serializer::Serializer(uint32_t version, bool forSave, SerializeFormat format)
 	if(forSave) {
 		switch(format) {
 			case SerializeFormat::Binary: _data.reserve(0x50000); break;
-			case SerializeFormat::Map: _mapValues.reserve(500); break;
+			case SerializeFormat::Map: _mapSaveValues.reserve(500); _mapSaveKeys.reserve(500); break;
 			case SerializeFormat::Text: _values.reserve(500); break;
 		}
 	}
@@ -231,17 +231,22 @@ void Serializer::SaveTo(ostream& file, int compressionLevel)
 
 void Serializer::LoadFromMap(unordered_map<string, SerializeMapValue>& map)
 {
-	_mapValues = map;
+	_mapLoadValues = map;
 }
 
 string Serializer::NormalizeName(const char* name, int index)
 {
-	string valName = name[0] == '_' ? name + 1 : name;
-	if(valName.size() > 6 && memcmp(valName.c_str(), "state.", 6) == 0) {
-		valName = valName.substr(6);
+	if(name[0] == '_') {
+		name++;
+	}
+	size_t len = strlen(name);
+	if(len > 6 && memcmp(name, "state.", 6) == 0) {
+		name += 6;
+		len -= 6;
 	}
 
-	for(size_t i = 0, len = valName.size(); i < len; i++) {
+	string valName(name, len);
+	for(size_t i = 0; i < len; i++) {
 		char c = valName[i];
 		if(c >= 'A' && c <= 'Z') {
 			valName[i] = ::tolower(c);

--- a/Utilities/Serializer.h
+++ b/Utilities/Serializer.h
@@ -80,7 +80,9 @@ private:
 	unordered_map<string, SerializeValue> _values;
 
 	//Used by Lua API
-	unordered_map<string, SerializeMapValue> _mapValues;
+	unordered_map<string, SerializeMapValue> _mapLoadValues;
+	vector<string> _mapSaveKeys;
+	vector<SerializeMapValue> _mapSaveValues;
 
 	uint32_t _version = 0;
 	bool _saving = false;
@@ -95,12 +97,17 @@ private:
 	string GetKey(const char* name, int index)
 	{
 		string valName = NormalizeName(name, index);
+#ifdef DEBUG
 		if(valName.empty()) {
 			throw std::runtime_error("invalid value name");
 		}
-		return _prefix + valName;
+#endif
+		if(_prefix.size()) {
+			return _prefix + valName;
+		} else {
+			return valName;
+		}
 	}
-
 	template<typename T>
 	void WriteValue(T value)
 	{
@@ -127,21 +134,25 @@ private:
 	void WriteMapFormat(string& key, T& value)
 	{
 		if constexpr(std::is_same<T, bool>::value) {
-			_mapValues.try_emplace(key, SerializeMapValueFormat::Bool, (bool)value);
+			_mapSaveKeys.push_back(key);
+			_mapSaveValues.push_back({ SerializeMapValueFormat::Bool, (bool)value });
 		} else if constexpr(std::is_integral<T>::value) {
-			_mapValues.try_emplace(key, SerializeMapValueFormat::Integer, (int64_t)value);
+			_mapSaveKeys.push_back(key);
+			_mapSaveValues.push_back({ SerializeMapValueFormat::Integer, (int64_t)value });
 		} else if constexpr(std::is_floating_point<T>::value) {
-			_mapValues.try_emplace(key, SerializeMapValueFormat::Double, (double)value);
+			_mapSaveKeys.push_back(key);
+			_mapSaveValues.push_back({ SerializeMapValueFormat::Double, (double)value });
 		} else if constexpr(std::is_same<T, string>::value) {
-			_mapValues.try_emplace(key, value);
+			_mapSaveKeys.push_back(key);
+			_mapSaveValues.push_back({ (string)value });
 		}
 	}
 
 	template<typename T>
 	void ReadMapFormat(string& key, T& value)
 	{
-		auto result = _mapValues.find(key);
-		if(result != _mapValues.end()) {
+		auto result = _mapLoadValues.find(key);
+		if(result != _mapLoadValues.end()) {
 			SerializeMapValue mapVal = result->second;
 			if constexpr(std::is_same<T, bool>::value) {
 				if(mapVal.Format == SerializeMapValueFormat::Bool) {
@@ -220,10 +231,25 @@ public:
 	bool IsSaving() { return _saving; }
 	
 	SerializeFormat GetFormat() { return _format; }
-	unordered_map<string, SerializeMapValue>& GetMapValues() { return _mapValues; }
+	vector<string>& GetMapKeys() { return _mapSaveKeys; }
+	vector<SerializeMapValue>& GetMapValues() { return _mapSaveValues; }
 
 	void SetErrorFlag() { _hasError = true; }
 	bool HasError() { return _hasError; }
+
+	void Reset()
+	{
+		_data.clear();
+		_prefixes.clear();
+		_prefix.clear();
+
+		_usedKeys.clear();
+		_values.clear();
+		_mapLoadValues.clear();
+		_mapSaveKeys.clear();
+		_mapSaveValues.clear();
+		_hasError = false;
+	}
 
 	bool IsValid() { return _values.size() > 0; }
 	void AddKeyPrefix(string prefix);


### PR DESCRIPTION
-getCpuState/setCpuState allow the same functionality as getState/setState, but limited to only the CPU's state, making them much faster (some performance optimizations to the serialization & Lua code were also done)
-getMasterClock/getCpuCycleCount are very fast alternatives to getState when all the script needs is a cycle count.