### PR TITLE
Debugger: Tilemap viewer - Fixed "edit tile" behavior on SNES when the tilemap is using 16x16 (or 16x8) tiles

### DIFF
--- a/Core/Debugger/PpuTools.h
+++ b/Core/Debugger/PpuTools.h
@@ -152,7 +152,9 @@ struct DebugTilemapTileInfo
 	int32_t TileMapAddress = -1;
 
 	int32_t TileIndex = -1;
-	int32_t TileAddress = -1;
+	
+	uint32_t TileCount = 0;
+	uint32_t TileAddresses[4] = {};
 
 	int32_t PixelData = -1;
 
@@ -166,6 +168,15 @@ struct DebugTilemapTileInfo
 	NullableBoolean HorizontalMirroring = NullableBoolean::Undefined;
 	NullableBoolean VerticalMirroring = NullableBoolean::Undefined;
 	NullableBoolean HighPriority = NullableBoolean::Undefined;
+
+	void AddAddress(uint32_t addr)
+	{
+		if(TileCount >= 4) {
+			throw std::runtime_error("Too many addresses for tile - array size needs to be increased");
+		}
+		TileAddresses[TileCount] = addr;
+		TileCount++;
+	}
 };
 
 struct DebugSpritePreviewInfo

--- a/Core/GBA/Debugger/GbaPpuTools.cpp
+++ b/Core/GBA/Debugger/GbaPpuTools.cpp
@@ -351,7 +351,7 @@ DebugTilemapTileInfo GbaPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 	result.Width = width;
 	result.TileMapAddress = tilemapAddr;
 	result.TileIndex = tileIndex;
-	result.TileAddress = tileStart;
+	result.AddAddress(tileStart);
 	result.PixelData = pixelData;
 	result.PaletteIndex = paletteIndex;
 	result.PaletteAddress = paletteIndex << 5;

--- a/Core/Gameboy/Debugger/GbPpuTools.cpp
+++ b/Core/Gameboy/Debugger/GbPpuTools.cpp
@@ -152,7 +152,7 @@ DebugTilemapTileInfo GbPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uint
 	result.Width = 8;
 	result.TileMapAddress = addr;
 	result.TileIndex = tileIndex;
-	result.TileAddress = tileStart;
+	result.AddAddress(tileStart);
 
 	if(isCgb) {
 		result.PaletteIndex = (attributes & 0x07);

--- a/Core/NES/Debugger/NesPpuTools.cpp
+++ b/Core/NES/Debugger/NesPpuTools.cpp
@@ -352,7 +352,7 @@ DebugTilemapTileInfo NesPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 	result.Height = 8;
 	result.TileMapAddress = baseAddr + ntOffset;
 	result.TileIndex = vram[result.TileMapAddress];
-	result.TileAddress = bgAddr + (result.TileIndex << 4);
+	result.AddAddress(bgAddr + (result.TileIndex << 4));
 	result.PaletteIndex = paletteBaseAddr >> 2;
 	result.PaletteAddress = 0x3F00 | paletteBaseAddr;
 	result.AttributeAddress = attributeAddress;

--- a/Core/PCE/Debugger/PceVdcTools.cpp
+++ b/Core/PCE/Debugger/PceVdcTools.cpp
@@ -52,7 +52,7 @@ DebugTilemapTileInfo PceVdcTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 	result.TileIndex = (batEntry & 0xFFF);
 	result.TileMapAddress = entryAddr;
 
-	result.TileAddress = result.TileIndex * 32;
+	result.AddAddress(result.TileIndex * 32);
 	result.PaletteAddress = result.PaletteIndex * 16;
 
 	result.Row = row;

--- a/Core/SMS/Debugger/SmsVdpTools.cpp
+++ b/Core/SMS/Debugger/SmsVdpTools.cpp
@@ -217,7 +217,7 @@ DebugTilemapTileInfo SmsVdpTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 
 		result.TileMapAddress = entryAddr;
 		result.TileIndex = tileIndex;
-		result.TileAddress = tileIndex * 32;
+		result.AddAddress(tileIndex * 32);
 		result.PaletteIndex = paletteOffset >> 4;
 		result.PaletteAddress = paletteOffset;
 		result.HighPriority = (ntData & 0x1000) ? NullableBoolean::True : NullableBoolean::False;
@@ -230,7 +230,7 @@ DebugTilemapTileInfo SmsVdpTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 		uint16_t tileAddr = (state.BgPatternTableAddress & 0x3800) + (tileIndex * 8);
 		result.TileMapAddress = ntAddr;
 		result.TileIndex = tileIndex;
-		result.TileAddress = tileAddr;
+		result.AddAddress(tileAddr);
 	} else {
 		//Graphic 1 / Graphic 2 / Multicolor
 		uint16_t ntAddr = state.NametableAddress + (column + row * 32);
@@ -250,7 +250,7 @@ DebugTilemapTileInfo SmsVdpTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uin
 		}
 		result.TileMapAddress = ntAddr;
 		result.TileIndex = tileIndex;
