### PR TITLE
SNES: Added alternative blend mode option for high resolution modes

### DIFF
--- a/Core/SNES/SnesDefaultVideoFilter.cpp
+++ b/Core/SNES/SnesDefaultVideoFilter.cpp
@@ -72,7 +72,7 @@ void SnesDefaultVideoFilter::OnBeforeApplyFilter()
 		InitLookupTable();
 	}
 	_forceFixedRes = snesConfig.ForceFixedResolution;
-	_blendHighRes = snesConfig.BlendHighResolutionModes;
+	_highResBlendMode = snesConfig.HighResBlendMode;
 	_videoConfig = config;
 }
 
@@ -104,12 +104,32 @@ void SnesDefaultVideoFilter::ApplyFilter(uint16_t *ppuOutputBuffer)
 		}
 	}
 
-	if(_baseFrameInfo.Width == 512 && _blendHighRes) {
+	if(_baseFrameInfo.Width == 512) {
+		ApplyBlend(frameInfo, out);
+	}
+}
+
+void SnesDefaultVideoFilter::ApplyBlend(FrameInfo frameInfo, uint32_t* out)
+{
+	if(_highResBlendMode == SnesHighResBlendMode::None) {
+		return;
+	}
+
+	if(_highResBlendMode == SnesHighResBlendMode::BlendAll) {
 		//Very basic blend effect for high resolution modes
 		for(uint32_t i = 0; i < frameInfo.Height; i++) {
 			for(uint32_t j = 0; j < frameInfo.Width; j++) {
-				uint32_t &pixel1 = out[i*frameInfo.Width + j];
+				uint32_t& pixel1 = out[i * frameInfo.Width + j];
 				pixel1 = BlendPixels(pixel1, out[i * frameInfo.Width + j + 1]);
+			}
+		}
+	} else {
+		//Blend even-odd columns together (looks nice for fake transparency effects, but bad for high resolution text, etc.)
+		for(uint32_t i = 0; i < frameInfo.Height; i++) {
+			for(uint32_t j = 0; j < frameInfo.Width; j += 2) {
+				uint32_t& pixel1 = out[i * frameInfo.Width + j];
+				pixel1 = BlendPixels(pixel1, out[i * frameInfo.Width + j + 1]);
+				out[i * frameInfo.Width + j + 1] = pixel1;
 			}
 		}
 	}

--- a/Core/SNES/SnesDefaultVideoFilter.h
+++ b/Core/SNES/SnesDefaultVideoFilter.h
@@ -10,13 +10,15 @@ private:
 	uint32_t _calculatedPalette[0x8000] = {};
 	VideoConfig _videoConfig = {};
 
-	bool _blendHighRes = false;
+	SnesHighResBlendMode _highResBlendMode = SnesHighResBlendMode::None;
 	bool _forceFixedRes = false;
 
 	void InitLookupTable();
 
 	__forceinline static uint32_t BlendPixels(uint32_t a, uint32_t b);
 	__forceinline uint32_t GetPixel(uint16_t* ppuFrame, uint32_t offset);
+
+	void ApplyBlend(FrameInfo frameInfo, uint32_t* out);
 
 protected:
 	void OnBeforeApplyFilter() override;

--- a/Core/Shared/SettingTypes.h
+++ b/Core/Shared/SettingTypes.h
@@ -540,6 +540,13 @@ enum class DspInterpolationType
 	None
 };
 
