### PR TITLE
NES: Update [OAM1ADDR] decay timestamp during vblank/fblank.

### DIFF
--- a/Core/NES/BaseNesPpu.h
+++ b/Core/NES/BaseNesPpu.h
@@ -115,7 +115,7 @@ protected:
 	uint32_t _ignoreVramRead = 0;
 	int32_t _openBusDecayStamp[8] = {};
 
-	uint64_t _oamDecayCycles[0x40] = {};
+	uint64_t _oamDecayCycles[0x20] = {};
 	bool _corruptOamRow[32] = {};
 
 	bool IsRenderingEnabled();

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -1426,6 +1426,12 @@ template<class T> void NesPpu<T>::ProcessScanlineFirstCycle()
 		SendFrame();
 		_frameCount++;
 	}
+
+	//Refresh the decay timer for the current OAM1 row if in vblank/fblank.
+	//This happens every dot on hardware, but doing it once per scanline should be more than enough while reducing performance cost.
+	if(_enableOamDecay && (_scanline >= 240 || !IsRenderingEnabled())) {
+		_oamDecayCycles[_spriteRamAddr >> 3] = _console->GetCpu()->GetCycleCount();
+	}
 }
 
 template<class T> void NesPpu<T>::UpdateState()


### PR DESCRIPTION
The NES accesses OAM on every single dot. When rendering is off, it uses OAM1ADDR for this, typically guaranteeing that a single row will not decay when rendering is disabled for an extended period of time. This means, for example, that sprite 0 should never decay in Battletoads despite its extended vblank.

This change updates the decay timestamp of the current OAM1ADDR row at the start of every blanking scanline, to simulate this behavior in the common case while minimizing performance impact.