### PR TITLE
Debugger: Console-specific scanline/cycle refresh values

### DIFF
--- a/UI/Config/Debugger/RefreshTimingConfig.cs
+++ b/UI/Config/Debugger/RefreshTimingConfig.cs
@@ -24,7 +24,7 @@ namespace Mesen.Config
 		}
 	}
 
-	public class RefreshTimingConsoleConfig : BaseConfig<RefreshTimingConfig>
+	public class RefreshTimingConsoleConfig : BaseConfig<RefreshTimingConsoleConfig>
 	{
 		[Reactive] public int RefreshScanline { get; set; } = 240;
 		[Reactive] public int RefreshCycle { get; set; } = 0;

--- a/UI/Config/Debugger/RefreshTimingConfig.cs
+++ b/UI/Config/Debugger/RefreshTimingConfig.cs
@@ -1,17 +1,35 @@
 ﻿using Mesen.Interop;
 using ReactiveUI.Fody.Helpers;
+using System.Collections.Generic;
 
 namespace Mesen.Config
 {
 	public class RefreshTimingConfig : BaseConfig<RefreshTimingConfig>
 	{
+		[Reactive] public Dictionary<CpuType, RefreshTimingConsoleConfig> ConsoleConfig { get; set; } = new();
 		[Reactive] public bool RefreshOnBreakPause { get; set; } = true;
 		[Reactive] public bool AutoRefresh { get; set; } = true;
 
+		public RefreshTimingConfig()
+		{
+		}
+
+		public RefreshTimingConsoleConfig GetConsoleConfig(CpuType cpuType)
+		{
+			if(!ConsoleConfig.TryGetValue(cpuType, out RefreshTimingConsoleConfig? config)) {
+				config = new();
+				ConsoleConfig[cpuType] = config;
+			}
+			return config;
+		}
+	}
+
+	public class RefreshTimingConsoleConfig : BaseConfig<RefreshTimingConfig>
+	{
 		[Reactive] public int RefreshScanline { get; set; } = 240;
 		[Reactive] public int RefreshCycle { get; set; } = 0;
 
-		public RefreshTimingConfig()
+		public RefreshTimingConsoleConfig()
 		{
 		}
 	}

--- a/UI/Debugger/Utilities/ToolRefreshHelper.cs
+++ b/UI/Debugger/Utilities/ToolRefreshHelper.cs
@@ -97,7 +97,7 @@ namespace Mesen.Debugger.Utilities
 			return Interlocked.Increment(ref _nextId);
 		}
 
-		private static int RegisterWindow(Window wnd, RefreshTimingConfig cfg, CpuType cpuType)
+		private static int RegisterWindow(Window wnd, RefreshTimingConsoleConfig cfg, CpuType cpuType)
 		{
 			if(_activeWindows.ContainsKey(wnd)) {
 				throw new Exception("Register window called twice");
@@ -136,7 +136,7 @@ namespace Mesen.Debugger.Utilities
 			}
 		}
 
-		private static int GetViewerId(Window wnd, RefreshTimingConfig cfg, CpuType cpuType)
+		private static int GetViewerId(Window wnd, RefreshTimingConsoleConfig cfg, CpuType cpuType)
 		{
 			if(_activeWindows.TryGetValue(wnd, out ToolInfo? toolInfo)) {
 				if(cfg.RefreshScanline != toolInfo.Scanline || cfg.RefreshCycle != toolInfo.Cycle) {
@@ -160,7 +160,7 @@ namespace Mesen.Debugger.Utilities
 
 		public static void ProcessNotification(Window wnd, NotificationEventArgs e, RefreshTimingViewModel cfg, ICpuTypeModel model, Action refresh)
 		{
-			int viewerId = GetViewerId(wnd, cfg.Config, model.CpuType);
+			int viewerId = GetViewerId(wnd, cfg.ConsoleConfig, model.CpuType);
 
 			switch(e.NotificationType) {
 				case ConsoleNotificationType.ViewerRefresh:
@@ -197,7 +197,7 @@ namespace Mesen.Debugger.Utilities
 
 					if(_activeWindows.TryGetValue(wnd, out ToolInfo? toolInfo)) {
 						toolInfo.CpuType = model.CpuType;
-						DebugApi.SetViewerUpdateTiming(toolInfo.ViewerId, cfg.Config.RefreshScanline, cfg.Config.RefreshCycle, model.CpuType);
+						DebugApi.SetViewerUpdateTiming(toolInfo.ViewerId, cfg.ConsoleConfig.RefreshScanline, cfg.ConsoleConfig.RefreshCycle, model.CpuType);
 					}
 					break;
 			}

--- a/UI/Debugger/Utilities/ToolRefreshHelper.cs
+++ b/UI/Debugger/Utilities/ToolRefreshHelper.cs
@@ -189,10 +189,6 @@ namespace Mesen.Debugger.Utilities
 							model.CpuType = romInfo.ConsoleType.GetMainCpuType();
 						}
 						model.OnGameLoaded();
-
-						Dispatcher.UIThread.Post(() => {
-							cfg.UpdateMinMaxValues(model.CpuType);
-						});
 					}
 
 					if(_activeWindows.TryGetValue(wnd, out ToolInfo? toolInfo)) {

--- a/UI/Debugger/ViewModels/PaletteViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/PaletteViewerViewModel.cs
@@ -22,7 +22,7 @@ namespace Mesen.Debugger.ViewModels
 	{
 		public CpuType CpuType { get; set; }
 		public PaletteViewerConfig Config { get; }
-		public RefreshTimingViewModel RefreshTiming { get; }
+		[Reactive] public RefreshTimingViewModel RefreshTiming { get; private set; }
 
 		[Reactive] public UInt32[] PaletteColors { get; set; } = Array.Empty<UInt32>();
 		[Reactive] public UInt32[]? PaletteValues { get; set; } = null;
@@ -227,6 +227,7 @@ namespace Mesen.Debugger.ViewModels
 
 		public void OnGameLoaded()
 		{
+			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, CpuType);
 			RefreshData();
 		}
 	}

--- a/UI/Debugger/ViewModels/RefreshTimingViewModel.cs
+++ b/UI/Debugger/ViewModels/RefreshTimingViewModel.cs
@@ -11,7 +11,7 @@ namespace Mesen.Debugger.ViewModels
 	public class RefreshTimingViewModel : ViewModelBase
 	{
 		public RefreshTimingConfig Config { get; }
-
+		public RefreshTimingConsoleConfig ConsoleConfig { get; }
 		[Reactive] public int MinScanline { get; private set; }
 		[Reactive] public int MaxScanline { get; private set; }
 		[Reactive] public int MaxCycle { get; private set; }
@@ -26,6 +26,7 @@ namespace Mesen.Debugger.ViewModels
 		public RefreshTimingViewModel(RefreshTimingConfig config, CpuType cpuType)
 		{
 			Config = config;
+			ConsoleConfig = config.GetConsoleConfig(cpuType);
 			_cpuType = cpuType;
 
 			UpdateMinMaxValues(_cpuType);
@@ -34,7 +35,7 @@ namespace Mesen.Debugger.ViewModels
 
 		public void Reset()
 		{
-			Config.RefreshScanline = _cpuType.GetConsoleType() switch {
+			ConsoleConfig.RefreshScanline = _cpuType.GetConsoleType() switch {
 				ConsoleType.Snes => 240,
 				ConsoleType.Nes => 241,
 				ConsoleType.Gameboy => 144,
@@ -45,7 +46,7 @@ namespace Mesen.Debugger.ViewModels
 				_ => throw new Exception("Invalid console type")
 			};
 
-			Config.RefreshCycle = 0;
+			ConsoleConfig.RefreshCycle = 0;
 		}
 
 		public void UpdateMinMaxValues(CpuType cpuType)
@@ -56,7 +57,7 @@ namespace Mesen.Debugger.ViewModels
 			MaxScanline = (int)timing.ScanlineCount + timing.FirstScanline - 1;
 			MaxCycle = (int)timing.CycleCount - 1;
 
-			if(Config.RefreshScanline < MinScanline || Config.RefreshScanline > MaxScanline || Config.RefreshCycle > MaxCycle) {
+			if(ConsoleConfig.RefreshScanline < MinScanline || ConsoleConfig.RefreshScanline > MaxScanline || ConsoleConfig.RefreshCycle > MaxCycle) {
 				Reset();
 			}
 		}

--- a/UI/Debugger/ViewModels/RefreshTimingViewModel.cs
+++ b/UI/Debugger/ViewModels/RefreshTimingViewModel.cs
@@ -31,6 +31,17 @@ namespace Mesen.Debugger.ViewModels
 
 			UpdateMinMaxValues(_cpuType);
 			ResetCommand = ReactiveCommand.Create(Reset);
+
+			ConsoleConfig.WhenAnyValue(x => x.RefreshScanline, x => x.RefreshCycle).Subscribe(x => UpdateMinMax());
+		}
+
+		private void UpdateMinMax()
+		{
+			//Manually enforce min/max to avoid issues when switching from one console type to another where the UI
+			//could end up setting the new console's scanline value to the max scanline value of the previous console
+			//(presumably due to the order in which the property bindings were processed)
+			ConsoleConfig.RefreshScanline = Math.Max(MinScanline, Math.Min(MaxScanline, ConsoleConfig.RefreshScanline));
+			ConsoleConfig.RefreshCycle = Math.Max(0, Math.Min(MaxCycle, ConsoleConfig.RefreshCycle));
 		}
 
 		public void Reset()
@@ -49,7 +60,7 @@ namespace Mesen.Debugger.ViewModels
 			ConsoleConfig.RefreshCycle = 0;
 		}
 
-		public void UpdateMinMaxValues(CpuType cpuType)
+		private void UpdateMinMaxValues(CpuType cpuType)
 		{
 			_cpuType = cpuType;
 			TimingInfo timing = EmuApi.GetTimingInfo(_cpuType);

--- a/UI/Debugger/ViewModels/RegisterViewerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/RegisterViewerWindowViewModel.cs
@@ -49,7 +49,6 @@ namespace Mesen.Debugger.ViewModels
 			}
 
 			UpdateRomInfo();
-			RefreshTiming.UpdateMinMaxValues(CpuType);
 			RefreshData();
 		}
 

--- a/UI/Debugger/ViewModels/RegisterViewerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/RegisterViewerWindowViewModel.cs
@@ -21,7 +21,7 @@ namespace Mesen.Debugger.ViewModels
 		[Reactive] public List<RegisterViewerTab> Tabs { get; set; } = new List<RegisterViewerTab>();
 		
 		public RegisterViewerConfig Config { get; }
-		public RefreshTimingViewModel RefreshTiming { get; }
+		[Reactive] public RefreshTimingViewModel RefreshTiming { get; private set; }
 
 		[Reactive] public List<object> FileMenuActions { get; private set; } = new();
 		[Reactive] public List<object> ViewMenuActions { get; private set; } = new();
@@ -157,6 +157,7 @@ namespace Mesen.Debugger.ViewModels
 
 		public void OnGameLoaded()
 		{
+			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, CpuType);
 			UpdateRomInfo();
 			RefreshData();
 		}

--- a/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
@@ -26,7 +26,7 @@ namespace Mesen.Debugger.ViewModels
 	public class SpriteViewerViewModel : DisposableViewModel, ICpuTypeModel, IMouseOverViewerModel
 	{
 		public SpriteViewerConfig Config { get; }
-		public RefreshTimingViewModel RefreshTiming { get; }
+		[Reactive] public RefreshTimingViewModel RefreshTiming { get; private set; }
 
 		public CpuType CpuType { get; set; }
 
@@ -211,8 +211,8 @@ namespace Mesen.Debugger.ViewModels
 							sprite.Palette + paletteOffset,
 							wnd,
 							CpuType,
-							RefreshTiming.Config.RefreshScanline,
-							RefreshTiming.Config.RefreshCycle
+							RefreshTiming.ConsoleConfig.RefreshScanline,
+							RefreshTiming.ConsoleConfig.RefreshCycle
 						);
 					}
 				}
