### PR TITLE
NES: Improve DMC sample duplication emulation.

### DIFF
--- a/Core/NES/APU/DeltaModulationChannel.cpp
+++ b/Core/NES/APU/DeltaModulationChannel.cpp
@@ -92,27 +92,30 @@ void DeltaModulationChannel::SetDmcReadBuffer(uint8_t value)
 		}
 	}
 
-	if(_sampleLength == 1 && !_loopFlag) {
-		//When DMA ends around the time the bit counter resets, a CPU glitch sometimes causes another DMA to be requested immediately.
-		if(_bitsRemaining == 8 && _timer.GetTimer() == _timer.GetPeriod() && _console->GetNesConfig().EnableDmcSampleDuplicationGlitch) {
-			//When the DMA ends on the same cycle as the bit counter resets
-			//This glitch exists on all H CPUs and some G CPUs (those from around 1990 and later)
-			//In this case, a full DMA is performed on the same address, and the same sample byte
-			//is played twice in a row by the DMC
-			_shiftRegister = _readBuffer;
-			_silenceFlag = false;
-			_bufferEmpty = true;
+	//When DMA ends around the time the bit counter resets, a CPU glitch sometimes causes another DMA to be requested immediately.
+	if(_bitsRemaining == 8 && _timer.GetTimer() == _timer.GetPeriod() && _console->GetNesConfig().EnableDmcSampleDuplicationGlitch) {
+		//When the DMA ends on the same cycle as the bit counter resets.
+		//On earlier CPUs, there is normally a 1 APU cycle gap between the end of one DMC DMA
+		//and the start of another. All H CPUs and some G CPUs (those from around 1990 and later)
+		//remove this gap requirement.
+		_shiftRegister = _readBuffer;
+		_silenceFlag = false;
+		_bufferEmpty = true;
+
+		//If the sample was 1 byte, a full DMA is performed on the same address
+		//and the same sample byte is played twice in a row by the DMC.
+		if(_sampleLength == 1) {
 			InitSample();
-			StartDmcTransfer();
-		} else if(_bitsRemaining == 1 && _timer.GetTimer() < 2) {
-			//When the DMA ends on the APU cycle before the bit counter resets
-			//If it this happens right before the bit counter resets,
-			//a DMA is triggered and aborted 1 cycle later (causing one halted CPU cycle)
-			_shiftRegister = _readBuffer;
-			_bufferEmpty = false;
-			InitSample();
-			_disableDelay = 3;
 		}
+		StartDmcTransfer();
+	} else if(_sampleLength == 1 && !_loopFlag && _bitsRemaining == 1 && _timer.GetTimer() < 2) {
+		//When the DMA ends on the APU cycle before the bit counter resets.
+		//If this happens right before the bit counter resets,
+		//a DMA is triggered and aborted 1 cycle later (causing one halted CPU cycle)
+		_shiftRegister = _readBuffer;
+		_bufferEmpty = false;
+		InitSample();
+		_disableDelay = 3;
 	}
 }
 

--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -413,6 +413,13 @@ void NesCpu::ProcessPendingDma(uint16_t readAddress, MemoryOperationType opType)
 				_dmcDmaRunning = false;
 				_abortDmcDma = false;
 				_console->GetApu()->SetDmcReadBuffer(readValue);
+				//On later CPUs, a DMC DMA may start immediately after another DMC DMA. We need to
+				//call ProcessPendingDma again to handle the behavior of the halt cycle. This
+				//allows the second DMA to clock the joypads again on NES-behavior consoles.
+				//Fixes dmc_dma_start_test_v2 case C with sample duplication turned on.
+				if(_needHalt) {
+					ProcessPendingDmaNoinline(readAddress, opType);
+				}
 			} else if(_spriteDmaTransfer) {
 				//DMC DMA is not running, or not ready, run sprite DMA
 				processCycle();

--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -418,7 +418,7 @@ void NesCpu::ProcessPendingDma(uint16_t readAddress, MemoryOperationType opType)
 				//allows the second DMA to clock the joypads again on NES-behavior consoles.
 				//Fixes dmc_dma_start_test_v2 case C with sample duplication turned on.
 				if(_needHalt) {
-					ProcessPendingDmaNoinline(readAddress, opType);
+					NoInlineProcessPendingDma(readAddress, opType);
 				}
 			} else if(_spriteDmaTransfer) {
 				//DMC DMA is not running, or not ready, run sprite DMA

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -64,6 +64,10 @@ private:
 
 	__forceinline void StartCpuCycle(bool forRead);
 	__forceinline void ProcessPendingDma(uint16_t readAddress, MemoryOperationType opType);
+	__noinline void ProcessPendingDmaNoinline(uint16_t readAddress, MemoryOperationType opType)
+	{
+		ProcessPendingDma(readAddress, opType);
+	}
 	uint8_t ProcessDmaRead(uint16_t addr, uint16_t& prevReadAddress, bool enableInternalRegReads, bool isNesBehavior);
 	__forceinline uint16_t FetchOperand();
 	__forceinline void EndCpuCycle(bool forRead);

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -64,7 +64,7 @@ private:
 
 	__forceinline void StartCpuCycle(bool forRead);
 	__forceinline void ProcessPendingDma(uint16_t readAddress, MemoryOperationType opType);
-	__noinline void ProcessPendingDmaNoinline(uint16_t readAddress, MemoryOperationType opType)
+	__noinline void NoInlineProcessPendingDma(uint16_t readAddress, MemoryOperationType opType)
 	{
 		ProcessPendingDma(readAddress, opType);
 	}


### PR DESCRIPTION
On late-G and H CPUs, starting a 1-byte sample just before the end of a DMC period can cause the sample to be fetched and played twice. This change fixes 2 issues related to this.

First, new research found that this bug is because there is normally at least a 1-APU cycle gap between the end of one DMC DMA and the start of the next DMC DMA on earlier CPUs, but these later CPUs remove that gap, allowing the aborted DMA behavior to occur sooner such that it can't be aborted.

But this means it actually affects any sample that is started at the end of a DMC period, not just ones that trigger the extra DMA. Mesen was previously only doing this in the case of 1-byte non-looping samples. This change fixes this issue. This was validated with AccuracyCoin's Implicit DMA Abort test and with dmc_dma_stop_test_v3 test F.

Second, when there are two DMC DMA's back to back while reading a joypad register, both of them should cause an extra clock of the joypads when using NES behavior (unless suppressed by the APU register activation bug). However, we were only seeing extra clocks with HVC-001 behavior (which is handled on every DMA cycle always) because Mesen only runs its halt cycle logic for the first of the two DMAs. This change makes ProcessPendingDma call itself in the case where we handle DMC DMA back to back so it can do this extra joypad clock if need be.

This second change was validated with dmc_dma_start_test_v2 test C, dmc_dma_implicit_stop_level_test, and a variant of apu_register_activation_test.