-		result.TileAddress = tileAddr;
+		result.AddAddress(tileAddr);
 
 		int32_t colorTableAddr;
 		if(state.M3_Use240LineMode) {

--- a/Core/SNES/Debugger/SnesPpuTools.cpp
+++ b/Core/SNES/Debugger/SnesPpuTools.cpp
@@ -493,7 +493,7 @@ DebugTilemapTileInfo SnesPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, ui
 
 		result.TileMapAddress = row * 256 + column * 2;
 		result.TileIndex = vram[result.TileMapAddress];
-		result.TileAddress = result.TileIndex * 128;
+		result.AddAddress(result.TileIndex * 128);
 		result.Height = 8;
 		result.Width = 8;
 	} else {
@@ -524,8 +524,14 @@ DebugTilemapTileInfo SnesPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, ui
 		result.TileMapAddress = addr;
 		
 		uint16_t tileStart = (layer.ChrAddress << 1) + result.TileIndex * 8 * bpp;
-		result.TileAddress = tileStart;
-
+		result.AddAddress(tileStart);
+		if(largeTileWidth) {
+			result.AddAddress((uint16_t)(tileStart + (8 * bpp)));
+			if(largeTileHeight) {
+				result.AddAddress((uint16_t)(tileStart + (16 * 8 * bpp)));
+				result.AddAddress((uint16_t)(tileStart + (17 * 8 * bpp)));
+			}
+		}
 	}
 
 	result.Row = row;