@@ -688,6 +688,7 @@ namespace Mesen.Debugger.ViewModels
 
 		public void OnGameLoaded()
 		{
+			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, CpuType);
 			RefreshData();
 		}
 	}

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -27,7 +27,7 @@ namespace Mesen.Debugger.ViewModels
 		public CpuType CpuType { get; set; }
 
 		public TileViewerConfig Config { get; }
-		public RefreshTimingViewModel RefreshTiming { get; }
+		[Reactive] public RefreshTimingViewModel RefreshTiming { get; private set; }
 
 		[Reactive] public DynamicBitmap ViewerBitmap { get; private set; }
 
@@ -264,8 +264,11 @@ namespace Mesen.Debugger.ViewModels
 			}
 		}
 
+		[MemberNotNull(nameof(RefreshTiming))]
 		private void InitForCpuType()
 		{
+			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, CpuType);
+
 			string selectedPreset = Config.SelectedPreset;
 
 			AvailableFormats = CpuType switch {
@@ -599,8 +602,8 @@ namespace Mesen.Debugger.ViewModels
 				SelectedPalette,
 				wnd,
 				CpuType,
-				RefreshTiming.Config.RefreshScanline,
-				RefreshTiming.Config.RefreshCycle
+				RefreshTiming.ConsoleConfig.RefreshScanline,
+				RefreshTiming.ConsoleConfig.RefreshCycle
 			);
 		}
 

