### PR TITLE
Debugger: Memory viewer - Improved performance on Linux

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -1221,6 +1221,7 @@
       </ShowIncludes>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -1257,6 +1258,7 @@
       </RuntimeTypeInfo>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -1289,6 +1291,7 @@
       <ControlFlowGuard>false</ControlFlowGuard>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -1321,6 +1324,7 @@
       <ControlFlowGuard>false</ControlFlowGuard>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/InteropDLL/InteropDLL.vcxproj
+++ b/InteropDLL/InteropDLL.vcxproj
@@ -113,6 +113,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -136,6 +137,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -161,6 +163,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -186,6 +189,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Lua/Lua.vcxproj
+++ b/Lua/Lua.vcxproj
@@ -194,6 +194,7 @@
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -211,6 +212,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -230,6 +232,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -249,6 +252,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/PGOHelper/PGOHelper.vcxproj
+++ b/PGOHelper/PGOHelper.vcxproj
@@ -4,7 +4,7 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>	 
+    </ProjectConfiguration>
     <ProjectConfiguration Include="PGO Optimize|x64">
       <Configuration>PGO Optimize</Configuration>
       <Platform>x64</Platform>
@@ -105,6 +105,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -125,6 +126,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +148,7 @@
       </AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -167,6 +170,7 @@
       </AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/SevenZip/SevenZip.vcxproj
+++ b/SevenZip/SevenZip.vcxproj
@@ -140,6 +140,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -157,6 +158,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -176,6 +178,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -195,6 +198,7 @@
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/UI/Debugger/Controls/HexEditor.HexViewDrawOperation.cs
+++ b/UI/Debugger/Controls/HexEditor.HexViewDrawOperation.cs
@@ -25,7 +25,7 @@ namespace Mesen.Debugger.Controls
 			private bool _inStringView;
 			private double _rowHeight;
 			private string _hexFormat;
-			private string _fontFamily;
+			private SKTypeface _typeface;
 			private float _fontSize;
 			private double _stringViewPosition;
 			private IHexEditorDataProvider _dataProvider;
@@ -42,7 +42,7 @@ namespace Mesen.Debugger.Controls
 			{
 				_he = he;
 				Bounds = _he.Bounds;
-				_fontFamily = _he.FontFamily.Name;
+				_typeface = _he._skTypeface;
 				_fontSize = (float)_he.FontSize;
 				_bytesPerRow = _he.BytesPerRow;
 				_hexFormat = _he.HexFormat;
@@ -125,8 +125,7 @@ namespace Mesen.Debugger.Controls
 				SKPaint paint = new SKPaint();
 				paint.Color = new SKColor(ColorHelper.GetColor(color).ToUInt32());
 
-				SKTypeface typeface = SKTypeface.FromFamilyName(_fontFamily);
-				SKFont font = new SKFont(typeface, _fontSize);
+				SKFont font = new SKFont(_typeface, _fontSize);
 				SetFontProperties(font);
 
 				using var builder = new SKTextBlobBuilder();
@@ -232,8 +231,7 @@ namespace Mesen.Debugger.Controls
 				SKPaint paint = new SKPaint();
 				paint.Color = new SKColor(ColorHelper.GetColor(color).ToUInt32());
 
-				SKTypeface typeface = SKTypeface.FromFamilyName(_fontFamily);
-				SKFont monoFont = new SKFont(typeface, _fontSize);
+				SKFont monoFont = new SKFont(_typeface, _fontSize);
 				SetFontProperties(monoFont);
 
 				SKFont altFont = new SKFont(SKFontManager.Default.MatchCharacter('あ'), _fontSize);
@@ -411,7 +409,7 @@ namespace Mesen.Debugger.Controls
 			private Size _letterSize;
 			private int _bytesPerRow;
 			private double _rowHeight;
-			private string _fontFamily;
+			private SKTypeface _typeface;
 			private float _fontSize;
 			private IHexEditorDataProvider _dataProvider;
 			private double _headerCharLength;
@@ -428,8 +426,8 @@ namespace Mesen.Debugger.Controls
 			{
 				_he = he;
 				Bounds = _he.Bounds;
-				_fontFamily = _he.FontFamily.Name;
 				_fontSize = (float)_he.FontSize;
+				_typeface = _he._skTypeface;
 				_bytesPerRow = _he.BytesPerRow;
 				_rowHeight = _he.RowHeight;
 				_rowHeaderWidth = _he.RowHeaderWidth;
@@ -473,8 +471,7 @@ namespace Mesen.Debugger.Controls
 					SKPaint paint = new SKPaint();
 					paint.Color = new SKColor(ColorHelper.GetColor(_headerForeground).ToUInt32());
 
-					SKTypeface typeface = SKTypeface.FromFamilyName(_fontFamily);
-					SKFont font = new SKFont(typeface, _fontSize);
+					SKFont font = new SKFont(_typeface, _fontSize);
 					font.Edging = _skiaEdging;
 					font.Subpixel = _skiaSubpixelSmoothing;
 

--- a/UI/Debugger/Controls/HexEditor.cs
+++ b/UI/Debugger/Controls/HexEditor.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Mesen.Utilities;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -135,6 +136,8 @@ namespace Mesen.Debugger.Controls
 
 		private Typeface Font { get; set; }
 		private Size LetterSize { get; set; }
+		private SKTypeface _skTypeface;
+
 		private double RowHeight => HighDensityMode ? LetterSize.Height * 0.8 : LetterSize.Height;
 
 		private int HeaderCharLength => DataProvider.Length > 0 ? (DataProvider.Length - 1).ToString(HexFormat).Length : 0;
@@ -793,6 +796,7 @@ namespace Mesen.Debugger.Controls
 			this.Font = new Typeface(FontFamily);
 			var text = new FormattedText("A", CultureInfo.CurrentCulture, FlowDirection.LeftToRight, Font, FontSize, null);
 			this.LetterSize = new Size(text.Width, text.Height);
+			_skTypeface = SKTypeface.FromFamilyName(FontFamily.Name);
 		}
 
 		private void DrawRowHeaders(DrawingContext context)

--- a/UI/Debugger/Controls/HexEditor.cs
+++ b/UI/Debugger/Controls/HexEditor.cs
@@ -11,6 +11,7 @@ using Mesen.Config;
 using System.Text.RegularExpressions;
 using Mesen.Debugger.Utilities;
 using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Mesen.Debugger.Controls
 {
@@ -791,6 +792,7 @@ namespace Mesen.Debugger.Controls
 			}
 		}
 
+		[MemberNotNull(nameof(HexEditor._skTypeface))]
 		private void InitFontAndLetterSize()
 		{
 			this.Font = new Typeface(FontFamily);

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -25,6 +25,7 @@
 		<SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
 		<AvaloniaNameGeneratorIsEnabled>false</AvaloniaNameGeneratorIsEnabled>
 		<AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64' Or '$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'">
 		<SolutionDir>..</SolutionDir>

--- a/Utilities/Utilities.vcxproj
+++ b/Utilities/Utilities.vcxproj
@@ -107,6 +107,7 @@
       <MinimalRebuild>false</MinimalRebuild>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -128,6 +129,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -151,6 +153,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -174,6 +177,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Windows/Windows.vcxproj
+++ b/Windows/Windows.vcxproj
@@ -103,6 +103,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -120,6 +121,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -139,6 +141,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -158,6 +161,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
SKTypeface.FromFamilyName appears to be very fast on Windows (1ms for 1000 calls), but slow on Linux (4ms per call).
This was called 3 times for each memory viewer refresh, causing performance issues on Linux.