### PR TITLE
SNES: Add Turbo File Twin support

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -29,6 +29,8 @@
     <ClInclude Include="NES\Mappers\Nintendo\CnromProtect.h" />
     <ClInclude Include="NES\Mappers\Unlicensed\Mapper487.h" />
     <ClInclude Include="NES\OpnInterface.h" />
+    <ClInclude Include="SNES\Input\AsciiTurboFileTwinStf.h" />
+    <ClInclude Include="SNES\Input\AsciiTurboFileTwinTf2.h" />
     <ClInclude Include="SNES\Input\SnesNttDataKeypad.h" />
     <ClInclude Include="SMS\Input\ColecoVisionController.h" />
     <ClInclude Include="Debugger\AddressInfo.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -2988,6 +2988,12 @@
     <ClInclude Include="SNES\Input\SnesNttDataKeypad.h">
       <Filter>SNES\Input</Filter>
     </ClInclude>
+    <ClInclude Include="SNES\Input\AsciiTurboFileTwinStf.h">
+      <Filter>SNES\Input</Filter>
+    </ClInclude>
+    <ClInclude Include="SNES\Input\AsciiTurboFileTwinTf2.h">
+      <Filter>SNES\Input</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Shared\Video\RotateFilter.cpp">

--- a/Core/NES/Input/AsciiTurboFile.h
+++ b/Core/NES/Input/AsciiTurboFile.h
@@ -6,6 +6,7 @@
 #include "Shared/BatteryManager.h"
 #include "Shared/Interfaces/IBattery.h"
 #include "Utilities/Serializer.h"
+#include "Utilities/BitUtilities.h"
 
 class AsciiTurboFile : public BaseControlDevice, public IBattery
 {
@@ -46,7 +47,7 @@ public:
 	uint8_t ReadRam(uint16_t addr) override
 	{
 		if(addr == 0x4017) {
-			return ((_data[_position / 8] >> (_position % 8)) & 0x01) << 2;
+			return BitUtilities::GetBitInArray(_data, FileSize, _position) << 2;
 		}
 		return 0;
 	}
@@ -59,8 +60,7 @@ public:
 
 		if(!(value & 0x04) && (_lastWrite & 0x04)) {
 			//Clock, perform write, increase position
-			_data[_position / 8] &= ~(1 << (_position % 8));
-			_data[_position / 8] |= (value & 0x01) << (_position % 8);
+			BitUtilities::SetBitInArray(_data, FileSize, _position, (value & 0x01) == 0x01);
 			_position = (_position + 1) & (AsciiTurboFile::BitCount - 1);
 		}
 

--- a/Core/NES/NesConsole.cpp
+++ b/Core/NES/NesConsole.cpp
@@ -400,10 +400,6 @@ void NesConsole::SaveBattery()
 	if(_mapper) {
 		_mapper->SaveBattery();
 	}
-
-	if(_controlManager) {
-		_controlManager->SaveBattery();
-	}
 }
 
 ShortcutState NesConsole::IsShortcutAllowed(EmulatorShortcut shortcut, uint32_t shortcutParam)

--- a/Core/NES/NesControlManager.cpp
+++ b/Core/NES/NesControlManager.cpp
@@ -8,7 +8,6 @@
 #include "Shared/Interfaces/IInputProvider.h"
 #include "Shared/Interfaces/IInputRecorder.h"
 #include "Shared/MessageManager.h"
-#include "Shared/BatteryManager.h"
 #include "Shared/Emulator.h"
 #include "Shared/KeyManager.h"
 #include "Shared/SystemActionManager.h"
@@ -225,16 +224,6 @@ void NesControlManager::UpdateInputState()
 
 	//Used by VS System games
 	RemapControllerButtons();
-}
-
-void NesControlManager::SaveBattery()
-{
-	for(shared_ptr<BaseControlDevice>& device : _controlDevices) {
-		shared_ptr<IBattery> batteryDevice = std::dynamic_pointer_cast<IBattery>(device);
-		if(batteryDevice) {
-			batteryDevice->SaveBattery();
-		}
-	}
 }
 
 uint8_t NesControlManager::ReadRam(uint16_t addr)

--- a/Core/NES/NesControlManager.h
+++ b/Core/NES/NesControlManager.h
@@ -38,8 +38,6 @@ public:
 	void UpdateControlDevices() override;
 	void UpdateInputState() override;
 
