### PR TITLE
Debugger: Lua - Add disassembly row APIs

### DIFF
--- a/Core/Debugger/LuaApi.cpp
+++ b/Core/Debugger/LuaApi.cpp
@@ -8,6 +8,7 @@
 #include "Debugger/ScriptingContext.h"
 #include "Debugger/MemoryAccessCounter.h"
 #include "Debugger/CdlManager.h"
+#include "Debugger/Disassembler.h"
 #include "Debugger/LabelManager.h"
 #include "Shared/SystemActionManager.h"
 #include "Shared/Video/DebugHud.h"
@@ -54,6 +55,8 @@
 #define checkminparams(x) if(!l.CheckParamCount(x)) { return 0; }
 #define checkinitdone() if(!_context->CheckInitDone()) { error("This function cannot be called outside a callback"); }
 #define checksavestateconditions() if(!_context->IsSaveStateAllowed()) { error("This function must be called inside an exec memory operation callback for the main CPU"); }
+
+static constexpr uint32_t MaxLuaDisassemblyRows = 10000;
 
 Debugger* LuaApi::_debugger = nullptr;
 Emulator* LuaApi::_emu = nullptr;
@@ -145,6 +148,9 @@ int LuaApi::GetLibrary(lua_State* lua)
 		{ "resetAccessCounters", LuaApi::ResetAccessCounters },
 
 		{ "getCdlData", LuaApi::GetCdlData },
+
+		{ "getDisassemblyRows", LuaApi::GetDisassemblyRows },
+		{ "getDisassemblyRowAddress", LuaApi::GetDisassemblyRowAddress },
 
 		{ "addCheat", LuaApi::AddCheat },
 		{ "clearCheats", LuaApi::ClearCheats },
@@ -981,6 +987,91 @@ int LuaApi::GetCdlData(lua_State* lua)
 		lua_rawseti(lua, -2, i);
 	}
 
+	return 1;
+}
+
+static void LuaPushAddressInfo(lua_State* lua, const char* name, const AddressInfo& address)
+{
+	lua_pushstring(lua, name);
+	lua_newtable(lua);
+	lua_pushintvalue(address, address.Address);
+	lua_pushintvalue(type, (int)address.Type);
+	lua_settable(lua, -3);
+}
+
+static void LuaPushEffectiveAddressInfo(lua_State* lua, const EffectiveAddressInfo& effectiveAddress)
+{
+	lua_newtable(lua);
+	lua_pushliteral(lua, "address"); lua_pushinteger(lua, effectiveAddress.Address); lua_settable(lua, -3);
+	lua_pushintvalue(memoryType, (int)effectiveAddress.Type);
+	lua_pushintvalue(valueSize, effectiveAddress.ValueSize);
+	lua_pushboolvalue(showAddress, effectiveAddress.ShowAddress);
+}
+
+static void LuaPushCodeLineData(lua_State* lua, const CodeLineData& row)
+{
+	lua_newtable(lua);
+	lua_pushintvalue(address, row.Address);
+	LuaPushAddressInfo(lua, "absoluteAddress", row.AbsoluteAddress);
+	lua_pushintvalue(opSize, row.OpSize);
+	lua_pushintvalue(flags, row.Flags);
+
+	lua_pushliteral(lua, "effectiveAddress");
+	LuaPushEffectiveAddressInfo(lua, row.EffectiveAddress);
+	lua_settable(lua, -3);
+
+	lua_pushintvalue(value, row.Value);
+	lua_pushintvalue(lineCpuType, (int)row.LineCpuType);
+
+	lua_pushliteral(lua, "byteCode");
+	lua_newtable(lua);
+	for(uint32_t i = 0; i < row.OpSize && i < sizeof(row.ByteCode); i++) {
+		lua_pusharrayvalue(i + 1, row.ByteCode[i]);
+	}
+	lua_settable(lua, -3);
+
+	lua_pushliteral(lua, "text");
+	lua_pushlstring(lua, row.Text, strnlen(row.Text, sizeof(row.Text)));
+	lua_settable(lua, -3);
+	lua_pushliteral(lua, "comment");
+	lua_pushlstring(lua, row.Comment, strnlen(row.Comment, sizeof(row.Comment)));
+	lua_settable(lua, -3);
+}
+
+int LuaApi::GetDisassemblyRows(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	uint32_t rowCount = l.ReadInteger();
+	uint32_t startAddress = l.ReadInteger();
+	CpuType cpuType = (CpuType)l.ReadInteger();
+	checkEnum(CpuType, cpuType, "invalid cpu type");
+	checkparams();
+	errorCond(!_debugger->HasCpuType(cpuType), "This CPU type is not available for the current system");
+	errorCond(rowCount > MaxLuaDisassemblyRows, "Maximum disassembly row count is 10000");
+
+	vector<CodeLineData> rows;
+	rows.resize(rowCount, {});
+	uint32_t returnedRows = rowCount > 0 ? _debugger->GetDisassembler()->GetDisassemblyOutput(cpuType, startAddress, rows.data(), rowCount) : 0;
+
+	lua_newtable(lua);
+	for(uint32_t i = 0; i < returnedRows; i++) {
+		LuaPushCodeLineData(lua, rows[i]);
+		lua_rawseti(lua, -2, i + 1);
+	}
+	return 1;
+}
+
+int LuaApi::GetDisassemblyRowAddress(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	int32_t rowOffset = (int32_t)l.ReadInteger();
+	uint32_t address = l.ReadInteger();
+	CpuType cpuType = (CpuType)l.ReadInteger();
+	checkEnum(CpuType, cpuType, "invalid cpu type");
+	checkparams();
+	errorCond(!_debugger->HasCpuType(cpuType), "This CPU type is not available for the current system");
+
+	lua_pushinteger(lua, _debugger->GetDisassembler()->GetDisassemblyRowAddress(cpuType, address, rowOffset));
 	return 1;
 }
 

