### PR TITLE
Netplay: Fixed game crashing when connecting to server

### DIFF
--- a/Core/Netplay/GameClientConnection.cpp
+++ b/Core/Netplay/GameClientConnection.cpp
@@ -225,9 +225,7 @@ void GameClientConnection::InitControlDevice()
 
 void GameClientConnection::ProcessNotification(ConsoleNotificationType type, void* parameter)
 {
-	if(type == ConsoleNotificationType::ConfigChanged) {
-		InitControlDevice();
-	} else if(type == ConsoleNotificationType::GameLoaded) {
+	if(type == ConsoleNotificationType::GameLoaded) {
 		_emu->RegisterInputProvider(this);
 	}
 }

--- a/Core/Netplay/GameConnection.cpp
+++ b/Core/Netplay/GameConnection.cpp
@@ -95,6 +95,9 @@ bool GameConnection::ConnectionError()
 void GameConnection::ProcessMessages()
 {
 	NetMessage* message;
+
+	ProcessPendingEvents();
+
 	while((message = ReadMessage()) != nullptr) {
 		//Loop until all messages have been processed
 		message->Initialize();

--- a/Core/Netplay/GameConnection.h
+++ b/Core/Netplay/GameConnection.h
@@ -29,6 +29,7 @@ private:
 
 protected:
 	void Disconnect();
+	virtual void ProcessPendingEvents() {}
 
 public:
 	static constexpr uint8_t SpectatorPort = 0xFF;

--- a/Core/Netplay/GameServerConnection.cpp
+++ b/Core/Netplay/GameServerConnection.cpp
@@ -58,6 +58,7 @@ void GameServerConnection::SendGameInformation()
 	SendNetMessage(gameInfo);
 	SaveStateMessage saveState(_emu);
 	SendNetMessage(saveState);
+	_previousConfig = GetSerializedConfig();
 }
 
 void GameServerConnection::SendMovieData(uint8_t port, ControlDeviceState state)
@@ -146,6 +147,14 @@ void GameServerConnection::ProcessMessage(NetMessage* message)
 	}
 }
 