-	void SaveBattery();
-
 	void Reset(bool softReset) override;
 
 	bool IsKeyboardConnected() override;

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -1,0 +1,150 @@
+#pragma once
+#include "pch.h"
+#include "Shared/BaseControlDevice.h"
+#include "Shared/Emulator.h"
+#include "Shared/BatteryManager.h"
+#include "Shared/Interfaces/IBattery.h"
+#include "Utilities/Serializer.h"
+
+class AsciiTurboFileTwinStf : public BaseControlDevice, public IBattery
+{
+private:
+	// Data access
+	static constexpr int FileSize = 128 * 1024;
+	uint32_t _position = 0;
+	uint8_t _data[AsciiTurboFileTwinStf::FileSize] = {};
+	uint8_t _currentByte = 0; // 8-bit shift register; current read/write byte
+
+	// Command state
+	bool _writeMode = false;
+	bool _readMode = false;
+	bool _firstAccess = false; // First data access after entering write mode or read mode
+	bool _didReadWithStrobe = false; // Were any $4017 reads done while strobe was on?
+	uint32_t _newCommand = 0; // 28-bit shift register
+
+	// Status report
+	uint32_t _stateBuffer = 0; // For the status report
+
+	SnesConsole* _console = nullptr;
+
+protected:
+	void Serialize(Serializer& s) override
+	{
+		BaseControlDevice::Serialize(s);
+		SVArray(_data, AsciiTurboFileTwinStf::FileSize);
+		SV(_currentByte);
+		SV(_position);
+		SV(_writeMode);
+		SV(_readMode);
+		SV(_firstAccess);
+		SV(_didReadWithStrobe);
+		SV(_newCommand);
+	}
+
+public:
+	AsciiTurboFileTwinStf(SnesConsole* console) : BaseControlDevice(console->GetEmulator(), ControllerType::AsciiTurboFileTwinStf, BaseControlDevice::ExpDevicePort)
+	{
+		_console = console;
+	}
+
+	void Init() override
+	{
+		_console->InitializeRam(_data, AsciiTurboFileTwinStf::FileSize);
+		_emu->GetBatteryManager()->LoadBattery(".turbofile_stf.sav", _data, AsciiTurboFileTwinStf::FileSize);
+	}
+
+	void SaveBattery() override
+	{
+		_emu->GetBatteryManager()->SaveBattery(".turbofile_stf.sav", _data, AsciiTurboFileTwinStf::FileSize);
+	}
+
+	void RefreshStateBuffer() override
+	{
+		_stateBuffer = 0b011111110111000000000000 | // Controller type $E, and then disambiguated with $FE
+			((uint8_t)_writeMode << 24) |
+			((uint8_t)_readMode << 25);
+		// Bit 26 is 1 if batteries are missing?
+		// Bit 27 is 1 if write protect is on
+		// Bits 28-31 are capacity; 0 = 128 KiB
+	}
+
+	uint8_t ReadRam(uint16_t addr) override
+	{
+		uint8_t output = 0;
+
+		if(addr == 0x4017) {
+			StrobeProcessRead();
+
+			// Get one bit from the status
+			output = _stateBuffer & 0x01;
+			_stateBuffer >>= 1;
+			_stateBuffer |= 1 << 31; // All bits after the first 32 are 1s in STF mode
+			if(_strobe) {
+				// Write mode is exited by turning the strobe and off without doing any $4017 reads
+				_didReadWithStrobe = true;
+				// Read mode is exited by doing a $4017 read with strobe
+				_readMode = false;
+				// Write mode is also exited if a $4017 read with strobe is done on the first access
+				if(_firstAccess) {
+					_writeMode = false;
+				}
+			}
+
+			uint8_t ioBit = (_console->GetInternalRegisters()->GetIoPortOutput() & 0x80) ? 0x01 : 0x00;
+
+			_newCommand = (_newCommand >> 1) | (ioBit << 27);
+
+			if(!(_currentByte & 0x01)) {
+				// Second output bit is the opposite of whatever bit is getting shifted out of _currentByte
+				output |= 2;
+			}
+			_currentByte >>= 1;
+			if(_writeMode && _strobe && ioBit) {
+				_currentByte |= 0x80;
+			}
+		}
+
+		return output;
+	}
+
+	void WriteRam(uint16_t addr, uint8_t value) override
+	{
+		bool prevStrobe = _strobe;
+		_strobe = (value & 0x01) == 0x01;
+
+		if(!prevStrobe && _strobe) {
+			_didReadWithStrobe = false;
+		}
+
+		if(prevStrobe && !_strobe) {
+			if(!_writeMode && !_readMode) {
+				// Potentially start a new command
+				_position = _newCommand >> 8;
+				if((_newCommand & 0xFF) == 0x24) {
+					_readMode = true;
+				} else if((_newCommand & 0xFF) == 0x75) {
+					_writeMode = true;
+				}
+				_firstAccess = true;
+			} else {
+				// Don't do a read or write the first time the strobe is turned on and off
+				// (Allows the program to get a status report and confirm the read/write command worked before accessing data)
+				if(!_firstAccess) {
+					if(_writeMode) {
+						if(_didReadWithStrobe) {
+							_data[_position % FileSize] = _currentByte;
+						} else {
+							_writeMode = false;
+						}
+					} else if(_readMode) {
+						_currentByte = _data[_position % FileSize];
+					}
+					_position++;
+				}
+				_firstAccess = false;
+			}
+			_newCommand = 0;
+			RefreshStateBuffer();
+		}
+	}
+};

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -14,6 +14,7 @@ private:
 	uint32_t _position = 0;
 	uint8_t _data[AsciiTurboFileTwinStf::FileSize] = {};
 	uint8_t _currentByte = 0; // 8-bit shift register; current read/write byte
