### PR TITLE
SNES: Add SPC dumper tool

### DIFF
--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -91,6 +91,12 @@ void SnesConsole::ProcessEndOfFrame()
 
 void SnesConsole::Reset()
 {
+	if(_emu->GetRomInfo().Format == RomFormat::Spc) {
+		// For SPC files, reload the initial state that the SPC file started with
+		_emu->ReloadRom(true);
+		return;
+	}
+
 	_dmaController->Reset();
 	_internalRegisters->Reset();
 	_memoryManager->Reset();

--- a/UI/Config/ConfigManager.cs
+++ b/UI/Config/ConfigManager.cs
@@ -249,6 +249,7 @@ namespace Mesen.Config
 		public static string TestFolder { get { return GetFolder(Path.Combine(ConfigManager.HomeFolder, "Tests"), null, false); } }
 		public static string HdPackFolder { get { return GetFolder(Path.Combine(ConfigManager.HomeFolder, "HdPacks"), null, false); } }
 		public static string RecentGamesFolder { get { return GetFolder(Path.Combine(ConfigManager.HomeFolder, "RecentGames"), null, false); } }
+		public static string DumpsFolder { get { return GetFolder(Path.Combine(ConfigManager.HomeFolder, "Dumps"), null, false); } }
 
 		public static string ConfigFile
 		{

--- a/UI/Debugger/Utilities/ContextMenuAction.cs
+++ b/UI/Debugger/Utilities/ContextMenuAction.cs
@@ -616,6 +616,8 @@ namespace Mesen.Debugger.Utilities
 
 		[IconFile("Camera")]
 		TakeScreenshot,
+		[IconFile("Export")]
+		SaveSpcFile,
 
 		[IconFile("Help")]
 		OnlineHelp,

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -1016,6 +1016,18 @@
 			<Control ID="btnCancel">Cancel</Control>
 		</Form>
 		
+		<Form ID="SaveSpcFileWindow">
+			<Control ID="wndTitle">Save a .SPC file</Control>
+
+			<Control ID="grpTags">ID666 tags</Control>
+			<Control ID="lblSongTitle">Song title</Control>
+			<Control ID="lblGameTitle">Game title</Control>
+			<Control ID="lblSongArtist">Artist</Control>
+
+			<Control ID="btnOK">Save file</Control>
+			<Control ID="btnCancel">Cancel</Control>
+		</Form>
+		
 		<Form ID="CheckBoxWarning">
 			<Control ID="Hint">(not recommended)</Control>
 		</Form>
@@ -3564,6 +3576,7 @@ E
 			<Value ID="InstallHdPack">Install HD Pack</Value>
 			<Value ID="HdPackBuilder">HD Pack Builder</Value>
 			<Value ID="TakeScreenshot">Take Screenshot</Value>
+			<Value ID="SaveSpcFile">Save .SPC File</Value>
 
 			<Value ID="OnlineHelp">Online Help</Value>
 			<Value ID="CommandLineHelp">Command-line options</Value>

--- a/UI/Utilities/FileDialogHelper.cs
+++ b/UI/Utilities/FileDialogHelper.cs
@@ -36,6 +36,7 @@ namespace Mesen.Utilities
 		public const string BinExt = "bin";
 		public const string NesExt = "nes";
 		public const string SufamiTurboExt = "st";
+		public const string SpcExt = "spc";
 
 		public static async Task<string?> OpenFile(string? initialFolder, IRenderRoot? parent, params string[] extensions)
 		{

--- a/UI/ViewModels/MainMenuViewModel.cs
+++ b/UI/ViewModels/MainMenuViewModel.cs
@@ -794,6 +794,14 @@ namespace Mesen.ViewModels
 				new MainMenuAction(EmulatorShortcut.TakeScreenshot) {
 					ActionType = ActionType.TakeScreenshot,
 				},
+
+				new MainMenuAction() {
+					ActionType = ActionType.SaveSpcFile,
+					IsVisible = () => MainWindow.RomInfo.CpuTypes.Contains(CpuType.Spc),
+					OnClick = () => {
+						ApplicationHelper.GetOrCreateUniqueWindow(wnd, () => new SaveSpcFileWindow());
+					}
+				},
 			};
 		}
 

--- a/UI/ViewModels/SaveSpcFileViewModel.cs
+++ b/UI/ViewModels/SaveSpcFileViewModel.cs
@@ -1,0 +1,84 @@
+﻿using Mesen.Debugger;
+using Mesen.Interop;
+using ReactiveUI.Fody.Helpers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Mesen.ViewModels
+{
+	public class SaveSpcFileViewModel : ViewModelBase
+	{
+		[Reactive] public string GameTitle { get; set; } = "";
+		[Reactive] public string SongTitle { get; set; } = "";
+		[Reactive] public string SongArtist { get; set; } = "";
+
+		public SaveSpcFileViewModel()
+		{
+
+		}
+
+		public async void WriteFixedLengthString(BinaryWriter writer, string text, int length)
+		{
+			byte[] textAsBytes = Encoding.ASCII.GetBytes(text);
+			byte[] buffer = new byte[length];
+
+			for(int i = 0; i < length; i++) {
+				buffer[i] = (i < textAsBytes.Length) ? textAsBytes[i] : (byte)0;
+			}
+
+			writer.Write(buffer);
+		}
+
+		public async void SaveSpcFile(string filename)
+		{
+			using(FileStream stream = File.Open(filename, FileMode.Create)) {
+				using(BinaryWriter writer = new BinaryWriter(stream, Encoding.UTF8, false)) {
+					byte[] spcRam = [];
+					byte[] spcMemory = [];
+					byte[] dspRegisters = [];
+					SpcState cpu = DebugApi.GetCpuState<SpcState>(CpuType.Spc);
+					DebugApi.GetMemoryState(MemoryType.SpcRam, ref spcRam);
+					DebugApi.GetMemoryState(MemoryType.SpcMemory, ref spcMemory);
+					DebugApi.GetMemoryState(MemoryType.SpcDspRegisters, ref dspRegisters);
+
+					WriteFixedLengthString(writer, "SNES-SPC700 Sound File Data v0.30", 33);
+					writer.Write((short)0x1a1a);
+					writer.Write((byte)26); // Has ID666 tags
+					writer.Write((byte)30); // Minor version number
+					writer.Write(cpu.PC);
+					writer.Write(cpu.A);
+					writer.Write(cpu.X);
+					writer.Write(cpu.Y);
+					writer.Write((byte)cpu.PS);
+					writer.Write(cpu.SP);
+					writer.Write((short)0); // Reserved
+					WriteFixedLengthString(writer, SongTitle, 32);
+					WriteFixedLengthString(writer, GameTitle, 32);
+					WriteFixedLengthString(writer, "", 16); // Name of dumper
+					WriteFixedLengthString(writer, "", 32); // Comments
+					WriteFixedLengthString(writer, DateTime.Now.ToString("MM/dd/yyyy"), 11); // Date dumped
+					WriteFixedLengthString(writer, "", 3);  // Number of Seconds to play song before Fading Out
+					WriteFixedLengthString(writer, "", 5);  // Length of fade in milliseconds
+					WriteFixedLengthString(writer, SongArtist, 32);
+					writer.Write((short)0); // No channels disabled, unknown emulator
+					WriteFixedLengthString(writer, "", 45); // Reserved
+
+					// Include the most recently written values for the write-only registers
+					spcMemory[0xF0] = spcRam[0xF0];
+					spcMemory[0xF1] = spcRam[0xF1];
+					spcMemory[0xFA] = spcRam[0xFA];
+					spcMemory[0xFB] = spcRam[0xFB];
+					spcMemory[0xFC] = spcRam[0xFC];
+
+					writer.Write(spcMemory, 0, 0x10000);
+					writer.Write(dspRegisters, 0, 128);
+					WriteFixedLengthString(writer, "", 64); // Unused
+					writer.Write(spcRam, 0x10000 - 64, 64); // Last 64 bytes of RAM, in case IPL was enabled
+				}
+			}
+		}
+	}
+}

--- a/UI/ViewModels/SaveSpcFileViewModel.cs
+++ b/UI/ViewModels/SaveSpcFileViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Mesen.Debugger;
+using Mesen.Debugger.Utilities;
 using Mesen.Interop;
 using ReactiveUI.Fody.Helpers;
 using System;
@@ -34,15 +35,15 @@ namespace Mesen.ViewModels
 
 		public async void SaveSpcFile(string filename)
 		{
+			bool releaseDebugger = !DebugWindowManager.HasOpenedDebugWindows();
+			bool paused = EmuApi.IsPaused();
+
 			using(FileStream stream = File.Open(filename, FileMode.Create)) {
 				using(BinaryWriter writer = new BinaryWriter(stream, Encoding.UTF8, false)) {
-					byte[] spcRam = [];
-					byte[] spcMemory = [];
-					byte[] dspRegisters = [];
 					SpcState cpu = DebugApi.GetCpuState<SpcState>(CpuType.Spc);
-					DebugApi.GetMemoryState(MemoryType.SpcRam, ref spcRam);
-					DebugApi.GetMemoryState(MemoryType.SpcMemory, ref spcMemory);
-					DebugApi.GetMemoryState(MemoryType.SpcDspRegisters, ref dspRegisters);
+					byte[] spcRam = DebugApi.GetMemoryState(MemoryType.SpcRam);
+					byte[] spcMemory = DebugApi.GetMemoryState(MemoryType.SpcMemory);
+					byte[] dspRegisters = DebugApi.GetMemoryState(MemoryType.SpcDspRegisters);
 
 					WriteFixedLengthString(writer, "SNES-SPC700 Sound File Data v0.30", 33);
 					writer.Write((short)0x1a1a);
@@ -60,7 +61,7 @@ namespace Mesen.ViewModels
 					WriteFixedLengthString(writer, "", 16); // Name of dumper
 					WriteFixedLengthString(writer, "", 32); // Comments
 					WriteFixedLengthString(writer, DateTime.Now.ToString("MM/dd/yyyy"), 11); // Date dumped
-					WriteFixedLengthString(writer, "", 3);  // Number of Seconds to play song before Fading Out
+					WriteFixedLengthString(writer, "", 3);  // Number of seconds to play song before fading out
 					WriteFixedLengthString(writer, "", 5);  // Length of fade in milliseconds
 					WriteFixedLengthString(writer, SongArtist, 32);
 					writer.Write((short)0); // No channels disabled, unknown emulator
@@ -77,6 +78,14 @@ namespace Mesen.ViewModels
 					writer.Write(dspRegisters, 0, 128);
 					WriteFixedLengthString(writer, "", 64); // Unused
 					writer.Write(spcRam, 0x10000 - 64, 64); // Last 64 bytes of RAM, in case IPL was enabled
+				}
+			}
+
+			if(releaseDebugger) {
+				//The debug calls to get SPC state will initialize the debugger - stop the debugger if no other debug window is opened
+				DebugApi.ReleaseDebugger();
+				if(paused) {
+					EmuApi.Pause();
 				}
 			}
 		}

--- a/UI/Windows/SaveSpcFileWindow.axaml
+++ b/UI/Windows/SaveSpcFileWindow.axaml
@@ -28,11 +28,11 @@
 		<StackPanel Orientation="Vertical" HorizontalAlignment="Left">
 			<c:OptionSection Header="{l:Translate grpTags}" Margin="0">
 				<Grid ColumnDefinitions="Auto,1*" RowDefinitions="Auto,Auto,Auto">
-					<TextBlock Grid.Row="0" Text="{l:Translate lblGameTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBlock Grid.Row="0" Text="{l:Translate lblGameTitle}" VerticalAlignment="Center" />
 					<TextBox Grid.Row="0" Grid.Column="1" Text="{Binding GameTitle}" MaxLength="32" Width="200"/>
-					<TextBlock Grid.Row="1" Text="{l:Translate lblSongTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBlock Grid.Row="1" Text="{l:Translate lblSongTitle}" VerticalAlignment="Center" />
 					<TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SongTitle}" MaxLength="32" Width="200" />
