### PR TITLE
NES: Adds MMC5 PCM read mode

### DIFF
--- a/Core/NES/Mappers/Audio/Mmc5Audio.h
+++ b/Core/NES/Mappers/Audio/Mmc5Audio.h
@@ -104,6 +104,14 @@ public:
 		_pcmOutput = 0;
 	}
 
+	__forceinline bool GetPcmReadMode() { return _pcmReadMode; }
+	void HandlePcmRead(uint16_t addr, uint8_t value)
+	{
+		if((addr & 0xC000) == 0x8000 && value) {
+			_pcmOutput = value;
+		}
+	}
+
 	uint8_t ReadRegister(uint16_t addr)
 	{
 		switch(addr) {
@@ -139,7 +147,7 @@ public:
 				break;
 
 			case 0x5010:
-				//TODO: Read mode & PCM IRQs are not implemented
+				//TODO: PCM IRQs
 				_pcmReadMode = (value & 0x01) == 0x01;
 				_pcmIrqEnabled = (value & 0x80) == 0x80;
 				break;

--- a/Core/NES/Mappers/Nintendo/MMC5.h
+++ b/Core/NES/Mappers/Nintendo/MMC5.h
@@ -441,6 +441,15 @@ protected:
 		}
 	}
 
+	uint8_t ReadRam(uint16_t addr) override
+	{
+		uint8_t value = BaseMapper::ReadRam(addr);
+		if(_audio->GetPcmReadMode()) {
+			_audio->HandlePcmRead(addr, value);
+		}
+		return value;
+	}
+
 	void WriteRam(uint16_t addr, uint8_t value) override
 	{
 		if(addr >= 0x5C00 && addr <= 0x5FFF && _extendedRamMode <= 1 && !_ppuInFrame) {


### PR DESCRIPTION
Based on Heemin's changes in PR #96. Tested with his mmc5_pcmread_test ROM in that PR. There's some kind of MMC5 audio clipping problem which we'll look into in a separate PR.