### PR TITLE
Fix snes rumble controller

### DIFF
--- a/Core/SNES/Input/SnesRumbleController.cpp
+++ b/Core/SNES/Input/SnesRumbleController.cpp
@@ -23,6 +23,13 @@ void SnesRumbleController::Serialize(Serializer& s)
 	SV(_rumbleData);
 }
 
+void SnesRumbleController::RefreshStateBuffer()
+{
+	_rumbleData = 0;
+
+	SnesController::RefreshStateBuffer();
+}
+
 uint8_t SnesRumbleController::ReadRam(uint16_t addr)
 {
 	if(IsCurrentPort(addr)) {
@@ -43,8 +50,6 @@ uint8_t SnesRumbleController::ReadRam(uint16_t addr)
 			uint16_t leftRumble = (rumble & 0x0F) * 4369;
 
 			KeyManager::SetForceFeedback(rightRumble, leftRumble);
-
-			_rumbleData = 0;
 		}
 	}
 

--- a/Core/SNES/Input/SnesRumbleController.cpp
+++ b/Core/SNES/Input/SnesRumbleController.cpp
@@ -21,11 +21,22 @@ void SnesRumbleController::Serialize(Serializer& s)
 {
 	SnesController::Serialize(s);
 	SV(_rumbleData);
+	SV(_rumbleActive);
+	SV(_lastRumbleFrame);
 }
 
 void SnesRumbleController::RefreshStateBuffer()
 {
 	_rumbleData = 0;
+
+	//The LRG rumble controller stops rumbling shortly after the last rumble command.
+	//Not accurate, assumes the game regularly latches the controller.
+	if(_rumbleActive) {
+		if(_emu->GetFrameCount() - _lastRumbleFrame > 2) {
+			KeyManager::SetForceFeedback(0, 0);
+			_rumbleActive = false;
+		}
+	}
 
 	SnesController::RefreshStateBuffer();
 }
@@ -50,6 +61,9 @@ uint8_t SnesRumbleController::ReadRam(uint16_t addr)
 			uint16_t leftRumble = (rumble & 0x0F) * 4369;
 
 			KeyManager::SetForceFeedback(rightRumble, leftRumble);
+
+			_rumbleActive = true;
+			_lastRumbleFrame = _emu->GetFrameCount();
 		}
 	}
 

--- a/Core/SNES/Input/SnesRumbleController.h
+++ b/Core/SNES/Input/SnesRumbleController.h
@@ -12,6 +12,8 @@ class SnesRumbleController : public SnesController
 private:
 	SnesConsole* _console = nullptr;
 	uint16_t _rumbleData = 0;
+	bool _rumbleActive = false;
+	uint32_t _lastRumbleFrame = 0;
 
 protected:
 	void Serialize(Serializer& s) override;

--- a/Core/SNES/Input/SnesRumbleController.h
+++ b/Core/SNES/Input/SnesRumbleController.h
@@ -15,6 +15,7 @@ private:
 
 protected:
 	void Serialize(Serializer& s) override;
+	void RefreshStateBuffer() override;
 
 public:
 	SnesRumbleController(Emulator* emu, SnesConsole* console, uint8_t port, KeyMappingSet keyMappings);


### PR DESCRIPTION
This PR fixes 2 bugs in Mesen's implementation of the LRG rumble controller.

* The LRG controller clears the internal 16-bit shift register when the controller is latched.
   * Mesen clears `_rumbleData` after setting force-feedback.
* The LRG controller stops rumbling when the game stops sending rumble commands to the controller.
   * Mesen on Linux stops after 2 seconds.
   * Mesen on my Windows 11 laptop does not stop rumbling.

This behaviour is discovered by a new test ROM I wrote that was tested by NovaSquirrel ([nesdev forum post with 2 test ROMs](https://forums.nesdev.org/viewtopic.php?t=26602)).  I wrote the test because Mesen, SNES_Mister and the [rumble controller spec doc](https://github.com/LimitedRunGames-Tech/snes-rumble/blob/main/docs/RumbleTech.pdf) have different behaviour regarding rumble controller latching.

The second commit fixes the second bug in a hacky way.  It uses `SnesRumbleController::RefreshStateBuffer()` as a timer callback as I did not want to add a rumble stop timeout to `KeyManager` and potentially break the game boy rumble.

These commits have been testing by:
 * Comparing my [rumble-controller-latching-v2.sfc](https://forums.nesdev.org/viewtopic.php?p=308521#p308521) test to SNES_MiSTer and NovaSquirrel's description the tests on her LRG rumble controller.
 * Running [RealityTest](https://github.com/LimitedRunGames-Tech/snes-rumble/tree/main/binaries) and confirming all effects work.
