### PR TITLE
NES: Change OAM decay timer length

### DIFF
--- a/Core/NES/NesPpu.h
+++ b/Core/NES/NesPpu.h
@@ -33,7 +33,7 @@ template<class T>
 class NesPpu : public BaseNesPpu
 {
 private:
-	static constexpr int32_t OamDecayCycleCount = 3000;
+	static constexpr int32_t OamDecayCycleCount = 4500; //About 40 scanlines.
 
 protected:
 	void UpdateStatusFlag();


### PR DESCRIPTION
Battletoads expects OAM to persist for about 37 scanlines. This changes Mesen's decay timeout from about 26 scanlines to about 40 scanlines.