### PR TITLE
TestRunner: Fix Lua require()

### DIFF
--- a/UI/Utilities/TestRunner.cs
+++ b/UI/Utilities/TestRunner.cs
@@ -42,7 +42,8 @@ namespace Mesen.Utilities
 			foreach(string luaScript in commandLineHelper.LuaScriptsToLoad) {
 				try {
 					string script = File.ReadAllText(luaScript);
-					DebugApi.LoadScript(luaScript, Path.GetDirectoryName(luaScript) ?? Program.OriginalFolder, script);
+					string path = (Path.GetDirectoryName(luaScript) ?? Program.OriginalFolder) + Path.DirectorySeparatorChar;
+					int scriptId = DebugApi.LoadScript(luaScript, path, script);
 				} catch { }
 			}
 


### PR DESCRIPTION
Make the path creation in --testrunner mode coherent with the path creation in ScriptWindowViewModel.cs so that require() in Lua scripts can result the same way.