### PR TITLE
Remove Windows-1252 smart quotes in Game Boy APU comments

### DIFF
--- a/Core/Gameboy/APU/GbNoiseChannel.cpp
+++ b/Core/Gameboy/APU/GbNoiseChannel.cpp
@@ -63,7 +63,7 @@ uint8_t GbNoiseChannel::GetRawOutput()
 double GbNoiseChannel::GetOutput()
 {
 	//"If a DAC is enabled, the digital range $0 to $F is linearly translated to the analog range -1 to 1,
-	//in arbitrary units. Importantly, the slope is negative: “digital 0” maps to “analog 1”, not “analog -1”."
+	//in arbitrary units. Importantly, the slope is negative: 'digital 0' maps to 'analog 1', not 'analog -1'."
 
 	//Return -7 to 7 "analog" range (higher digital value = lower analog value)
 	return (7 - (int8_t)_state.Output) * (double)_dac.GetDacVolume() / 100;

--- a/Core/Gameboy/APU/GbSquareChannel.cpp
+++ b/Core/Gameboy/APU/GbSquareChannel.cpp
@@ -116,7 +116,7 @@ uint8_t GbSquareChannel::GetRawOutput()
 double GbSquareChannel::GetOutput()
 {
 	//"If a DAC is enabled, the digital range $0 to $F is linearly translated to the analog range -1 to 1,
-	//in arbitrary units. Importantly, the slope is negative: “digital 0” maps to “analog 1”, not “analog -1”."
+	//in arbitrary units. Importantly, the slope is negative: 'digital 0' maps to 'analog 1', not 'analog -1'."
 
 	//Return -7 to 7 "analog" range (higher digital value = lower analog value)
 	return (7 - (int8_t)_state.Output) * (double)_dac.GetDacVolume() / 100;

--- a/Core/Gameboy/APU/GbWaveChannel.cpp
+++ b/Core/Gameboy/APU/GbWaveChannel.cpp
@@ -73,7 +73,7 @@ uint8_t GbWaveChannel::GetRawOutput()
 double GbWaveChannel::GetOutput()
 {
 	//"If a DAC is enabled, the digital range $0 to $F is linearly translated to the analog range -1 to 1,
-	//in arbitrary units. Importantly, the slope is negative: “digital 0” maps to “analog 1”, not “analog -1”."
+	//in arbitrary units. Importantly, the slope is negative: 'digital 0' maps to 'analog 1', not 'analog -1'."
 
 	//Return -7 to 7 "analog" range (higher digital value = lower analog value)
 	return (7 - (int8_t)_state.Output) * (double)_dac.GetDacVolume() / 100;


### PR DESCRIPTION
Apparently not being utf8-clean poses build problems for other locales