### PR TITLE
NES: Fix N163 internal RAM address auto-increasement wrapping behavior

### DIFF
--- a/Core/NES/Mappers/Audio/Namco163Audio.h
+++ b/Core/NES/Mappers/Audio/Namco163Audio.h
@@ -168,7 +168,7 @@ public:
 			case 0x4800:
 				_console->GetEmulator()->ProcessMemoryAccess<CpuType::Nes, MemoryType::NesMapperRam, MemoryOperationType::Write>(_ramPosition + _ramOffset, value);
 				_internalRam[_ramPosition] = value;
-				if(_autoIncrement) {
+				if(_autoIncrement && _ramPosition != 0x7F) {
 					_ramPosition = (_ramPosition + 1) & 0x7F;
 				}
 				break;
@@ -189,7 +189,7 @@ public:
 			case 0x4800: {
 				value = _internalRam[_ramPosition];
 				_console->GetEmulator()->ProcessMemoryAccess<CpuType::Nes, MemoryType::NesMapperRam, MemoryOperationType::Read>(_ramPosition + _ramOffset, value);
-				if(_autoIncrement) {
+				if(_autoIncrement && _ramPosition != 0x7F) {
 					_ramPosition = (_ramPosition + 1) & 0x7F;
 				}
 				break;

--- a/Core/NES/Mappers/Audio/Namco163Audio.h
+++ b/Core/NES/Mappers/Audio/Namco163Audio.h
@@ -169,7 +169,7 @@ public:
 				_console->GetEmulator()->ProcessMemoryAccess<CpuType::Nes, MemoryType::NesMapperRam, MemoryOperationType::Write>(_ramPosition + _ramOffset, value);
 				_internalRam[_ramPosition] = value;
 				if(_autoIncrement && _ramPosition != 0x7F) {
-					_ramPosition = (_ramPosition + 1) & 0x7F;
+					_ramPosition++;
 				}
 				break;
 			case 0xE000:
@@ -190,7 +190,7 @@ public:
 				value = _internalRam[_ramPosition];
 				_console->GetEmulator()->ProcessMemoryAccess<CpuType::Nes, MemoryType::NesMapperRam, MemoryOperationType::Read>(_ramPosition + _ramOffset, value);
 				if(_autoIncrement && _ramPosition != 0x7F) {
-					_ramPosition = (_ramPosition + 1) & 0x7F;
+					_ramPosition++;
 				}
 				break;
 			}


### PR DESCRIPTION
The real N163 just clips the address when you try to read or write in auto-inc mode.

Test ROM: https://github.com/HeeminTV/Famicom-Tests/tree/main/n163_addresswrappingtest