### PR TITLE
NES: Fixed overclocking causing the APU to desynchronize from the CPU

### DIFF
--- a/Core/NES/APU/NesApu.cpp
+++ b/Core/NES/APU/NesApu.cpp
@@ -246,6 +246,9 @@ void NesApu::Serialize(Serializer& s)
 	if(s.GetFormat() != SerializeFormat::Map) {
 		//End the Apu frame - makes it simpler to restore sound after a state reload
 		EndFrame();
+
+		SV(_apuEnabled);
+		SV(_apuDisabledStamp);
 	}
 
 	SV(_square1);
@@ -263,7 +266,23 @@ void NesApu::AddExpansionAudioDelta(AudioChannel channel, int16_t delta)
 
 void NesApu::SetApuStatus(bool enabled)
 {
-	_apuEnabled = enabled;
+	if(_apuEnabled == enabled) {
+		return;
+	}
+
+	if(!enabled) {
+		_apuDisabledStamp = _console->GetCpu()->GetCycleCount();
+		_apuEnabled = false;
+	} else {
+		uint64_t gap = _console->GetCpu()->GetCycleCount() - _apuDisabledStamp;
+		if(gap & 0x01) {
+			//CPU ran an odd number of cycles while the APU was disabled for overclocking
+			//Run an extra APU cycle here to re-sync odd/even cycles with the CPU
+			//This is needed to ensure DMC DMA occurs on the correct cycles with overclocking.
+			Exec();
+		}
+		_apuEnabled = true;
+	}
 }
 
 bool NesApu::IsApuEnabled()

--- a/Core/NES/APU/NesApu.h
+++ b/Core/NES/APU/NesApu.h
@@ -40,7 +40,7 @@ private:
 	EmuSettings* _settings;
 
 	ConsoleRegion _region;
-	
+
 	uint64_t _apuDisabledStamp = 0;
 
 private:

--- a/Core/NES/APU/NesApu.h
+++ b/Core/NES/APU/NesApu.h
@@ -40,6 +40,8 @@ private:
 	EmuSettings* _settings;
 
 	ConsoleRegion _region;
+	
+	uint64_t _apuDisabledStamp = 0;
 
 private:
 	__forceinline bool NeedToRun(uint32_t currentCycle);

--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -321,8 +321,8 @@ void NesCpu::EndCpuCycle(bool forRead)
 void NesCpu::StartCpuCycle(bool forRead)
 {
 	_masterClock += forRead ? (_startClockCount - 1) : (_startClockCount + 1);
-	_state.CycleCount++;
 	_console->GetPpu()->Run(_masterClock - _ppuOffset);
+	_state.CycleCount++;
 	_console->ProcessCpuClock();
 }
 

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -1271,16 +1271,17 @@ template<class T> void NesPpu<T>::TriggerNmi()
 template<class T> void NesPpu<T>::UpdateApuStatus()
 {
 	NesApu* apu = _console->GetApu();
-	apu->SetApuStatus(true);
+	bool enabled = true;
 	if(_scanline > 240) {
 		if(_scanline > _standardVblankEnd) {
 			//Disable APU for extra lines after NMI
-			apu->SetApuStatus(false);
+			enabled = false;
 		} else if(_scanline >= _standardNmiScanline && _scanline < _nmiScanline) {
 			//Disable APU for extra lines before NMI
-			apu->SetApuStatus(false);
+			enabled = false;
 		}
 	}
+	apu->SetApuStatus(enabled);
 }
 
 template<class T> void NesPpu<T>::DebugUpdateFrameBuffer(bool toGrayscale)


### PR DESCRIPTION
When overclocking is used, this could cause DMC DMA to happen on the wrong cycle parity, causing issues with code that uses sprite DMA to align 4016 reads to prevent DMC DMA from corrupting the read value.