--- a/Core/WS/Debugger/WsPpuTools.cpp
+++ b/Core/WS/Debugger/WsPpuTools.cpp
@@ -151,7 +151,7 @@ DebugTilemapTileInfo WsPpuTools::GetTilemapTileInfo(uint32_t x, uint32_t y, uint
 	result.Width = 8;
 	result.TileMapAddress = tilemapAddr;
 	result.TileIndex = tileIndex;
-	result.TileAddress = tilesetAddr + tileIndex * tileSize;
+	result.AddAddress(tilesetAddr + tileIndex * tileSize);
 
 	result.PaletteIndex = tilePalette;
 	result.PaletteAddress = state.Mode >= WsVideoMode::Color2bpp ? (0xFE00 | (result.PaletteIndex << 4)) : (result.PaletteIndex << 2);

--- a/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
@@ -205,7 +205,7 @@ namespace Mesen.Debugger.ViewModels
 						DebugPaletteInfo pal = _data.Palette.Value;
 						int paletteOffset = (int)(pal.SpritePaletteOffset / pal.ColorsPerPalette);
 						TileEditorWindow.OpenAtTile(
-							sprite.TileAddresses.Select(x => new AddressInfo() { Address = (int)x, Type = CpuType.GetVramMemoryType(sprite.UseExtendedVram) }).ToList(),
+							sprite.TileAddresses.Select(x => new TileAddressInfo() { Address = new AddressInfo() { Address = (int)x, Type = CpuType.GetVramMemoryType(sprite.UseExtendedVram) } }).ToList(),
 							sprite.RealWidth / size.Width,
 							sprite.Format,
 							sprite.Palette + paletteOffset,

--- a/UI/Debugger/ViewModels/TileEditorViewModel.cs
+++ b/UI/Debugger/ViewModels/TileEditorViewModel.cs
@@ -39,7 +39,7 @@ public class TileEditorViewModel : DisposableViewModel
 	public List<ContextMenuAction> ToolbarActions { get; private set; } = new();
 
 	private CpuType _cpuType;
-	private List<AddressInfo> _tileAddresses;
+	private List<TileAddressInfo> _tileAddresses;
 	private int _columnCount = 1;
 	private int _rowCount = 1;
 	private TileFormat _tileFormat;
@@ -48,13 +48,13 @@ public class TileEditorViewModel : DisposableViewModel
 	[Obsolete("For designer only")]
 	public TileEditorViewModel() : this(new() { new() }, 1, TileFormat.Bpp4, 0) { }
 
-	public TileEditorViewModel(List<AddressInfo> tileAddresses, int columnCount, TileFormat format, int initialPalette)
+	public TileEditorViewModel(List<TileAddressInfo> tileAddresses, int columnCount, TileFormat format, int initialPalette)
 	{
 		Config = ConfigManager.Config.Debug.TileEditor;
 		_tileAddresses = tileAddresses;
 		_columnCount = columnCount;
 		_rowCount = tileAddresses.Count / columnCount;
-		_cpuType = tileAddresses[0].Type.ToCpuType();
+		_cpuType = tileAddresses[0].Address.Type.ToCpuType();
 		_tileFormat = format;
 		SelectedColor = initialPalette * GetColorsPerPalette(_tileFormat);
 
@@ -244,13 +244,22 @@ public class TileEditorViewModel : DisposableViewModel
 		int row = position.Y / tileSize.Height;
 		int tileX = position.X % tileSize.Width;
 		int tileY = position.Y % tileSize.Height;
+
+		TileAddressInfo tile = _tileAddresses[column + row * _columnCount];
+		if(tile.HorizontalMirroring) {
+			tileX = (tileSize.Width - tileX) - 1;
+		}
+		if(tile.VerticalMirroring) {
+			tileY = (tileSize.Height - tileY) - 1;
+		}
+
 		return new(column, row, tileX, tileY);
 	}
 
 	public int GetColorAtPosition(PixelPoint position)
 	{
 		TilePixelPositionInfo pos = GetPositionInfo(position);
-		int paletteColorIndex = DebugApi.GetTilePixel(_tileAddresses[pos.Column + pos.Row * _columnCount], _tileFormat, pos.TileX, pos.TileY);
+		int paletteColorIndex = DebugApi.GetTilePixel(_tileAddresses[pos.Column + pos.Row * _columnCount].Address, _tileFormat, pos.TileX, pos.TileY);
 		return SelectedColor - (SelectedColor % GetColorsPerPalette(_tileFormat)) + paletteColorIndex;
 	}
 
@@ -262,7 +271,7 @@ public class TileEditorViewModel : DisposableViewModel
 	private void SetPixelColor(PixelPoint position, int color)
 	{
 		TilePixelPositionInfo pos = GetPositionInfo(position);
-		DebugApi.SetTilePixel(_tileAddresses[pos.Column + pos.Row * _columnCount], _tileFormat, pos.TileX, pos.TileY, color);
+		DebugApi.SetTilePixel(_tileAddresses[pos.Column + pos.Row * _columnCount].Address, _tileFormat, pos.TileX, pos.TileY, color);
 	}
 
 	public void UpdatePixel(PixelPoint position, bool clearPixel)
@@ -288,15 +297,17 @@ public class TileEditorViewModel : DisposableViewModel
 				for(int y = 0; y < _rowCount; y++) {
 					for(int x = 0; x < _columnCount; x++) {
 						fixed(UInt32* ptr = _tileBuffer) {
-							AddressInfo addr = _tileAddresses[y * _columnCount + x];
-							byte[] sourceData = DebugApi.GetMemoryValues(addr.Type, (uint)addr.Address, (uint)(addr.Address + bytesPerTile - 1));
+							TileAddressInfo addr = _tileAddresses[y * _columnCount + x];
+							byte[] sourceData = DebugApi.GetMemoryValues(addr.Address.Type, (uint)addr.Address.Address, (uint)(addr.Address.Address + bytesPerTile - 1));
 							DebugApi.GetTileView(_cpuType, GetOptions(x, y), sourceData, sourceData.Length, PaletteColors, (IntPtr)ptr);
 							UInt32* viewer = (UInt32*)framebuffer.FrameBuffer.Address;
 							int rowPitch = ViewerBitmap.PixelSize.Width;
 							int baseOffset = x * tileSize.Width + y * tileSize.Height * rowPitch;
 							for(int j = 0; j < tileSize.Height; j++) {
+								int yDest = addr.VerticalMirroring ? (tileSize.Height - j - 1) : j;
 								for(int i = 0; i < tileSize.Width; i++) {
-									viewer[baseOffset + j * rowPitch + i] = ptr[j * tileSize.Width + i];
+									int xDest = addr.HorizontalMirroring ? (tileSize.Width - i - 1) : i;
+									viewer[baseOffset + yDest * rowPitch + xDest] = ptr[j * tileSize.Width + i];
 								}
 							}
 						}
@@ -326,14 +337,14 @@ public class TileEditorViewModel : DisposableViewModel
 		int tileIndex = row * _columnCount + column;
 
 		return new GetTileViewOptions() {
-			MemType = _tileAddresses[tileIndex].Type,
+			MemType = _tileAddresses[tileIndex].Address.Type,
 			Format = _tileFormat,
 			Width = _tileFormat.GetTileSize().Width / 8,
 			Height = _tileFormat.GetTileSize().Height / 8,
 			Palette = SelectedColor / GetColorsPerPalette(_tileFormat),
 			Layout = TileLayout.Normal,
 			Filter = TileFilter.None,
-			StartAddress = _tileAddresses[tileIndex].Address,
+			StartAddress = _tileAddresses[tileIndex].Address.Address,
 			Background = Config.Background,
 			UseGrayscalePalette = false
 		};
@@ -350,4 +361,11 @@ public class TileEditorViewModel : DisposableViewModel
 		TranslateUp,
 		TranslateDown,
 	}
+}
+
+public class TileAddressInfo
+{
+	public AddressInfo Address { get; set; }
+	public bool HorizontalMirroring { get; set; }
+	public bool VerticalMirroring { get; set; }
 }

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -586,10 +586,10 @@ namespace Mesen.Debugger.ViewModels
 		private void EditTileGrid(int columnCount, int rowCount, Window wnd)
 		{
 			PixelPoint p = ViewerMousePos ?? PixelPoint.FromPoint(SelectionRect.TopLeft, 1);
-			List<AddressInfo> addresses = new();
+			List<TileAddressInfo> addresses = new();
 			for(int row = 0; row < rowCount; row++) {
 				for(int col = 0; col < columnCount; col++) {
-					addresses.Add(new AddressInfo() { Address = GetTileAddress(new PixelPoint(p.X + col*GridSizeX, p.Y + row*GridSizeY)), Type = Config.Source });
+					addresses.Add(new TileAddressInfo() { Address = new AddressInfo() { Address = GetTileAddress(new PixelPoint(p.X + col*GridSizeX, p.Y + row*GridSizeY)), Type = Config.Source } });
 				}
 			}
 			TileEditorWindow.OpenAtTile(

--- a/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
@@ -689,7 +689,7 @@ namespace Mesen.Debugger.ViewModels
 		{
 			return new ContextMenuAction() {
 				ActionType = ActionType.Custom,
-				CustomText = $"{columnCount}x{rowCount} ({GridSizeX * columnCount}px x {GridSizeY * rowCount}px)",
+				DynamicText = () => $"{columnCount}x{rowCount} ({GridSizeX * columnCount}px x {GridSizeY * rowCount}px)",
 				OnClick = () => EditTileGrid(columnCount, rowCount, wnd)
 			};
 		}
@@ -701,12 +701,33 @@ namespace Mesen.Debugger.ViewModels
 			}
 
 			PixelPoint p = ViewerMousePos ?? PixelPoint.FromPoint(SelectionRect.TopLeft, 1);
-			List<AddressInfo> addresses = new();
+			List<TileAddressInfo> addresses = new();
 			MemoryType memType = GetVramMemoryType();
 			int palette = -1;
+			bool doubleWidth = false;
+			bool doubleHeight = false;
+			TileFormat format = _data.TilemapInfo.Format;
+			int tileWidth = GridSizeX;
+			int tileHeight = GridSizeY;
+	
+			PixelSize size = format.GetTileSize();
+
+			//On the SNES, the tile size may be 8x8, but the tilemap is defined in 16x16 (or 16x8) blocks.
+			//In this scenario, adjust the column/row count fetch the data for each part of the tilemap entry separately
+			doubleWidth = tileWidth == size.Width * 2;
+			if(doubleWidth) {
+				columnCount *= 2;
+				tileWidth /= 2;
+			}
+			doubleHeight = tileHeight == size.Height * 2;
+			if(doubleHeight) {
+				rowCount *= 2;
+				tileHeight /= 2;
+			}
+
 			for(int row = 0; row < rowCount; row++) {
 				for(int col = 0; col < columnCount; col++) {
-					DebugTilemapTileInfo? tile = DebugApi.GetTilemapTileInfo((uint)(p.X + GridSizeX*col), (uint)(p.Y + GridSizeY*row), CpuType, GetOptions(SelectedTab), _data.Vram, _data.PpuState, _data.PpuToolsState);
+					DebugTilemapTileInfo? tile = DebugApi.GetTilemapTileInfo((uint)(p.X + tileWidth*col), (uint)(p.Y + tileHeight*row), CpuType, GetOptions(SelectedTab), _data.Vram, _data.PpuState, _data.PpuToolsState);
 					if(tile == null) {
 						if(col == 0) {
 							rowCount = row;
@@ -720,7 +741,20 @@ namespace Mesen.Debugger.ViewModels
 					if(palette == -1) {
 						palette = tile.Value.PaletteIndex;
 					}
-					addresses.Add(new AddressInfo() { Address = tile.Value.TileAddress, Type = memType });
+
+					bool hMirror = tile.Value.HorizontalMirroring == NullableBoolean.True;
+					bool vMirror = tile.Value.VerticalMirroring == NullableBoolean.True;
+
+					int colIndex = hMirror ? (~col & 0x01) : (col & 0x01);
+					int rowIndex = vMirror ? (~row & 0x01) : (row & 0x01);
+					int tileAddrIndex = (doubleWidth ? colIndex : 0) + (doubleHeight ? rowIndex * 2 : 0);
+					if(tileAddrIndex < tile.Value.TileCount) {
+						addresses.Add(new TileAddressInfo() {
+							Address = new AddressInfo() { Address = (int)tile.Value.TileAddresses[tileAddrIndex], Type = memType },
+							HorizontalMirroring = hMirror,
+							VerticalMirroring = vMirror
+						});
+					}
 				}
 			}
 

--- a/UI/Debugger/Windows/TileEditorWindow.axaml.cs
+++ b/UI/Debugger/Windows/TileEditorWindow.axaml.cs
@@ -120,7 +120,7 @@ namespace Mesen.Debugger.Windows
 			AvaloniaXamlLoader.Load(this);
 		}
 
-		public static void OpenAtTile(List<AddressInfo> tileAddresses, int columnCount, TileFormat tileFormat, int selectedPalette, Window parent, CpuType cpuType, int scanline, int cycle)
+		public static void OpenAtTile(List<TileAddressInfo> tileAddresses, int columnCount, TileFormat tileFormat, int selectedPalette, Window parent, CpuType cpuType, int scanline, int cycle)
 		{
 			if(EmuApi.IsPaused()) {
 				//If paused, use the current state - this might mismatch if viewer doesn't have "refresh on pause" enabled
@@ -135,16 +135,16 @@ namespace Mesen.Debugger.Windows
 			}
 		}
 
-		private static void InternalOpenAtTile(List<AddressInfo> tileAddresses, int columnCount, TileFormat tileFormat, int selectedPalette, Window parent)
+		private static void InternalOpenAtTile(List<TileAddressInfo> tileAddresses, int columnCount, TileFormat tileFormat, int selectedPalette, Window parent)
 		{
 			for(int i = 0; i < tileAddresses.Count; i++) {
-				AddressInfo addr = tileAddresses[i];
+				AddressInfo addr = tileAddresses[i].Address;
 				if(addr.Type.IsRelativeMemory()) {
-					tileAddresses[i] = DebugApi.GetAbsoluteAddress(addr);
+					tileAddresses[i].Address = DebugApi.GetAbsoluteAddress(addr);
 				}
 			}
 
-			if(tileAddresses.Any(x => x.Address < 0)) {
+			if(tileAddresses.Any(x => x.Address.Address < 0)) {
 				return;
 			}
 

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -1176,8 +1176,11 @@ namespace Mesen.Interop
 		public Int32 TileMapAddress;
 
 		public Int32 TileIndex;
-		public Int32 TileAddress;
+		public UInt32 TileCount;
 		
+		[MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+		public UInt32[] TileAddresses;
+
 		public Int32 PixelData;
 
 		public Int32 PaletteIndex;
@@ -1190,6 +1193,8 @@ namespace Mesen.Interop
 		public NullableBoolean HorizontalMirroring;
 		public NullableBoolean VerticalMirroring;
 		public NullableBoolean HighPriority;
+
+		public Int32 TileAddress => TileCount == 0 ? -1 : (Int32)TileAddresses[0];
 	};
 
 	public enum TileFilter


### PR DESCRIPTION
Also added support for horizontal/vertical mirroring when editing mirrored tiles from the tilemap viewer.