+	uint8_t _mostRecentByte; // Byte most recently read or written
 
 	// Command state
 	bool _writeMode = false;
@@ -34,6 +35,7 @@ protected:
 		BaseControlDevice::Serialize(s);
 		SVArray(_data, AsciiTurboFileTwinStf::FileSize);
 		SV(_currentByte);
+		SV(_mostRecentByte);
 		SV(_position);
 		SV(_writeMode);
 		SV(_readMode);
@@ -131,6 +133,7 @@ public:
 				}
 				_firstAccess = true;
 				_didWriteAnything = false;
+				_currentByte = _mostRecentByte;
 			} else {
 				// Don't do a read or write the first time the strobe is turned on and off
 				// (Allows the program to get a status report and confirm the read/write command worked before accessing data)
@@ -138,12 +141,14 @@ public:
 					if(_writeMode) {
 						if(_didReadWithStrobe) {
 							_data[_position % FileSize] = _currentByte;
+							_mostRecentByte = _currentByte;
 							_didWriteAnything = true;
 						} else {
 							_writeMode = false;
 						}
 					} else if(_readMode) {
-						_currentByte = _data[_position % FileSize];
+						_mostRecentByte = _data[_position % FileSize];
+						_currentByte = _mostRecentByte;
 					}
 					_position++;
 				}

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -25,7 +25,7 @@ private:
 	uint32_t _newCommand = 0; // 28-bit shift register
 
 	// Status report
-	uint32_t _stateBuffer = 0; // For the status report
+	uint32_t _stateBuffer = 0;
 
 	SnesConsole* _console = nullptr;
 

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -20,6 +20,7 @@ private:
 	bool _readMode = false;
 	bool _firstAccess = false; // First data access after entering write mode or read mode
 	bool _didReadWithStrobe = false; // Were any $4017 reads done while strobe was on?
+	bool _didWriteAnything = false; // Have any writes actually gone through?
 	uint32_t _newCommand = 0; // 28-bit shift register
 
 	// Status report
@@ -38,6 +39,7 @@ protected:
 		SV(_readMode);
 		SV(_firstAccess);
 		SV(_didReadWithStrobe);
+		SV(_didWriteAnything);
 		SV(_newCommand);
 	}
 