+void GameServerConnection::ProcessPendingEvents()
+{
+	if(_needSendGameInfo) {
+		SendGameInformation();
+		_needSendGameInfo = false;
+	}
+}
+
 void GameServerConnection::SelectControllerPort(NetplayControllerInfo controller)
 {
 	auto lock = _emu->AcquireLock();
@@ -179,23 +188,16 @@ void GameServerConnection::ProcessNotification(ConsoleNotificationType type, voi
 		case ConsoleNotificationType::GameReset:
 		case ConsoleNotificationType::StateLoaded:
 		case ConsoleNotificationType::CheatsChanged:
-		case ConsoleNotificationType::ConfigChanged:
 			SendGameInformation();
 			break;
 
 		case ConsoleNotificationType::PpuFrameDone: {
 			//Detect any configuration change that impacts emulation
 			//Send a save state to clients if any change is done
-			Serializer s(0, true);
-			EmuSettings* settings = _emu->GetSettings();
-			s.Stream(*settings, "", -1);
-			stringstream currentConfig;
-			s.SaveTo(currentConfig, 0);
-
-			if(_previousConfig != currentConfig.str()) {
-				SendGameInformation();
+			string cfg = GetSerializedConfig();
+			if(_previousConfig != cfg) {
+				_needSendGameInfo = true;
 			}
-			_previousConfig = currentConfig.str();
 			break;
 		}
 
@@ -214,4 +216,14 @@ void GameServerConnection::ProcessNotification(ConsoleNotificationType type, voi
 NetplayControllerInfo GameServerConnection::GetControllerPort()
 {
 	return _controllerPort;
+}
+
+string GameServerConnection::GetSerializedConfig()
+{
+	Serializer s(0, true);
+	EmuSettings* settings = _emu->GetSettings();
+	s.Stream(*settings, "", -1);
+	stringstream cfg;
+	s.SaveTo(cfg, 0);
+	return cfg.str();
 }

--- a/Core/Netplay/GameServerConnection.h
+++ b/Core/Netplay/GameServerConnection.h
@@ -25,6 +25,7 @@ private:
 	string _connectionHash;
 	string _serverPassword;
 	bool _handshakeCompleted = false;
+	bool _needSendGameInfo = false;
 
 	void PushState(ControlDeviceState state);
 	void SendServerInformation();
@@ -35,8 +36,11 @@ private:
 
 	void ProcessHandshakeResponse(HandShakeMessage* message);
 
+	string GetSerializedConfig();
+
 protected:
 	void ProcessMessage(NetMessage* message) override;
+	void ProcessPendingEvents() override;
 
 public:
 	GameServerConnection(GameServer* gameServer, Emulator* emu, unique_ptr<Socket> socket, string serverPassword);

--- a/Core/Netplay/SaveStateMessage.h
+++ b/Core/Netplay/SaveStateMessage.h
@@ -2,7 +2,6 @@
 #include "pch.h"
 #include "Netplay/NetMessage.h"
 #include "Shared/Emulator.h"
-#include "Shared/EmuSettings.h"
 #include "Shared/CheatManager.h"
 #include "Shared/SaveStateManager.h"
 
@@ -11,10 +10,12 @@ class SaveStateMessage : public NetMessage
 private:
 	vector<CheatCode> _activeCheats;
 	vector<uint8_t> _stateData;
+	ConsoleType _consoleType;
 
 protected:
 	void Serialize(Serializer& s) override
 	{
+		SV(_consoleType);
 		SVVector(_stateData);
 		SVVector(_activeCheats);
 	}
@@ -35,13 +36,15 @@ public:
 		uint32_t dataSize = (uint32_t)state.tellp();
 		_stateData.resize(dataSize);
 		state.read((char*)_stateData.data(), dataSize);
+
+		_consoleType = emu->GetConsoleType();
 	}
 
 	void LoadState(Emulator* emu)
 	{
 		std::stringstream ss;
 		ss.write((char*)_stateData.data(), _stateData.size());
-		emu->Deserialize(ss, SaveStateManager::FileFormatVersion, true);
+		emu->Deserialize(ss, SaveStateManager::FileFormatVersion, true, _consoleType, false);
 
 		emu->GetCheatManager()->SetCheats(_activeCheats);
 	}

--- a/Core/Shared/Interfaces/INotificationListener.h
+++ b/Core/Shared/Interfaces/INotificationListener.h
@@ -14,7 +14,6 @@ enum class ConsoleNotificationType
 	DebuggerResumed,
 	PpuFrameDone,
 	ResolutionChanged,
-	ConfigChanged,
 	ExecuteShortcut,
 	ReleaseShortcut,
 	EmulationStopped,

--- a/UI/Debugger/Utilities/DebugWindowManager.cs
+++ b/UI/Debugger/Utilities/DebugWindowManager.cs
@@ -118,7 +118,6 @@ namespace Mesen.Debugger.Utilities
 				case ConsoleNotificationType.ReleaseShortcut:
 				case ConsoleNotificationType.RefreshSoftwareRenderer:
 				case ConsoleNotificationType.CheatsChanged:
-				case ConsoleNotificationType.ConfigChanged:
 				case ConsoleNotificationType.MissingFirmware:
 				case ConsoleNotificationType.RequestConfigChange:
 				case ConsoleNotificationType.ResolutionChanged:

--- a/UI/Interop/NotificationListener.cs
+++ b/UI/Interop/NotificationListener.cs
@@ -72,7 +72,6 @@ namespace Mesen.Interop
 		DebuggerResumed,
 		PpuFrameDone,
 		ResolutionChanged,
-		ConfigChanged,
 		ExecuteShortcut,
 		ReleaseShortcut,
 		EmulationStopped,


### PR DESCRIPTION
The server would send a save state taken inside the PpuFrameDone event when a config change was detected, which is not safe. PpuFrameDone runs in the middle of CPU instructions, which could make the CPU resume execution from an incorrect state/address after the state is loaded.

The "ConfigChanged" event was also completely unused (never triggered by any code), so it was removed.