### PR TITLE
Debugger: Fixed tooltips wrapping some texts on 2 lines when not needed

### DIFF
--- a/UI/Debugger/Controls/DynamicTooltip.axaml
+++ b/UI/Debugger/Controls/DynamicTooltip.axaml
@@ -65,6 +65,7 @@
 								Height="NaN"
 								BorderThickness="0"
 								IsReadOnly="True"
+								TextWrapping="NoWrap"
 								Tapped="TextBox_Tapped"
 								ContextRequested="TextBox_ContextRequested"
 								LostFocus="TextBox_LostFocus"


### PR DESCRIPTION
This was most likely caused by the recent Avalonia upgrade