### PR TITLE
GB: Add GBC palette to memory viewer

### DIFF
--- a/Core/Debugger/DebugUtilities.h
+++ b/Core/Debugger/DebugUtilities.h
@@ -104,6 +104,8 @@ public:
 			case MemoryType::GbBootRom:
 			case MemoryType::GbVideoRam:
 			case MemoryType::GbSpriteRam:
+			case MemoryType::GbBgPaletteRam:
+			case MemoryType::GbObjPaletteRam:
 			case MemoryType::GameboyMemory:
 				return CpuType::Gameboy;
 

--- a/Core/Gameboy/GbPpu.cpp
+++ b/Core/Gameboy/GbPpu.cpp
@@ -48,6 +48,10 @@ void GbPpu::Init(Emulator* emu, Gameboy* gameboy, GbMemoryManager* memoryManager
 
 	_gameboy->InitializeRam(_state.CgbBgPalettes, 4 * 8 * sizeof(uint16_t));
 	_gameboy->InitializeRam(_state.CgbObjPalettes, 4 * 8 * sizeof(uint16_t));
+	if(_state.CgbEnabled) {
+		_emu->RegisterMemory(MemoryType::GbBgPaletteRam, _state.CgbBgPalettes, 4 * 8 * sizeof(uint16_t));
+		_emu->RegisterMemory(MemoryType::GbObjPaletteRam, _state.CgbObjPalettes, 4 * 8 * sizeof(uint16_t));
+	}
 
 	UpdatePalette();
 
@@ -1247,7 +1251,9 @@ void GbPpu::WriteCgbRegister(uint16_t addr, uint8_t value)
 uint8_t GbPpu::ReadCgbPalette(uint8_t& pos, uint16_t* pal)
 {
 	if(_state.Mode <= PpuMode::OamEvaluation) {
-		return (pal[pos >> 1] >> ((pos & 0x01) ? 8 : 0)) & 0xFF;
+		uint8_t value = (pal[pos >> 1] >> ((pos & 0x01) ? 8 : 0)) & 0xFF;
+		_emu->ProcessPpuRead<CpuType::Gameboy>(pos, value, (pal == _state.CgbBgPalettes) ? MemoryType::GbBgPaletteRam : MemoryType::GbObjPaletteRam);
+		return value;
 	}
 	return 0xFF;
 }
@@ -1255,6 +1261,7 @@ uint8_t GbPpu::ReadCgbPalette(uint8_t& pos, uint16_t* pal)
 void GbPpu::WriteCgbPalette(uint8_t& pos, uint16_t* pal, bool autoInc, uint8_t value)
 {
 	if(_state.Mode <= PpuMode::OamEvaluation) {
+		_emu->ProcessPpuWrite<CpuType::Gameboy>(pos, value, (pal == _state.CgbBgPalettes) ? MemoryType::GbBgPaletteRam : MemoryType::GbObjPaletteRam);
 		if(pos & 0x01) {
 			pal[pos >> 1] = (pal[pos >> 1] & 0xFF) | (value << 8);
 		} else {

--- a/Core/Shared/MemoryType.h
+++ b/Core/Shared/MemoryType.h
@@ -49,6 +49,8 @@ enum class MemoryType
 	GbBootRom,
 	GbVideoRam,
 	GbSpriteRam,
+	GbBgPaletteRam,
+	GbObjPaletteRam,
 
 	NesPrgRom,
 	NesInternalRam,

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -632,6 +632,8 @@ namespace Mesen.Interop
 		GbBootRom,
 		GbVideoRam,
 		GbSpriteRam,
+		GbBgPaletteRam,
+		GbObjPaletteRam,
 
 		NesPrgRom,
 		NesInternalRam,

--- a/UI/Interop/MemoryTypeExtensions.cs
+++ b/UI/Interop/MemoryTypeExtensions.cs
@@ -192,6 +192,8 @@ namespace Mesen.Interop
 
 				case MemoryType.GbBootRom:
 				case MemoryType.GbSpriteRam:
+				case MemoryType.GbBgPaletteRam:
+				case MemoryType.GbObjPaletteRam:
 
 				case MemoryType.NesSecondarySpriteRam:
 				case MemoryType.NesSpriteRam:

--- a/UI/Interop/MemoryTypeExtensions.cs
+++ b/UI/Interop/MemoryTypeExtensions.cs
@@ -44,6 +44,8 @@ namespace Mesen.Interop
 				case MemoryType.GbBootRom:
 				case MemoryType.GbVideoRam:
 				case MemoryType.GbSpriteRam:
+				case MemoryType.GbBgPaletteRam:
+				case MemoryType.GbObjPaletteRam:
 				case MemoryType.GameboyMemory:
 					return CpuType.Gameboy;
 
@@ -137,6 +139,8 @@ namespace Mesen.Interop
 
 				case MemoryType.GbVideoRam:
 				case MemoryType.GbSpriteRam:
+				case MemoryType.GbBgPaletteRam:
+				case MemoryType.GbObjPaletteRam:
 
 				case MemoryType.NesPpuMemory:
 				case MemoryType.NesSecondarySpriteRam:
@@ -482,6 +486,8 @@ namespace Mesen.Interop
 				MemoryType.GbBootRom => "BOOT",
 				MemoryType.GbVideoRam => "VRAM",
 				MemoryType.GbSpriteRam => "OAM",
+				MemoryType.GbBgPaletteRam => "BG PAL",
+				MemoryType.GbObjPaletteRam => "OBJ PAL",
 
 				MemoryType.NesMemory => "CPU",
 				MemoryType.NesPpuMemory => "PPU",

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -2821,6 +2821,8 @@ E
 			<Value ID="GbBootRom">GB - Boot ROM</Value>
 			<Value ID="GbVideoRam">GB - Video RAM</Value>
 			<Value ID="GbSpriteRam">GB - Sprite RAM</Value>
+			<Value ID="GbBgPaletteRam">GB - Background Palette RAM</Value>
+			<Value ID="GbObjPaletteRam">GB - Sprite Palette RAM</Value>
 
 			<Value ID="NesMemory">CPU Memory</Value>
 			<Value ID="NesPpuMemory">PPU Memory</Value>


### PR DESCRIPTION
The new memory areas will show up when a game starts in GBC mode and the boot ROM switches it to GB mode, but that's probably fine? Considering that's actual GBC internal state.