@@ -61,7 +63,7 @@ public:
 	void RefreshStateBuffer() override
 	{
 		_stateBuffer = 0b011111110111000000000000 | // Controller type $E, and then disambiguated with $FE
-			((uint8_t)_writeMode << 24) |
+			((uint8_t)(_writeMode & !_didWriteAnything) << 24) |
 			((uint8_t)_readMode << 25);
 		// Bit 26 is 1 if batteries are missing?
 		// Bit 27 is 1 if write protect is on
@@ -117,6 +119,7 @@ public:
 		}
 
 		if(prevStrobe && !_strobe) {
+			RefreshStateBuffer();
 			if(!_writeMode && !_readMode) {
 				// Potentially start a new command
 				_position = _newCommand >> 8;
@@ -126,6 +129,7 @@ public:
 					_writeMode = true;
 				}
 				_firstAccess = true;
+				_didWriteAnything = false;
 			} else {
 				// Don't do a read or write the first time the strobe is turned on and off
 				// (Allows the program to get a status report and confirm the read/write command worked before accessing data)
@@ -133,6 +137,7 @@ public:
 					if(_writeMode) {
 						if(_didReadWithStrobe) {
 							_data[_position % FileSize] = _currentByte;
+							_didWriteAnything = true;
 						} else {
 							_writeMode = false;
 						}
@@ -144,7 +149,6 @@ public:
 				_firstAccess = false;
 			}
 			_newCommand = 0;
-			RefreshStateBuffer();
 		}
 	}
 };

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -65,7 +65,8 @@ public:
 		_stateBuffer = 0b011111110111000000000000 | // Controller type $E, and then disambiguated with $FE
 			((uint8_t)(_writeMode & !_didWriteAnything) << 24) |
 			((uint8_t)_readMode << 25);
-		// Bit 26 is 1 if batteries are missing?
+		// Bit 26 is 1 if batteries are missing
+		// TODOSNES - Verify behavior of bit 26; it may actually be a "low battery" flag, but so far it's only been confirmed that it is 1 when the Turbo File Twin has no batteries in it
 		// Bit 27 is 1 if write protect is on
 		// Bits 28-31 are capacity; 0 = 128 KiB
 	}

--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -12,7 +12,7 @@ private:
 	// Data access
 	static constexpr int FileSize = 128 * 1024;
 	uint32_t _position = 0;
-	uint8_t _data[AsciiTurboFileTwinStf::FileSize] = {};
+	uint8_t* _data = nullptr;
 	uint8_t _currentByte = 0; // 8-bit shift register; current read/write byte
 	uint8_t _mostRecentByte; // Byte most recently read or written
 
@@ -49,6 +49,12 @@ public:
 	AsciiTurboFileTwinStf(SnesConsole* console) : BaseControlDevice(console->GetEmulator(), ControllerType::AsciiTurboFileTwinStf, BaseControlDevice::ExpDevicePort)
 	{
 		_console = console;
+		_data = new uint8_t[AsciiTurboFileTwinStf::FileSize];
+	}
+
+	~AsciiTurboFileTwinStf()
+	{
+		delete[] _data;
 	}
 
 	void Init() override
@@ -140,17 +146,21 @@ public:
 				if(!_firstAccess) {
 					if(_writeMode) {
 						if(_didReadWithStrobe) {
-							_data[_position % FileSize] = _currentByte;
+							if(_position < FileSize) { // Turbo File Twin ignores writes at out-of-range addresses
+								_data[_position] = _currentByte;
+							}
 							_mostRecentByte = _currentByte;
 							_didWriteAnything = true;
 						} else {
 							_writeMode = false;
 						}
 					} else if(_readMode) {
-						_mostRecentByte = _data[_position % FileSize];
+						if(_position < FileSize) { // Turbo File Twin ignores reads at out-of-range addresses
+							_mostRecentByte = _data[_position];
+						}
 						_currentByte = _mostRecentByte;
 					}
-					_position++;
+					_position = (_position + 1) & 0xFFFFF;
 				}
 				_firstAccess = false;
 			}

