### PR TITLE
Video: NTSC filter - Fixed "merge fields" issues

### DIFF
--- a/Core/GBA/GbaDefaultVideoFilter.cpp
+++ b/Core/GBA/GbaDefaultVideoFilter.cpp
@@ -104,7 +104,7 @@ void GbaDefaultVideoFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 	}
 
 	if(_applyNtscFilter) {
-		_ntscFilter.ApplyFilter(out, GbaConstants::ScreenWidth, GbaConstants::ScreenHeight, 0);
+		_ntscFilter.ApplyFilter(out, GbaConstants::ScreenWidth, GbaConstants::ScreenHeight, IsOddFrame());
 	}
 }
 

--- a/Core/Gameboy/GbDefaultVideoFilter.cpp
+++ b/Core/Gameboy/GbDefaultVideoFilter.cpp
@@ -112,7 +112,7 @@ void GbDefaultVideoFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 	}
 
 	if(_applyNtscFilter) {
-		_ntscFilter.ApplyFilter(out, frame.Width, frame.Height, 0);
+		_ntscFilter.ApplyFilter(out, frame.Width, frame.Height, IsOddFrame());
 	}
 }
 

--- a/Core/NES/NesNtscFilter.cpp
+++ b/Core/NES/NesNtscFilter.cpp
@@ -80,7 +80,8 @@ void NesNtscFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 		NesDefaultVideoFilter::ApplyPalBorder(ppuOutputBuffer);
 	}
 
-	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, GetVideoPhase(), _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, NES_NTSC_OUT_WIDTH(_baseFrameInfo.Width) * 4);
+	int phase = _ntscSetup.merge_fields ? 0 : GetVideoPhase();
+	nes_ntsc_blit(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, phase, _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, NES_NTSC_OUT_WIDTH(_baseFrameInfo.Width) * 4);
 
 	for(uint32_t i = 0; i < frameInfo.Height; i += 2) {
 		memcpy(GetOutputBuffer() + i * frameInfo.Width, _ntscBuffer + yOffset + xOffset + (i / 2) * baseWidth, frameInfo.Width * sizeof(uint32_t));

--- a/Core/PCE/PceNtscFilter.cpp
+++ b/Core/PCE/PceNtscFilter.cpp
@@ -99,10 +99,11 @@ void PceNtscFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 		}
 	}
 
+	int phase = _ntscSetup.merge_fields ? 0 : (IsOddFrame() ? 0 : 1);
 	if(_frameDivider) {
-		snes_ntsc_blit(&_ntscData, _rgb555Buffer, frameWidth, IsOddFrame() ? 0 : 1, frameWidth, rowCount, GetOutputBuffer(), frameInfo.Width * sizeof(uint32_t));
+		snes_ntsc_blit(&_ntscData, _rgb555Buffer, frameWidth, phase, frameWidth, rowCount, GetOutputBuffer(), frameInfo.Width * sizeof(uint32_t));
 	} else {
-		snes_ntsc_blit_hires(&_ntscData, _rgb555Buffer, frameWidth, IsOddFrame() ? 0 : 1, frameWidth, rowCount, _ntscBuffer, frameInfo.Width * sizeof(uint32_t));
+		snes_ntsc_blit_hires(&_ntscData, _rgb555Buffer, frameWidth, phase, frameWidth, rowCount, _ntscBuffer, frameInfo.Width * sizeof(uint32_t));
 
 		for(uint32_t i = 0; i < rowCount; i++) {
 			uint32_t* src = _ntscBuffer + i * frameInfo.Width;

--- a/Core/SNES/SnesNtscFilter.cpp
+++ b/Core/SNES/SnesNtscFilter.cpp
@@ -58,14 +58,15 @@ void SnesNtscFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 	uint32_t xOffset = overscan.Left;
 	uint32_t yOffset = overscan.Top / 2 * baseWidth;
 
+	int phase = _ntscSetup.merge_fields ? 0 : (IsOddFrame() ? 0 : 1);
 	if(useHighResOutput) {
-		snes_ntsc_blit_hires(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, IsOddFrame() ? 0 : 1, _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, baseWidth * 4);
+		snes_ntsc_blit_hires(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, phase, _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, baseWidth * 4);
 
 		for(uint32_t i = 0; i < frameInfo.Height; i++) {
 			memcpy(GetOutputBuffer() + i * frameInfo.Width, _ntscBuffer + yOffset * 2 + xOffset + i * baseWidth, frameInfo.Width * sizeof(uint32_t));
 		}
 	} else {
-		snes_ntsc_blit(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, IsOddFrame() ? 0 : 1, _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, baseWidth * 4);
+		snes_ntsc_blit(&_ntscData, ppuOutputBuffer, _baseFrameInfo.Width, phase, _baseFrameInfo.Width, _baseFrameInfo.Height, _ntscBuffer, baseWidth * 4);
 
 		for(uint32_t i = 0; i < frameInfo.Height; i += 2) {
 			memcpy(GetOutputBuffer() + i * frameInfo.Width, _ntscBuffer + yOffset + xOffset + i / 2 * baseWidth, frameInfo.Width * sizeof(uint32_t));

--- a/Core/Shared/Video/GenericNtscFilter.h
+++ b/Core/Shared/Video/GenericNtscFilter.h
@@ -101,6 +101,9 @@ public:
 			_inputBuffer[i] = ColorUtilities::Rgb888To555(inOut[i]);
 		}
 
+		if(_ntscSetup.merge_fields) {
+			phase = 0;
+		}
 		snes_ntsc_blit(&_ntscData, _inputBuffer, inWidth, phase, inWidth, inHeight, inOut, outWidth * sizeof(uint32_t));
 	}
 };

--- a/Core/WS/WsDefaultVideoFilter.cpp
+++ b/Core/WS/WsDefaultVideoFilter.cpp
@@ -121,6 +121,6 @@ void WsDefaultVideoFilter::ApplyFilter(uint16_t* ppuOutputBuffer)
 	}
 
 	if(_applyNtscFilter) {
-		_ntscFilter.ApplyFilter(out, size.Width, size.Height, 0);
+		_ntscFilter.ApplyFilter(out, size.Width, size.Height, IsOddFrame());
 	}
 }

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -167,7 +167,7 @@
 			<Control ID="trkGamma">Gamma</Control>
 			<Control ID="trkResolution">Resolution</Control>
 			<Control ID="trkSharpness">Sharpness</Control>
-			<Control ID="chkMergeFields">Merge Fields</Control>
+			<Control ID="chkMergeFields">Remove artifact jitter</Control>
 			<Control ID="chkVerticalBlend">Apply Vertical Blending</Control>
 
 			<Control ID="lblNtscBisqwitSettings">NTSC settings (Bisqwit)</Control>


### PR DESCRIPTION
"burst phase" should always be set to 0 when this option is enabled (this is what blargg's own demo does), otherwise there's still jitter from one frame to another (though less obvious jitter) 

Also made the GB/GBA/WS filters alternate between the 2 phases, which makes the colors look better, even without merge fields enabled.

The option was also renamed to "Remove artifact jitter" to help understand what it does.