### PR TITLE
Fix GBA serial timings to pass serial timing tests

### DIFF
--- a/Core/GBA/GbaSerial.h
+++ b/Core/GBA/GbaSerial.h
@@ -133,6 +133,7 @@ public:
 				if(active && !_state.Active) {
 					_state.StartMasterClock = _memoryManager->GetMasterClock();
 					_state.EndMasterClock = _state.StartMasterClock + (_state.InternalShiftClockSpeed2MHz ? 8 : 64) * (_state.TransferWord ? 32 : 8);
+					_state.EndMasterClock += 6;
 					if(_state.IrqEnabled) {
 						_state.IrqMasterClock = _state.EndMasterClock;
 						_memoryManager->SetPendingUpdateFlag();
@@ -156,6 +157,7 @@ public:
 					if(_state.StartMasterClock == _memoryManager->GetMasterClock()) {
 						//Update end based on params
 						_state.EndMasterClock = _state.StartMasterClock + (_state.InternalShiftClockSpeed2MHz ? 8 : 64) * (_state.TransferWord ? 32 : 8);
+						_state.EndMasterClock += 6;
 					}
 					if(_state.IrqEnabled) {
 						_state.IrqMasterClock = _state.EndMasterClock;


### PR DESCRIPTION
Yes, this is weird. There is apparently just an extra 6 cycles for serial transfers, at least as far as testing indicates.

See https://github.com/mgba-emu/suite and https://github.com/alyosha-tas/gba-tests for serial timing tests.