### PR TITLE
NES Mapper: Add VRC4f support

### DIFF
--- a/Core/NES/Mappers/Konami/VRC2_4.h
+++ b/Core/NES/Mappers/Konami/VRC2_4.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include "pch.h"
 #include "NES/BaseMapper.h"
 #include "NES/Mappers/Konami/VrcIrq.h"
@@ -13,6 +13,7 @@ enum class VRCVariant
 	VRC4c,	//21
 	VRC4d,	//25
 	VRC4e,	//23
+	VRC4f,	//23
 	VRC4_27, //27
 	VRC6a,
 	VRC6b
@@ -56,6 +57,7 @@ class VRC2_4 : public BaseMapper
 						default:
 						case 0: _variant = VRCVariant::VRC2b; break;
 						case 2: _variant = VRCVariant::VRC4e; break;
+						case 1: _variant = VRCVariant::VRC4f; break;
 						case 3: _variant = VRCVariant::VRC2b; break;
 					}
 					break;
@@ -243,6 +245,16 @@ class VRC2_4 : public BaseMapper
 						A0 |= (addr >> 2) & 0x01;
 						A1 |= (addr >> 3) & 0x01;
 						break;
+					case VRCVariant::VRC4f:
+						//Mapper 23
+						//VRC4f
+						A0 = addr & 0x01;
+						A1 = (addr >> 1) & 0x01;
+
+						//VRC4f
+						A0 |= (addr >> 0) & 0x01;
+						A1 |= (addr >> 1) & 0x01;
+						break;
 					default:
 						throw std::runtime_error("not supported");
 						break;
@@ -296,6 +308,11 @@ class VRC2_4 : public BaseMapper
 						//Mapper 23
 						A0 = (addr >> 2) & 0x01;
 						A1 = (addr >> 3) & 0x01;
+						break;
+					case VRCVariant::VRC4f:
+						//Mapper 23
+						A0 = (addr >> 0) & 0x01;
+						A1 = (addr >> 1) & 0x01;
 						break;
 
 					default:


### PR DESCRIPTION
Added support for the VRC4f mapper (Mapper 23, SubMapper 1).
The game "World Hero" uses this mapper and can be used for testing and verification.