### PR TITLE
NES: Fix handling of internal and external open buses.

### DIFF
--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -9,6 +9,7 @@
 #include "NES/NesMemoryManager.h"
 #include "NES/NesControlManager.h"
 #include "NES/NesConsole.h"
+#include "NES/NesTypes.h"
 #include "Shared/MessageManager.h"
 #include "Shared/EmuSettings.h"
 #include "Shared/Emulator.h"
@@ -477,10 +478,12 @@ uint8_t NesCpu::ProcessDmaRead(uint16_t addr, uint16_t& prevReadAddress, bool en
 
 		switch(internalAddr) {
 			case 0x4015:
-				val = _memoryManager->Read(internalAddr, MemoryOperationType::DmaRead);
+				//Reads to $4015 don't update the value on the external bus
+				//Only the CPU's internal bus is updated
+				val = _memoryManager->Read<NesCpuBusType::Internal>(internalAddr, MemoryOperationType::DmaRead);
 				if(!isSameAddress) {
 					//Also trigger a read from the actual address the CPU was supposed to read from (external bus)
-					_memoryManager->Read(addr, MemoryOperationType::DmaRead);
+					_memoryManager->Read<NesCpuBusType::External>(addr, MemoryOperationType::DmaRead);
 				}
 				break;
 

--- a/Core/NES/NesMemoryManager.cpp
+++ b/Core/NES/NesMemoryManager.cpp
@@ -122,6 +122,7 @@ uint16_t NesMemoryManager::DebugReadWord(uint16_t addr)
 	return DebugRead(addr) | (DebugRead(addr + 1) << 8);
 }
 
+template<NesCpuBusType busType>
 uint8_t NesMemoryManager::Read(uint16_t addr, MemoryOperationType operationType)
 {
 	uint8_t value = _ramReadHandlers[addr]->ReadRam(addr);
@@ -130,7 +131,7 @@ uint8_t NesMemoryManager::Read(uint16_t addr, MemoryOperationType operationType)
 	}
 	_emu->ProcessMemoryRead<CpuType::Nes>(addr, value, operationType);
 
-	_openBusHandler.SetOpenBus(value, addr == 0x4015);
+	_openBusHandler.SetOpenBus<busType>(value, addr == 0x4015);
 
 	return value;
 }
@@ -139,7 +140,7 @@ void NesMemoryManager::Write(uint16_t addr, uint8_t value, MemoryOperationType o
 {
 	if(_emu->ProcessMemoryWrite<CpuType::Nes>(addr, value, operationType)) {
 		_ramWriteHandlers[addr]->WriteRam(addr, value);
-		_openBusHandler.SetOpenBus(value, false);
+		_openBusHandler.SetOpenBus(value);
 	}
 }
 
@@ -177,3 +178,7 @@ uint8_t NesMemoryManager::GetInternalOpenBus(uint8_t mask)
 {
 	return _openBusHandler.GetInternalOpenBus() & mask;
 }
+
+template uint8_t NesMemoryManager::Read<NesCpuBusType::Both>(uint16_t, MemoryOperationType);
+template uint8_t NesMemoryManager::Read<NesCpuBusType::Internal>(uint16_t, MemoryOperationType);
+template uint8_t NesMemoryManager::Read<NesCpuBusType::External>(uint16_t, MemoryOperationType);

--- a/Core/NES/NesMemoryManager.h
+++ b/Core/NES/NesMemoryManager.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 
 #include "NES/INesMemoryHandler.h"
+#include "NES/NesTypes.h"
 #include "NES/OpenBusHandler.h"
 #include "NES/InternalRamHandler.h"
 #include "Shared/MemoryOperationType.h"
@@ -54,6 +55,7 @@ public:
 
 	uint8_t* GetInternalRam();
 
+	template<NesCpuBusType busType = NesCpuBusType::Both>
 	uint8_t Read(uint16_t addr, MemoryOperationType operationType = MemoryOperationType::Read);
 	void Write(uint16_t addr, uint8_t value, MemoryOperationType operationType);
 

--- a/Core/NES/NesTypes.h
+++ b/Core/NES/NesTypes.h
@@ -42,6 +42,14 @@ enum class MemoryOperation
 	Any = 3
 };
 
+
+enum NesCpuBusType
+{
+	Internal,
+	External,
+	Both
+};
+
 struct NesCpuState : BaseState
 {
 	uint64_t CycleCount = 0;

--- a/Core/NES/OpenBusHandler.h
+++ b/Core/NES/OpenBusHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "pch.h"
 #include "NES/INesMemoryHandler.h"
+#include "NES/NesTypes.h"
 #include "Utilities/Serializer.h"
 
 class OpenBusHandler : public INesMemoryHandler, public ISerializable
@@ -31,17 +32,25 @@ public:
 
 	__forceinline uint8_t GetInternalOpenBus()
 	{
-		return _externalOpenBus;
+		return _internalOpenBus;
 	}
 
-	__forceinline void SetOpenBus(uint8_t value, bool setInternalOnly)
+	template<NesCpuBusType busType = NesCpuBusType::Both>
+	__forceinline void SetOpenBus(uint8_t value, bool forceInternal = false)
 	{
-		//Reads to $4015 don't update the value on the external bus
-		//Only the CPU's internal bus is updated
-		if(!setInternalOnly) {
-			_externalOpenBus = value;
+		if(forceInternal) {
+			_internalOpenBus = value;
+			return;
 		}
-		_internalOpenBus = value;
+
+		switch(busType) {
+			case NesCpuBusType::Internal: _internalOpenBus = value; break;
+			case NesCpuBusType::External: _externalOpenBus = value; break;
+			case NesCpuBusType::Both:
+				_internalOpenBus = value;
+				_externalOpenBus = value;
+				break;
+		}
 	}
 
 	void GetMemoryRanges(MemoryRanges & ranges) override


### PR DESCRIPTION
When reading from $4015, the internal and external CPU buses are isolated. This means the CPU reads the value from the internal $4015 register, which is not repeated onto the external bus, and any response to the read from an external device is not seen by the CPU (not even in the form of a bus conflict).

As a result, the internal $4015 result updates only the internal open bus value, and any external result updates only the external open bus value. If the buses are isolated again on the next CPU cycle, then open bus bits on the internal bus read will not be affected by the external open bus value.

This has been verified in a new test that lands a DMA-that-activates-$4015 on a $4015 read, so the two buses diverge on the DMA read cycle and $4015 is then read by the CPU on the next cycle to verify that the internal open bus was not affected by the DMA read. Furthermore, if the CPU then reads from external open bus afterward, it gets the DMA value from external open bus, which persisted but wasn't previously accessible due to bus isolation.

Mesen previously had a bug where its GetInternalOpenBus function was returning the wrong bus value (_externalOpenBus instead of _internalOpenBus). Fixing this was not enough to fix the test, because SetOpenBus would update both buses on any external read. This change fixes the GetInternalOpenBus bug and changes SetOpenBus to be able to update either bus independently.

This was tested with the new AccuracyCoin "Internal Data Bus" test.