### PR TITLE
Fix banking on 163 when no battery is present

### DIFF
--- a/Core/NES/Mappers/Namco/Namco163.h
+++ b/Core/NES/Mappers/Namco/Namco163.h
@@ -55,6 +55,7 @@ protected:
 	uint16_t GetPrgPageSize() override { return 0x2000; }
 	uint16_t GetChrPageSize() override { return 0x400; }
 	uint32_t GetSaveRamPageSize() override { return 0x800; }
+	uint32_t GetWorkRamPageSize() override { return 0x800; }
 	bool AllowRegisterRead() override { return true; }
 	bool EnableCpuClockHook() override { return true; }
 	uint32_t GetMapperRamSize() override { return Namco163Audio::AudioRamSize; }


### PR DESCRIPTION
Heemin wanted to make a homebrew for Namco's 163 without needing a battery, but Mesen was handling cart RAM banks incorrectly (all four 2KiB windows were the first 2KiB of the 8KiB of cart ram, regardless of amount specified in the header)

The added line fixes that.