### PR TITLE
CI: Don't attempt to sign macOS build for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
   pull_request:
     branches:
-	   - '*'
+      - '*'
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Build Mesen (AppImage)
         run: |
           ${{ matrix.platform.script }}
+
       - name: Upload Mesen (AppImage)
         uses: actions/upload-artifact@v4
         if: github.event_name != 'pull_request'
@@ -201,6 +202,7 @@ jobs:
           ${{ matrix.make_flags }} make -j$(sysctl -n hw.logicalcpu)
 
       - name: Sign binary
+        if: github.event_name != 'pull_request'
         env:
           APP_NAME: bin/osx-${{ matrix.platform.arch }}/Release/osx-${{ matrix.platform.arch }}/publish/Mesen.app
           CERT_DATA: ${{ secrets.MACOS_CERTIFICATE }}
@@ -226,6 +228,7 @@ jobs:
           codesign --force --deep --timestamp --keychain macos-build.keychain --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"
 
       - name: Zip Mesen.app
+        if: github.event_name != 'pull_request'
         run: |
           ditto -c -k --sequesterRsrc --keepParent bin/osx-${{ matrix.platform.arch }}/Release/osx-${{ matrix.platform.arch }}/publish/Mesen.app bin/osx-${{ matrix.platform.arch }}/Release/Mesen.app.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build Mesen
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+	   - '*'
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,5 +1,13 @@
 name: clang-format Check
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+
 jobs:
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/dotnet-format-check.yml
+++ b/.github/workflows/dotnet-format-check.yml
@@ -1,5 +1,13 @@
 name: dotnet format check
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
+
 jobs:
   dotnet-format:
     runs-on: windows-latest


### PR DESCRIPTION
This failed because the signing certificate is not available when building a PR from a fork.

Also, changed workflow settings to not run "push" workflows on any branch other than the master branch. These checks will run when making PRs, but don't need to run on the branches in this repo.