--- a/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
@@ -26,7 +26,7 @@ namespace Mesen.Debugger.ViewModels
 		[Reactive] public bool IsNes { get; private set; }
 
 		public TilemapViewerConfig Config { get; }
-		public RefreshTimingViewModel RefreshTiming { get; }
+		[Reactive] public RefreshTimingViewModel RefreshTiming { get; private set; }
 
 		[Reactive] public Rect SelectionRect { get; set; }
 		[Reactive] public int GridSizeX { get; set; } = 8;
@@ -71,7 +71,6 @@ namespace Mesen.Debugger.ViewModels
 		{
 			Config = ConfigManager.Config.Debug.TilemapViewer.Clone();
 			CpuType = cpuType;
-			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, cpuType);
 
 			_picViewer = picViewer;
 			InitForCpuType();
@@ -294,8 +293,10 @@ namespace Mesen.Debugger.ViewModels
 			}
 		}
 
+		[MemberNotNull(nameof(RefreshTiming))]
 		private void InitForCpuType()
 		{
+			RefreshTiming = new RefreshTimingViewModel(Config.RefreshTiming, CpuType);
 			IsNes = CpuType == CpuType.Nes;
 
 			if(IsNes) {
@@ -736,8 +737,8 @@ namespace Mesen.Debugger.ViewModels
 				palette,
 				wnd,
 				CpuType,
-				RefreshTiming.Config.RefreshScanline,
-				RefreshTiming.Config.RefreshCycle
+				RefreshTiming.ConsoleConfig.RefreshScanline,
+				RefreshTiming.ConsoleConfig.RefreshCycle
 			);
 		}
 

