### PR TITLE
NES: Revert to using console region for NSF init

### DIFF
--- a/Core/NES/Mappers/NSF/NsfMapper.cpp
+++ b/Core/NES/Mappers/NSF/NsfMapper.cpp
@@ -154,7 +154,7 @@ void NsfMapper::OnAfterResetPowerOn()
 
 	NesCpuState& state = _console->GetCpu()->GetState();
 	state.A = _songNumber;
-	state.X = (_nsfHeader.Flags & 0x01) ? 1 : 0; //PAL = 1, NTSC = 0
+	state.X = _console->GetRegion() == ConsoleRegion::Pal ? 1 : 0; //PAL = 1, NTSC = 0
 	state.Y = 0;
 	state.SP = 0xFD;
 


### PR DESCRIPTION
Mesen2 previously changed the NSF handling to use the NSF header (bit 0 of offset $7A) to determine the value of X passed to to the NSF's init routine (this is a region parameter which allows the NSF to adjust playback for PAL/NTSC). This change was incorrectly forcing multi-region NSFs to assume NTSC playback (X = 0) regardless of the console's region, since the majority of them do not set bit 0 when using dual PAL/NTSC (bit 1 of offset $7A = 1) for compatibility with some players.

This PR reverts the behaviour to that of Mesen 0.9.9, where the console region setting is used to determine the value passed into X when calling the init routine. This matches NSFPlay's behaviour when forcing a particular region and makes multi-region NSFs work properly again, even if they do not claim to be dual PAL/NTSC. (e.g. FamiTracker exports using the "Tempo" mode tempo)

Thanks to Sour for pointing out the change.

Example multi-region NSF (port of my Sabre tunes for FDS-diskmag): [SabreNSF_Test.zip](https://github.com/user-attachments/files/27118582/SabreNSF_Test.zip)
