### PR TITLE
MMC5: Reduce the volume of the PCM channel by around 33%

### DIFF
--- a/Core/NES/Mappers/Audio/Mmc5Audio.h
+++ b/Core/NES/Mappers/Audio/Mmc5Audio.h
@@ -84,7 +84,7 @@ protected:
 
 		//"The sound output of the square channels are equivalent in volume to the corresponding APU channels"
 		//"The polarity of all MMC5 channels is reversed compared to the APU."
-		int16_t summedOutput = -(_square1.GetOutput() + _square2.GetOutput() + _pcmOutput);
+		int16_t summedOutput = -(_square1.GetOutput() * 3 + _square2.GetOutput() * 3 + _pcmOutput);
 		if(summedOutput != _lastOutput) {
 			_console->GetApu()->AddExpansionAudioDelta(AudioChannel::MMC5, summedOutput - _lastOutput);
 			_lastOutput = summedOutput;

--- a/Core/NES/NesSoundMixer.cpp
+++ b/Core/NES/NesSoundMixer.cpp
@@ -184,7 +184,7 @@ int16_t NesSoundMixer::GetOutputVolume(bool forRightChannel)
 
 	return (int16_t)(squareVolume + tndVolume +
 		GetChannelOutput(AudioChannel::FDS, forRightChannel) * 20 +
-		GetChannelOutput(AudioChannel::MMC5, forRightChannel) * 43 +
+		GetChannelOutput(AudioChannel::MMC5, forRightChannel) * 14 +
 		GetChannelOutput(AudioChannel::Namco163, forRightChannel) * 20 +
 		GetChannelOutput(AudioChannel::Sunsoft5B, forRightChannel) * 15 +
 		GetChannelOutput(AudioChannel::VRC6, forRightChannel) * 5 +


### PR DESCRIPTION
The previous implementation allowed the MMC5 PCM channel to reach a maximum amplitude of 16x that of the MMC5 Pulse channels. This seems incorrect from a reading of the [wiki](https://www.nesdev.org/wiki/MMC5_audio), which suggests that the volume attainable should be roughly 2x that of the APU DMC channel. Using the [mixing formula for the APU](https://www.nesdev.org/wiki/APU_Mixer) as a guide, I arrived at around a 33% reduction in volume to match this documented intent.

I don't especially trust this calculation, as the MMC5 channels shouldn't exhibit the same nonlinearity as the built-in channels, but I lack the means to perform hardware testing. Take this figure with a grain of salt.

In the short term, this stops the MMC5 PCM channel from clipping very badly if actually driven at its maximum amplitude, which affects homebrew and modern chiptune. I spot checked the only known licensed game to use the feature (Shin 4 Nin Uchi Mahjong - Yakuman Tengoku) and observed no regressions.