### PR TITLE
Rainbow: implement reading $4150 to access the scanline counter

### DIFF
--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -565,6 +565,8 @@ uint8_t Rainbow::ReadRegister(uint16_t addr)
 
 		case 0x412F: return _windowControl.ToByte();
 
+		case 0x4150: return (uint8_t)_scanlineCounter;
+
 		case 0x4151:
 			_slIrqPending = false;
 			UpdateIrqStatus();


### PR DESCRIPTION
As documented https://github.com/BrokeStudio/rainbow-net/blob/master/NES/mapper-doc.md#ppu-irq-latch-4150-read-write

I confirmed with Broke Studio that the scanline counter is reset to a value of $FF when rendering is disabled, which matches Mesen's tracked counter behavior, so all we need to do is report that value on read.