### PR TITLE
SNES: Fix clock counting logic for DMAs longer than 255 bytes

### DIFF
--- a/Core/SNES/SnesDmaController.cpp
+++ b/Core/SNES/SnesDmaController.cpp
@@ -78,7 +78,7 @@ void SnesDmaController::RunDma(DmaChannelConfig &channel)
 
 	const uint8_t *transferOffsets = _transferOffset[channel.TransferMode];
 
-	uint8_t i = 0;
+	uint32_t i = 0;
 	do {
 		//Manual DMA transfers run to the end of the transfer when started
 		CopyDmaByte(


### PR DESCRIPTION
When transfer is larger than 255 bytes, i wraps back to 0, causing _dmaClockCounter to be incremented by the wrong amount. This could cause minor timing issues because the value of _dmaClockCounter is used in SyncEndDma() to determine how many cycles to stall before the CPU resumes its execution. This appears to make my old timing_test rom give a result that's closer to hardware for the last row ("WRAM DMA 1K+FR")