-					<TextBlock Grid.Row="2" Text="{l:Translate lblSongArtist}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBlock Grid.Row="2" Text="{l:Translate lblSongArtist}" VerticalAlignment="Center" />
 					<TextBox Grid.Row="2" Grid.Column="1" Text="{Binding SongArtist}" MaxLength="32" Width="200"/>
 				</Grid>
 			</c:OptionSection>

--- a/UI/Windows/SaveSpcFileWindow.axaml
+++ b/UI/Windows/SaveSpcFileWindow.axaml
@@ -1,0 +1,41 @@
+<Window
+	xmlns="https://github.com/avaloniaui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:m="clr-namespace:Mesen"
+	xmlns:c="using:Mesen.Controls"
+	xmlns:vm="using:Mesen.ViewModels"
+	xmlns:v="using:Mesen.Views"
+	xmlns:l="using:Mesen.Localization"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:Class="Mesen.Windows.SaveSpcFileWindow"
+   x:Name="root"
+	Width="300" Height="160"
+	x:DataType="vm:SaveSpcFileViewModel"
+	Title="{l:Translate wndTitle}"  
+>
+	<Design.DataContext>
+		<vm:SaveSpcFileViewModel />
+	</Design.DataContext>
+
+	<DockPanel Margin="5">
+		<StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right">
+			<Button MinWidth="70" HorizontalContentAlignment="Center" Click="Ok_OnClick" Content="{l:Translate btnOK}" />
+			<Button MinWidth="70" HorizontalContentAlignment="Center" IsCancel="True" Click="Cancel_OnClick" Content="{l:Translate btnCancel}" />
+		</StackPanel>
+		
+		<StackPanel Orientation="Vertical" HorizontalAlignment="Left">
+			<c:OptionSection Header="{l:Translate grpTags}" Margin="0">
+				<Grid ColumnDefinitions="Auto,1*" RowDefinitions="Auto,Auto,Auto">
+					<TextBlock Grid.Row="0" Text="{l:Translate lblGameTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBox Grid.Row="0" Grid.Column="1" Text="{Binding GameTitle}" MaxLength="32" Width="200"/>
+					<TextBlock Grid.Row="1" Text="{l:Translate lblSongTitle}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SongTitle}" MaxLength="32" Width="200" />
+					<TextBlock Grid.Row="2" Text="{l:Translate lblSongArtist}" DockPanel.Dock="Left" VerticalAlignment="Center" />
+					<TextBox Grid.Row="2" Grid.Column="1" Text="{Binding SongArtist}" MaxLength="32" Width="200"/>
+				</Grid>
+			</c:OptionSection>
+		</StackPanel>
+	</DockPanel>
+</Window>