--- a/UI/Debugger/Views/RefreshTimingView.axaml
+++ b/UI/Debugger/Views/RefreshTimingView.axaml
@@ -21,14 +21,14 @@
 	<StackPanel Orientation="Horizontal" Background="#15808080">
 		<CheckBox IsChecked="{Binding Config.AutoRefresh}" Content="{l:Translate lblScanline}" />
 		<c:MesenNumericUpDown
-			Value="{Binding Config.RefreshScanline}"
+			Value="{Binding ConsoleConfig.RefreshScanline}"
 			Minimum="{Binding MinScanline}"
 			Maximum="{Binding MaxScanline}"
 			Margin="3 0"
 		/>
 		<TextBlock VerticalAlignment="Center" Text="{l:Translate lblCycle}" />
 		<c:MesenNumericUpDown
-			Value="{Binding Config.RefreshCycle}"
+			Value="{Binding ConsoleConfig.RefreshCycle}"
 			Minimum="0"
 			Maximum="{Binding MaxCycle}"
 			Margin="3 0"

--- a/UI/Debugger/Views/RefreshTimingView.axaml
+++ b/UI/Debugger/Views/RefreshTimingView.axaml
@@ -22,15 +22,12 @@
 		<CheckBox IsChecked="{Binding Config.AutoRefresh}" Content="{l:Translate lblScanline}" />
 		<c:MesenNumericUpDown
 			Value="{Binding ConsoleConfig.RefreshScanline}"
-			Minimum="{Binding MinScanline}"
-			Maximum="{Binding MaxScanline}"
 			Margin="3 0"
 		/>
 		<TextBlock VerticalAlignment="Center" Text="{l:Translate lblCycle}" />
 		<c:MesenNumericUpDown
 			Value="{Binding ConsoleConfig.RefreshCycle}"
 			Minimum="0"
-			Maximum="{Binding MaxCycle}"
 			Margin="3 0"
 		/>
 		<c:IconButton


### PR DESCRIPTION
Keep console-specific scanline/cycle refresh values for each debug tool (instead of constantly auto-resetting them to the default settings when switching around multiple consoles that have incompatible values, etc.)