### PR TITLE
SNES: Turbo File Twin STF mode seems to update status on strobe rising edge

### DIFF
--- a/Core/SNES/Input/AsciiTurboFileTwinStf.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinStf.h
@@ -84,12 +84,6 @@ public:
 		uint8_t output = 0;
 
 		if(addr == 0x4017) {
-			StrobeProcessRead();
-
-			// Get one bit from the status
-			output = _stateBuffer & 0x01;
-			_stateBuffer >>= 1;
-			_stateBuffer |= 1 << 31; // All bits after the first 32 are 1s in STF mode
 			if(_strobe) {
 				// Write mode is exited by turning the strobe and off without doing any $4017 reads
 				_didReadWithStrobe = true;
@@ -99,6 +93,11 @@ public:
 				if(_firstAccess) {
 					_writeMode = false;
 				}
+			} else {
+				// Get one bit from the status
+				output = _stateBuffer & 0x01;
+				_stateBuffer >>= 1;
+				_stateBuffer |= 1 << 31; // All bits after the first 32 are 1s in STF mode
 			}
 
 			uint8_t ioBit = (_console->GetInternalRegisters()->GetIoPortOutput() & 0x80) ? 0x01 : 0x00;
@@ -125,10 +124,10 @@ public:
 
 		if(!prevStrobe && _strobe) {
 			_didReadWithStrobe = false;
+			RefreshStateBuffer();
 		}
 
 		if(prevStrobe && !_strobe) {
-			RefreshStateBuffer();
 			if(!_writeMode && !_readMode) {
 				// Potentially start a new command
 				_position = _newCommand >> 8;


### PR DESCRIPTION
Very minor accuracy fix, but worth having if being exact and covering all known edge cases doesn't cost performance. Behavior is exposed in this specific scenario:
* Strobe turned on
* Do write sequence that turns write mode on
* Strobe turned off
* Strobe turned on <-- Shift register with status is updated here; write mode = 1 in the status
* Read $4017 with strobe on, which exits write mode if done on the very first access
* Strobe turned off
* Read status report through $4017 D0 without turning strobe on again <-- Status still says write mode = 1
If strobe is turned on after this point to refresh the shift register, the status will say that write mode = 0

This behavior was added to my test suite, as well as a test that confirms that you will get all 0s in D0 when you read with strobe on.
[turbo-file-twin-test-suite.zip](https://github.com/user-attachments/files/27908567/turbo-file-twin-test-suite.zip)