--- a/Core/SNES/Input/AsciiTurboFileTwinTf2.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinTf2.h
@@ -1,0 +1,101 @@
+#pragma once
+#include "pch.h"
+#include "Shared/BaseControlDevice.h"
+#include "Shared/Emulator.h"
+#include "Shared/BatteryManager.h"
+#include "Shared/Interfaces/IBattery.h"
+#include "Utilities/Serializer.h"
+
+class AsciiTurboFileTwinTf2 : public BaseControlDevice, public IBattery
+{
+private:
+	static constexpr int FileSize = 0x2000;
+	static constexpr int BitCount = FileSize * 8;
+	uint16_t _position = 0;
+	uint8_t _data[AsciiTurboFileTwinTf2::FileSize] = {};
+	uint8_t _unlockCounter = 0; // 4-bit counter - consistently 0 at power on
+	bool _unlocked = false; // Memory access is allowed when true
+
+	SnesConsole* _console = nullptr;
+	uint32_t _stateBuffer = 0; // For the status report
+
+protected:
+	void Serialize(Serializer& s) override
+	{
+		BaseControlDevice::Serialize(s);
+		SVArray(_data, AsciiTurboFileTwinTf2::FileSize);
+		SV(_position);
+		SV(_unlockCounter);
+		SV(_unlocked);
+		SV(_stateBuffer);
+	}
+
+public:
+	AsciiTurboFileTwinTf2(SnesConsole* console) : BaseControlDevice(console->GetEmulator(), ControllerType::AsciiTurboFileTwinTf2, BaseControlDevice::ExpDevicePort)
+	{
+		_console = console;
+	}
+
+	void Init() override
+	{
+		_console->InitializeRam(_data, AsciiTurboFileTwinTf2::FileSize);
+		_emu->GetBatteryManager()->LoadBattery(".turbofile.sav", _data, AsciiTurboFileTwinTf2::FileSize);
+	}
+
+	void SaveBattery() override
+	{
+		_emu->GetBatteryManager()->SaveBattery(".turbofile.sav", _data, AsciiTurboFileTwinTf2::FileSize);
+	}
+
+	void RefreshStateBuffer() override
+	{
+		_stateBuffer = 0b111111110111000000000000; // Controller type $E, and then disambiguated with $FF
+		if(_unlocked) {
+			_stateBuffer |= 1 << 11;
+		}
+	}
+
+	uint8_t ReadRam(uint16_t addr) override
+	{
+		uint8_t output = 0;
+
+		if(addr == 0x4017) {
+			StrobeProcessRead();
+
+			if(_strobe) {
+				_unlockCounter = (_unlockCounter + 1) & 0xF;
+				_position = 0;
+			} else {
+				_unlocked = _unlockCounter == 0xF;
+			}
+
+			// Return one bit from the status
+			output = _stateBuffer & 0x01;
+			_stateBuffer >>= 1;
+			_stateBuffer |= 1 << 23; // All bits after the first 24 are 1s in TFII mode
+
+			// Get current bit in the Turbo File data
+			output |= ((_data[_position / 8] >> (_position % 8)) & 0x01) << 1;
+		}
+
+		return output;
+	}
+
+	void WriteRam(uint16_t addr, uint8_t value) override
+	{
+		bool prevStrobe = _strobe;
+		_strobe = (value & 0x01) == 0x01;
+
+		if(prevStrobe && !_strobe) {
+			RefreshStateBuffer();
+
+			if(_unlocked) {
+				//Perform write and increase position
+				uint8_t ioPort = _console->GetInternalRegisters()->GetIoPortOutput();
+				_data[_position / 8] &= ~(1 << (_position % 8));
+				_data[_position / 8] |= ((ioPort & 0x80) ? 0x01 : 0x00) << (_position % 8);
+				_position = (_position + 1) & (AsciiTurboFileTwinTf2::BitCount - 1);
+			}
+		}
+	}
+};

--- a/Core/SNES/Input/AsciiTurboFileTwinTf2.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinTf2.h
@@ -14,7 +14,7 @@ private:
 	static constexpr int BitCount = FileSize * 8;
 	uint16_t _position = 0;
 	uint8_t _data[AsciiTurboFileTwinTf2::FileSize] = {};
-	uint8_t _unlockCounter = 0; // 4-bit counter - consistently 0 at power on
+	uint8_t _unlockCounter = 0; // 4-bit counter
 	bool _unlocked = false; // Memory access is allowed when true
 
 	SnesConsole* _console = nullptr;