--- a/Core/Debugger/LuaApi.h
+++ b/Core/Debugger/LuaApi.h
@@ -102,6 +102,9 @@ public:
 
 	static int GetCdlData(lua_State* lua);
 
+	static int GetDisassemblyRows(lua_State* lua);
+	static int GetDisassemblyRowAddress(lua_State* lua);
+
 private:
 	static FrameInfo InternalGetScreenSize();
 

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -153,6 +153,31 @@
 	],
 	"returnValue": { "type": "Array", "description": "Array of bytes" }
 },
+
+{
+	"name": "getDisassemblyRows",
+	"category": "Miscellaneous",
+	"subcategory": "Disassembly",
+	"description": "Returns a 1-indexed array of tables describing disassembled rows starting at the given address. Each row contains \"address\", \"absoluteAddress\", \"opSize\", \"flags\", \"effectiveAddress\", \"value\", \"lineCpuType\", \"byteCode\", \"text\" and \"comment\". The row count is capped at 10000.\n\nNote: the disassembler is populated lazily as code executes, so freshly loaded regions can return zero rows until they have run.",
+	"parameters": [
+		{ "name": "cpuType", "type": "Enum", "enumName": "cpuType", "description": "CPU type" },
+		{ "name": "startAddress", "type": "Int", "description": "Address of the first row to return" },
+		{ "name": "rowCount", "type": "Int", "description": "Number of rows to return" }
+	],
+	"returnValue": { "type": "Array", "description": "Array of disassembly rows" }
+},
+{
+	"name": "getDisassemblyRowAddress",
+	"category": "Miscellaneous",
+	"subcategory": "Disassembly",
+	"description": "Returns the address that corresponds to a row offset relative to the row containing the given address. Useful for stepping through the disassembly view by row count.",
+	"parameters": [
+		{ "name": "cpuType", "type": "Enum", "enumName": "cpuType", "description": "CPU type" },
+		{ "name": "address", "type": "Int", "description": "Address contained in the reference row" },
+		{ "name": "rowOffset", "type": "Int", "description": "Number of rows to move (positive or negative)" }
+	],
+	"returnValue": { "type": "Int", "description": "Address of the resulting row" }
+},
 {
 	"name": "getCpuState",
 	"category": "Emulation",


### PR DESCRIPTION
## Summary

Adds Lua APIs for reading structured debugger disassembly rows:

- `emu.getDisassemblyRows(cpuType, startAddress, rowCount)`
- `emu.getDisassemblyRowAddress(cpuType, address, rowOffset)`

These expose the debugger/disassembler's existing row data to Lua scripts without adding game-specific interpretation or changing emulator state.

## Motivation

Lua scripts can currently read memory and CPU state, but they cannot ask MesenCE's debugger for the same structured disassembly rows shown by the disassembly view.

This is useful for scripts that need to inspect nearby instructions, log debugger-style disassembly, or correlate runtime state with the debugger's decoded view.

## API

### `emu.getDisassemblyRows(cpuType, startAddress, rowCount)`

Returns a 1-indexed Lua array of disassembly row tables starting at `startAddress`.

Each row includes fields such as:

- `address`
- `absoluteAddress`
- `opSize`
- `flags`
- `effectiveAddress`
- `value`
- `lineCpuType`
- `byteCode`
- `text`
- `comment`

The requested row count is capped at 10000 to avoid accidental large Lua allocations.

Note: disassembly data is populated lazily by the debugger, so a newly loaded or not-yet-executed region may return fewer rows than requested.

### `emu.getDisassemblyRowAddress(cpuType, address, rowOffset)`

Returns the address corresponding to a row offset relative to the row containing `address`.

This mirrors the debugger view's row navigation behavior and lets Lua scripts page or step through disassembly by row count rather than guessing instruction sizes.

## Non-goals

This PR intentionally does not add disassembly search APIs. Search helpers can be proposed separately if this row-reading API shape is acceptable.

## Validation

Tested locally on macOS arm64:

```bash
PATH="/opt/homebrew/opt/dotnet@8/bin:$PATH" \
DOTNET_ROOT="/opt/homebrew/opt/dotnet@8/libexec" \
make clean

PATH="/opt/homebrew/opt/dotnet@8/bin:$PATH" \
DOTNET_ROOT="/opt/homebrew/opt/dotnet@8/libexec" \
make ui
```

Lua documentation JSON validates:

```bash
python3 -m json.tool UI/Debugger/Documentation/LuaDocumentation.json >/dev/null
```

Also tested via `--testRunner` against an SNES ROM:

- `getDisassemblyRows(...)` returned structured rows
- `getDisassemblyRowAddress(...)` returned a row-relative address
- `emu.stop(0)` exited with code 0 after a clean rebuild
