### PR TITLE
PCE: Fixed CD-ROM playback for WAV files incorrectly interpreting the WAV header as audio samples

### DIFF
--- a/Core/Shared/CdReader.cpp
+++ b/Core/Shared/CdReader.cpp
@@ -4,6 +4,7 @@
 #include "Utilities/StringUtilities.h"
 #include "Utilities/FolderUtilities.h"
 #include "Utilities/magic_enum.hpp"
+#include "Utilities/Audio/WavReader.h"
 
 struct CueIndexEntry
 {
@@ -25,9 +26,16 @@ struct CueTrackEntry
 	vector<CueIndexEntry> Indexes;
 };
 
+enum class CueFileFormat
+{
+	Binary,
+	Wave
+};
+
 struct CueFileEntry
 {
 	string Filename;
+	CueFileFormat Format;
 	vector<CueTrackEntry> Tracks;
 };
 
@@ -68,7 +76,24 @@ bool CdReader::LoadCue(VirtualFile& cueFile, DiscInfo& disc)
 				if(cueFile.IsArchive()) {
 					dataFile = VirtualFile(cueFile.GetFilePath(), filename);
 				}
-				files.push_back({ dataFile });
+
+				vector<string> fileEntry = StringUtilities::Split(StringUtilities::ToUpper(line), ' ');
+				string fileFormat;
+				if(fileEntry.size() > 0) {
+					fileFormat = fileEntry[fileEntry.size() - 1];
+				}
+
+				CueFileEntry entry = { dataFile };
+
+				if(fileFormat == "BINARY") {
+					entry.Format = CueFileFormat::Binary;
+				} else if(fileFormat == "WAVE") {
+					entry.Format = CueFileFormat::Wave;
+				} else {
+					MessageManager::Log("[CUE] Unsupported file format: " + fileFormat);
+					return false;
+				}
+				files.push_back(entry);
 			} else {
 				MessageManager::Log("[CUE] Invalid FILE entry");
 				return false;
@@ -165,7 +190,19 @@ bool CdReader::LoadCue(VirtualFile& cueFile, DiscInfo& disc)
 			return false;
 		}
 