@@ -51,7 +51,7 @@ public:
 	void RefreshStateBuffer() override
 	{
 		_stateBuffer = 0b111111110111000000000000; // Controller type $E, and then disambiguated with $FF
-		if(_unlocked) {
+		if(_unlocked) { // TODOSNES - This bit can also get set without doing a non-strobe $4017 read to actually finish unlocking; further research required
 			_stateBuffer |= 1 << 11;
 		}
 	}
@@ -66,6 +66,7 @@ public:
 			if(_strobe) {
 				_unlockCounter = (_unlockCounter + 1) & 0xF;
 				_position = 0;
+				_unlocked = false; // TODOSNES - Verify that this actually locks it
 			} else {
 				_unlocked = _unlockCounter == 0xF;
 			}

--- a/Core/SNES/Input/AsciiTurboFileTwinTf2.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinTf2.h
@@ -51,7 +51,9 @@ public:
 	void RefreshStateBuffer() override
 	{
 		_stateBuffer = 0b111111110111000000000000; // Controller type $E, and then disambiguated with $FF
-		if(_unlocked) { // TODOSNES - This bit can also get set without doing a non-strobe $4017 read to actually finish unlocking; further research required
+		if(_unlocked) {
+			// TODOSNES - When a game increments _unlockCounter without doing a $4017 read without strobe,
+			// this bit can somehow get set. That's not implemented here.
 			_stateBuffer |= 1 << 11;
 		}
 	}
@@ -63,10 +65,13 @@ public:
 		if(addr == 0x4017) {
 			StrobeProcessRead();
 
+			// TODOSNES - The unlock and position reset logic does not match hardware in all cases,
+			// but does seem to match what happens when games read $4017 without strobe after changing _unlockCounter,
+			// which ASCII games do. More research is required to figure out what really happens.
 			if(_strobe) {
 				_unlockCounter = (_unlockCounter + 1) & 0xF;
 				_position = 0;
-				_unlocked = false; // TODOSNES - Verify that this actually locks it
+				_unlocked = false;
 			} else {
 				_unlocked = _unlockCounter == 0xF;
 			}
@@ -91,7 +96,10 @@ public:
 			RefreshStateBuffer();
 
 			if(_unlocked) {
-				//Perform write and increase position
+				// TODOSNES - The 32 KiB of memory that TFII has access to is 8-bit memory, and it seems to be possible
+				// to write to unintended bits when the program stops writing at a position that's not at a byte boundary.
+
+				// Perform write and increase position
 				uint8_t ioPort = _console->GetInternalRegisters()->GetIoPortOutput();
 				BitUtilities::SetBitInArray(_data, FileSize, _position, (ioPort & 0x80) == 0x80);
 				_position = (_position + 1) & (AsciiTurboFileTwinTf2::BitCount - 1);

--- a/Core/SNES/Input/AsciiTurboFileTwinTf2.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinTf2.h
@@ -5,6 +5,7 @@
 #include "Shared/BatteryManager.h"
 #include "Shared/Interfaces/IBattery.h"
 #include "Utilities/Serializer.h"
+#include "Utilities/BitUtilities.h"
 
 class AsciiTurboFileTwinTf2 : public BaseControlDevice, public IBattery
 {
@@ -75,9 +76,8 @@ public:
 			_stateBuffer |= 1 << 23; // All bits after the first 24 are 1s in TFII mode
 
 			// Get current bit in the Turbo File data
-			output |= ((_data[_position / 8] >> (_position % 8)) & 0x01) << 1;
+			output |= BitUtilities::GetBitInArray(_data, FileSize, _position) << 1;
 		}
-
 		return output;
 	}
 
@@ -92,8 +92,7 @@ public:
 			if(_unlocked) {
 				//Perform write and increase position
 				uint8_t ioPort = _console->GetInternalRegisters()->GetIoPortOutput();
-				_data[_position / 8] &= ~(1 << (_position % 8));
-				_data[_position / 8] |= ((ioPort & 0x80) ? 0x01 : 0x00) << (_position % 8);
+				BitUtilities::SetBitInArray(_data, FileSize, _position, (ioPort & 0x80) == 0x80);
 				_position = (_position + 1) & (AsciiTurboFileTwinTf2::BitCount - 1);
 			}
 		}

--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -270,10 +270,6 @@ void SnesConsole::SaveBattery()
 	if(_cart) {
 		_cart->SaveBattery();
 	}
-
-	if(_controlManager) {
-		_controlManager->SaveBattery();
-	}
 }
 
 BaseVideoFilter* SnesConsole::GetVideoFilter(bool getDefaultFilter)

--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -270,6 +270,10 @@ void SnesConsole::SaveBattery()
 	if(_cart) {
 		_cart->SaveBattery();
 	}
+
+	if(_controlManager) {
+		_controlManager->SaveBattery();
+	}
 }
 
 BaseVideoFilter* SnesConsole::GetVideoFilter(bool getDefaultFilter)

--- a/Core/SNES/SnesControlManager.cpp
+++ b/Core/SNES/SnesControlManager.cpp
@@ -15,6 +15,8 @@
 #include "SNES/Input/Multitap.h"
 #include "SNES/Input/SuperScope.h"
 #include "SNES/Input/SnesNttDataKeypad.h"
