### PR TITLE
NES: Fixes DMA timing bug at end of frame.

### DIFF
--- a/Core/NES/APU/NesApu.cpp
+++ b/Core/NES/APU/NesApu.cpp
@@ -199,6 +199,7 @@ void NesApu::Exec()
 {
 	_currentCycle++;
 	if(_currentCycle == NesSoundMixer::CycleLength - 1) {
+		_dmc->ProcessClock();
 		EndFrame();
 	} else if(NeedToRun(_currentCycle)) {
 		Run();
@@ -207,7 +208,6 @@ void NesApu::Exec()
 
 void NesApu::EndFrame()
 {
-	_dmc->ProcessClock();
 	Run();
 	_square1->EndFrame();
 	_square2->EndFrame();


### PR DESCRIPTION
When DMC is enabled via $4015, it starts a timer for when the resulting load DMA needs to occur. When the frame ends, this timer can be decremented an extra time due to a call to NesApu::EndFrame that wasn't expected to have execution side effects. Stepping back can also trigger this because EndFrame is called from NesApu::Serialize. Sour suggested moving the DMC ProcessClock call out of this function to fix it, which works.

This fixes very rare failures in the AccuracyCoin Implicit DMA Abort test.