--- a/UI/Windows/SaveSpcFileWindow.axaml.cs
+++ b/UI/Windows/SaveSpcFileWindow.axaml.cs
@@ -1,0 +1,55 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Mesen.Config;
+using Mesen.Interop;
+using Mesen.Utilities;
+using Mesen.ViewModels;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Mesen.Windows
+{
+	public class SaveSpcFileWindow : MesenWindow
+	{
+		private SaveSpcFileViewModel _model;
+
+		public SaveSpcFileWindow()
+		{
+			_model = new SaveSpcFileViewModel();
+			DataContext = _model;
+
+			InitializeComponent();
+#if DEBUG
+			this.AttachDevTools();
+#endif
+		}
+
+		private void InitializeComponent()
+		{
+			AvaloniaXamlLoader.Load(this);
+		}
+
+		private async void SaveSpcFile()
+		{
+			string? filename = await FileDialogHelper.SaveFile(ConfigManager.DumpsFolder, EmuApi.GetRomInfo().GetRomName() + ".spc", this, FileDialogHelper.SpcExt);
+			if(filename != null) {
+				_model.SaveSpcFile(filename);
+				Close(true);
+			}
+		}
+
+		private void Ok_OnClick(object sender, RoutedEventArgs e)
+		{
+			SaveSpcFile();
+		}
+
+		private void Cancel_OnClick(object sender, RoutedEventArgs e)
+		{
+			Close(false);
+		}
+	}
+}


### PR DESCRIPTION
Also fixes resetting while playing an SPC file so that it reloads the file.