+#include "SNES/Input/AsciiTurboFileTwinTf2.h"
+#include "SNES/Input/AsciiTurboFileTwinStf.h"
 #include "Shared/EventType.h"
 #include "Utilities/Serializer.h"
 #include "Shared/SystemActionManager.h"
@@ -72,6 +74,13 @@ shared_ptr<BaseControlDevice> SnesControlManager::CreateControllerDevice(Control
 		case ControllerType::SnesNttDataKeypad:
 			device.reset(new SnesNttDataKeypad(_emu, port, port == 0 ? cfg.Port1.Keys : cfg.Port2.Keys));
 			break;
+
+		case ControllerType::AsciiTurboFileTwinTf2:
+			device.reset(new AsciiTurboFileTwinTf2(_console));
+			break;
+		case ControllerType::AsciiTurboFileTwinStf:
+			device.reset(new AsciiTurboFileTwinStf(_console));
+			break;
 	}
 
 	return device;
@@ -86,6 +95,7 @@ void SnesControlManager::UpdateControlDevices()
 	}
 
 	auto lock = _deviceLock.AcquireSafe();
+	SaveBattery();
 	ClearDevices();
 	for(int i = 0; i < 2; i++) {
 		shared_ptr<BaseControlDevice> device = CreateControllerDevice(i == 0 ? cfg.Port1.Type : cfg.Port2.Type, i);

--- a/Core/Shared/BaseControlManager.cpp
+++ b/Core/Shared/BaseControlManager.cpp
@@ -11,6 +11,7 @@
 #include "Shared/EventType.h"
 #include "Shared/MessageManager.h"
 #include "Utilities/Serializer.h"
+#include "Interfaces/IBattery.h"
 
 BaseControlManager::BaseControlManager(Emulator* emu, CpuType cpuType)
 {
@@ -230,4 +231,14 @@ uint32_t BaseControlManager::GetPollCounter()
 void BaseControlManager::SetPollCounter(uint32_t value)
 {
 	_pollCounter = value;
+}
+
+void BaseControlManager::SaveBattery()
+{
+	for(shared_ptr<BaseControlDevice>& device : _controlDevices) {
+		shared_ptr<IBattery> batteryDevice = std::dynamic_pointer_cast<IBattery>(device);
+		if(batteryDevice) {
+			batteryDevice->SaveBattery();
+		}
+	}
 }

--- a/Core/Shared/BaseControlManager.h
+++ b/Core/Shared/BaseControlManager.h
@@ -55,6 +55,8 @@ public:
 	uint32_t GetPollCounter();
 	void SetPollCounter(uint32_t value);
 
+	void SaveBattery();
+
 	virtual void Reset(bool softReset) {}
 
 	void RegisterInputProvider(IInputProvider* provider);

--- a/Core/Shared/Emulator.cpp
+++ b/Core/Shared/Emulator.cpp
@@ -286,7 +286,7 @@ void Emulator::Stop(bool sendNotification, bool preventRecentGameSave, bool save
 
 	if(_console && saveBattery) {
 		//Only save battery on power off, otherwise SaveBattery() is called by LoadRom()
-		_console->SaveBattery();
+		SaveBattery();
 	}
 
 	if(!preventRecentGameSave && _console && !_settings->GetPreferences().DisableGameSelectionScreen && !_audioPlayerHud) {
@@ -419,7 +419,7 @@ bool Emulator::InternalLoadRom(VirtualFile romFile, VirtualFile patchFile, bool 
 
 	if(_console) {
 		//Make sure the battery is saved to disk before we load another game (or reload the same game)
-		_console->SaveBattery();
+		SaveBattery();
 	}
 
 	_soundMixer->StopAudio();
@@ -597,6 +597,14 @@ void Emulator::TryLoadRom(VirtualFile& romFile, LoadRomResult& result, unique_pt
 				_batteryManager->Initialize(FolderUtilities::GetFilename(_rom.RomFile.GetFileName(), false), hasBattery);
 			}
 		}
+	}
+}
+
+void Emulator::SaveBattery()
+{
+	_console->SaveBattery();
+	if(_console->GetControlManager()) {
+		_console->GetControlManager()->SaveBattery();
 	}
 }
 

--- a/Core/Shared/Emulator.h
+++ b/Core/Shared/Emulator.h
@@ -134,6 +134,8 @@ private:
 	void TryLoadRom(VirtualFile& romFile, LoadRomResult& result, unique_ptr<IConsole>& console, bool useFileSignature);
 	template<typename T> void TryLoadRom(VirtualFile& romFile, LoadRomResult& result, unique_ptr<IConsole>& console, bool useFileSignature);
 
+	void SaveBattery();
+
 	void InitConsole(unique_ptr<IConsole>& newConsole, ConsoleMemoryInfo originalConsoleMemory[], bool preserveRom);
 
 	bool InternalLoadRom(VirtualFile romFile, VirtualFile patchFile, bool stopRom = true, bool forPowerCycle = false);

--- a/Core/Shared/SettingTypes.h
+++ b/Core/Shared/SettingTypes.h
@@ -183,6 +183,8 @@ enum class ControllerType
 	Multitap,
 	SnesRumbleController,
 	SnesNttDataKeypad,
+	AsciiTurboFileTwinTf2,
+	AsciiTurboFileTwinStf,
 
 	//NES controllers
 	NesController,

--- a/UI/Config/InputConfig.cs
+++ b/UI/Config/InputConfig.cs
@@ -353,6 +353,8 @@ namespace Mesen.Config
 		Multitap,
 		SnesRumbleController,
 		SnesNttDataKeypad,
+		AsciiTurboFileTwinTf2,
+		AsciiTurboFileTwinStf,
 
 		//NES controllers
 		NesController,

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -2019,6 +2019,8 @@ E
 			<Value ID="SuperScope">Super Scope</Value>
 			<Value ID="Multitap">Super Multitap</Value>
 			<Value ID="SnesNttDataKeypad">SNES NTT Data Keypad</Value>
+			<Value ID="AsciiTurboFileTwinTf2">Turbo File Twin (TFII mode)</Value>
+			<Value ID="AsciiTurboFileTwinStf">Turbo File Twin (STF mode)</Value>
 
 			<Value ID="NesController">NES Controller</Value>
 			<Value ID="FamicomController">Famicom Controller</Value>

--- a/UI/ViewModels/SnesInputConfigViewModel.cs
+++ b/UI/ViewModels/SnesInputConfigViewModel.cs
@@ -30,6 +30,8 @@ namespace Mesen.ViewModels
 			ControllerType.SnesMouse,
 			ControllerType.SuperScope,
 			ControllerType.SnesNttDataKeypad,
+			ControllerType.AsciiTurboFileTwinTf2,
+			ControllerType.AsciiTurboFileTwinStf,
 			ControllerType.Multitap,
 		};
 

--- a/Utilities/BitUtilities.h
+++ b/Utilities/BitUtilities.h
@@ -15,4 +15,20 @@ public:
 	{
 		return (uint8_t)(value >> bitNumber);
 	}
+
+	template<typename T>
+	__forceinline static void SetBitInArray(T array[], size_t byteCount, size_t position, bool value)
+	{
+		position %= byteCount;
+		array[position / 8] &= ~(1 << (position % 8));
+		if(value) {
+			array[position / 8] |= 1 << (position % 8);
+		}
+	}
+
+	template<typename T>
+	__forceinline static uint8_t GetBitInArray(T array[], size_t byteCount, size_t position)
+	{
+		return (uint8_t)((array[(position / 8) % byteCount] >> (position % 8)) & 0x01);
+	}
 };

--- a/Utilities/BitUtilities.h
+++ b/Utilities/BitUtilities.h
@@ -19,7 +19,7 @@ public:
 	template<typename T>
 	__forceinline static void SetBitInArray(T array[], size_t byteCount, size_t position, bool value)
 	{
-		position %= byteCount;
+		position %= byteCount * 8;
 		array[position / 8] &= ~(1 << (position % 8));
 		if(value) {
 			array[position / 8] |= 1 << (position % 8);


### PR DESCRIPTION
Implements both TFII and STF modes, and the implementation was based on trying to deliberately explore edge cases and figure out the underlying behavior with tests. Licensed games using Turbo File Twin are currently untested.

There's currently a known inaccuracy where, in STF mode, if you start a write command and read the status twice without writing any data, the second status read seems to exit write mode while also misreporting that it's still active. This needs more research but is such a specific edge case that it shouldn't affect any game that isn't deliberately trying to do something weird.