-		disc.Files.push_back(files[i].Filename);
+		uint32_t fileOffset = 0;
+		if(files[i].Format == CueFileFormat::Wave) {
+			vector<uint8_t> headerData;
+			physicalFile.ReadChunk(headerData, 0, 100);
+			WavHeader header = WavReader::GetHeader(headerData.data(), (uint32_t)headerData.size(), (uint32_t)physicalFile.GetSize());
+			if(!header.Valid || header.BitsPerSample != 16 || header.ChannelCount != 2 || header.SampleRate != 44100) {
+				MessageManager::Log("[CUE] Unsupported WAVE file (must be 16-bit, stereo and 44,100 Hz): " + files[i].Filename);
+				return false;
+			}
+			fileOffset = header.HeaderSize;
+		}
+
+		disc.Files.push_back({ files[i].Filename });
 		int startSector = i == 0 ? 0 : (disc.Tracks[disc.Tracks.size() - 1].LastSector + 1);
 		for(size_t j = 0; j < files[i].Tracks.size(); j++) {
 			CueTrackEntry entry = files[i].Tracks[j];
@@ -225,6 +262,7 @@ bool CdReader::LoadCue(VirtualFile& cueFile, DiscInfo& disc)
 			if(trk.HasLeadIn && !entry.PreGap.HasGap) {
 				trk.FileOffset += (trk.StartPosition.ToLba() - trk.LeadInPosition.ToLba()) * trk.GetSectorSize();
 			}
+			trk.FileOffset += fileOffset;
 			trk.FileIndex = (uint32_t)disc.Files.size() - 1;
 
 			disc.Tracks.push_back(trk);

--- a/Utilities/Audio/WavReader.cpp
+++ b/Utilities/Audio/WavReader.cpp
@@ -1,53 +1,62 @@
 #include "pch.h"
 #include "Utilities/Audio/WavReader.h"
 
-unique_ptr<WavReader> WavReader::Create(uint8_t* wavData, uint32_t length)
+WavHeader WavReader::GetHeader(uint8_t* wavData, uint32_t dataLength, uint32_t fileLength)
 {
-	//Basic WAV file read checks (should be using FourCC logic instead, but this will do for now)
-	if(!wavData || length < 100) {
-		return nullptr;
+	WavHeader header = {};
+	if(!wavData || dataLength < 100) {
+		return header;
 	}
+
 	if(memcmp(wavData, "RIFF", 4) || memcmp(wavData + 8, "WAVE", 4) || memcmp(wavData + 12, "fmt ", 4)) {
-		return nullptr;
+		return header;
 	}
 
 	uint32_t riffSize = wavData[4] | (wavData[5] << 8) | (wavData[6] << 16) | (wavData[7] << 24);
-	if(riffSize + 8 != length) {
+	if(riffSize + 8 != fileLength) {
 		//Invalid RIFF header (length does not match file size)
-		return nullptr;
-	}
-
-	uint32_t channelCount = wavData[22] | (wavData[23] << 8);
-	if(channelCount != 1) {
-		//Only mono files are supported at the moment
-		return nullptr;
+		return header;
 	}
 
 	uint32_t fmtSize = wavData[16] | (wavData[17] << 8) | (wavData[18] << 16) | (wavData[19] << 24);
+	if(fmtSize > 50) {
+		return header;
+	}
+
 	if(memcmp(wavData + 20 + fmtSize, "data", 4)) {
 		//Couldn't find data chunk
+		return header;
+	}
+
+	header.Valid = true;
+	header.FmtSize = fmtSize;
+	header.HeaderSize = 28 + header.FmtSize;
+	header.DataSize = wavData[24 + fmtSize] | (wavData[25 + fmtSize] << 8) | (wavData[26 + fmtSize] << 16) | (wavData[27 + fmtSize] << 24);
+	header.ChannelCount = wavData[22] | (wavData[23] << 8);
+	header.BitsPerSample = wavData[34] | (wavData[35] << 8);
+	header.SampleRate = wavData[24] | (wavData[25] << 8) | (wavData[26] << 16) | (wavData[27] << 24);
+
+	return header;
+}
+
+unique_ptr<WavReader> WavReader::Create(uint8_t* wavData, uint32_t length)
+{
+	//Basic WAV file read checks (should be using FourCC logic instead, but this will do for now)
+	WavHeader header = GetHeader(wavData, length, length);
+	if(!header.Valid || header.ChannelCount != 1 || header.BitsPerSample != 16) {
 		return nullptr;
 	}
 
-	uint32_t dataSize = wavData[24 + fmtSize] | (wavData[25 + fmtSize] << 8) | (wavData[26 + fmtSize] << 16) | (wavData[27 + fmtSize] << 24);
-	if(dataSize + 28 + fmtSize > length) {
+	if(header.DataSize + header.HeaderSize > length) {
 		//data chunk is too big
 		return nullptr;
 	}
 
-	uint32_t bitsPerSample = wavData[34] | (wavData[35] << 8);
-	if(bitsPerSample != 16) {
-		//Only support 16-bit samples for now
-		return nullptr;
-	}
-
-	uint32_t sampleRate = wavData[24] | (wavData[25] << 8) | (wavData[26] << 16) | (wavData[27] << 24);
-
 	unique_ptr<WavReader> r(new WavReader());
 	r->_fileData = wavData;
 	r->_fileSize = length;
-	r->_fileSampleRate = sampleRate;
-	r->_dataStartOffset = 28 + fmtSize;
+	r->_fileSampleRate = header.SampleRate;
+	r->_dataStartOffset = header.HeaderSize;
 	return r;
 }
 

--- a/Utilities/Audio/WavReader.h
+++ b/Utilities/Audio/WavReader.h
@@ -2,6 +2,17 @@
 #include "pch.h"
 #include "Utilities/Audio/HermiteResampler.h"
 
+struct WavHeader
+{
+	bool Valid;
+	uint32_t HeaderSize;
+	uint32_t FmtSize;
+	uint32_t DataSize;
+	uint32_t SampleRate;
+	uint32_t BitsPerSample;
+	uint32_t ChannelCount;
+};
+
 class WavReader
 {
 private:
@@ -22,6 +33,8 @@ private:
 public:
 	static unique_ptr<WavReader> Create(uint8_t* wavData, uint32_t length);
 	~WavReader();
+
+	static WavHeader GetHeader(uint8_t* wavData, uint32_t dataLength, uint32_t fileLength);
 
 	void Play(uint32_t startSample);
 	bool IsPlaybackOver();


### PR DESCRIPTION
With these changes, the .cue file parser now correctly reads the "BINARY", "WAVE", etc. markers at the end of FILE entries. It rejects everything except BINARY and WAVE.

For WAVE files, it'll attempt to load the file's header as if it was a .wav file (regardless of the filename). If the file doesn't appear to be a .wav file, it will be rejected. If it's a valid .wav file and is a 16-bit, stereo, 44,100 Hz track, the loader will adjust the file offset to skip the .wav file's header (~44 bytes). This avoids the PCE cd-rom playing the .wav header as samples (and allows the game to play the last few samples in the file.

WavReader was slightly modified to allow reusing the header parsing code. This file is only used when playing NES .studybox files - as far as I can tell, this is still working correctly.