### PR TITLE
NES: Oversize discrete mapper boards

### DIFF
--- a/Core/NES/Mappers/Nintendo/UnRom_180.h
+++ b/Core/NES/Mappers/Nintendo/UnRom_180.h
@@ -17,6 +17,6 @@ protected:
 
 	void WriteRegister(uint16_t addr, uint8_t value) override
 	{
-		SelectPrgPage(1, value & 0x07);
+		SelectPrgPage(1, value);
 	}
 };

--- a/Core/NES/Mappers/Unlicensed/Nina01.h
+++ b/Core/NES/Mappers/Unlicensed/Nina01.h
@@ -18,9 +18,9 @@ protected:
 	void WriteRegister(uint16_t addr, uint8_t value) override
 	{
 		switch(addr) {
-			case 0x7FFD: SelectPrgPage(0, value & 0x01); break;
-			case 0x7FFE: SelectChrPage(0, value & 0x0F); break;
-			case 0x7FFF: SelectChrPage(1, value & 0x0F); break;
+			case 0x7FFD: SelectPrgPage(0, value); break;
+			case 0x7FFE: SelectChrPage(0, value); break;
+			case 0x7FFF: SelectChrPage(1, value); break;
 		}
 
 		WritePrgRam(addr, value);


### PR DESCRIPTION
This simply removes bit AND operation in few discrete board bank number writes such as NINA-001/002 and [180](https://www.nesdev.org/wiki/INES_Mapper_180).