+enum class SnesHighResBlendMode
+{
+	None,
+	BlendAll,
+	BlendEvenOdd
+};
+
 struct SnesConfig
 {
 	ControllerConfig Port1;
@@ -551,7 +558,7 @@ struct SnesConfig
 	ConsoleRegion Region = ConsoleRegion::Auto;
 
 	bool AllowInvalidInput = false;
-	bool BlendHighResolutionModes = false;
+	SnesHighResBlendMode HighResBlendMode = SnesHighResBlendMode::None;
 	bool HideBgLayer1 = false;
 	bool HideBgLayer2 = false;
 	bool HideBgLayer3 = false;

--- a/UI/Config/SnesConfig.cs
+++ b/UI/Config/SnesConfig.cs
@@ -33,7 +33,7 @@ namespace Mesen.Config
 		[Reactive] public ConsoleRegion Region { get; set; } = ConsoleRegion.Auto;
 
 		//Video
-		[Reactive] public bool BlendHighResolutionModes { get; set; } = false;
+		[Reactive] public SnesHighResBlendMode HighResBlendMode { get; set; } = SnesHighResBlendMode.None;
 		[Reactive] public bool HideBgLayer1 { get; set; } = false;
 		[Reactive] public bool HideBgLayer2 { get; set; } = false;
 		[Reactive] public bool HideBgLayer3 { get; set; } = false;
@@ -92,7 +92,7 @@ namespace Mesen.Config
 
 				AllowInvalidInput = this.AllowInvalidInput,
 
-				BlendHighResolutionModes = this.BlendHighResolutionModes,
+				HighResBlendMode = this.HighResBlendMode,
 				HideBgLayer1 = this.HideBgLayer1,
 				HideBgLayer2 = this.HideBgLayer2,
 				HideBgLayer3 = this.HideBgLayer3,
@@ -151,7 +151,8 @@ namespace Mesen.Config
 		public ConsoleRegion Region;
 
 		[MarshalAs(UnmanagedType.I1)] public bool AllowInvalidInput;
-		[MarshalAs(UnmanagedType.I1)] public bool BlendHighResolutionModes;
+		
+		public SnesHighResBlendMode HighResBlendMode;
 		[MarshalAs(UnmanagedType.I1)] public bool HideBgLayer1;
 		[MarshalAs(UnmanagedType.I1)] public bool HideBgLayer2;
 		[MarshalAs(UnmanagedType.I1)] public bool HideBgLayer3;
@@ -190,5 +191,12 @@ namespace Mesen.Config
 		Cubic,
 		Sinc,
 		None
+	}
+
+	public enum SnesHighResBlendMode
+	{
+		None,
+		BlendAll,
+		BlendEvenOdd
 	}
 }

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -269,7 +269,7 @@
 			<Control ID="tpgVideo">Video</Control>
 			<Control ID="lblMiscSettings">Miscellaneous Settings</Control>
 
-			<Control ID="chkBlendHighResolutionModes">Blend high resolution modes</Control>
+			<Control ID="lblHighResBlendMode">High resolution blend mode: </Control>
 			<Control ID="chkHideBgLayer1">Hide background layer 1</Control>
 			<Control ID="chkHideBgLayer2">Hide background layer 2</Control>
 			<Control ID="chkHideBgLayer3">Hide background layer 3</Control>
@@ -2470,6 +2470,11 @@ E
 		<Enum ID="MesenTheme">
 			<Value ID="Light">Light</Value>
 			<Value ID="Dark">Dark</Value>
+		</Enum>
+		<Enum ID="SnesHighResBlendMode">
+			<Value ID="None">None (default)</Value>
+			<Value ID="BlendAll">Blend entire screen</Value>
+			<Value ID="BlendEvenOdd">Blend even/odd columns (fake transparency)</Value>
 		</Enum>
 		<Enum ID="PceConsoleType">
 			<Value ID="Auto">Auto (recommended)</Value>

--- a/UI/Views/SnesConfigView.axaml
+++ b/UI/Views/SnesConfigView.axaml
@@ -158,7 +158,10 @@
 					<v:VideoConfigOverrideView DataContext="{Binding Config.ConfigOverrides}" />
 
 					<c:OptionSection Header="{l:Translate lblMiscSettings}">
-						<CheckBox IsChecked="{Binding Config.BlendHighResolutionModes}" Content="{l:Translate chkBlendHighResolutionModes}" />
+						<WrapPanel>
+							<TextBlock Text="{l:Translate lblHighResBlendMode}" VerticalAlignment="Center" />
+							<c:EnumComboBox SelectedItem="{Binding Config.HighResBlendMode}" />
+						</WrapPanel>
 						<c:CheckBoxWarning IsChecked="{Binding Config.ForceFixedResolution}" Text="{l:Translate chkForceFixedResolution}" />
 						<c:CheckBoxWarning IsChecked="{Binding Config.DisableFrameSkipping}" Text="{l:Translate chkDisableFrameSkipping}" />
 						<c:CheckBoxWarning IsChecked="{Binding Config.HideBgLayer1}" Text="{l:Translate chkHideBgLayer1}" />


### PR DESCRIPTION
Blending even/odd columns only allows fake transparency effects to work while avoiding blurring the image. This blend mode does not work well in all scenarios (e.g high resolution text in Secret of Mana menus looks pretty terrible)