### PR TITLE
NES: FDS Accuracy Improvements

### DIFF
--- a/Core/NES/Mappers/FDS/BaseFdsChannel.h
+++ b/Core/NES/Mappers/FDS/BaseFdsChannel.h
@@ -111,6 +111,6 @@ public:
 
 	void ResetTimer()
 	{
-		_timer = 8 * (_speed + 1) * _masterSpeed;
+		_timer = 8 * (_speed + 1) * (_masterSpeed + 1);
 	}
 };

--- a/Core/NES/Mappers/FDS/BaseFdsChannel.h
+++ b/Core/NES/Mappers/FDS/BaseFdsChannel.h
@@ -39,8 +39,8 @@ public:
 		switch(addr & 0x03) {
 			case 0:
 				_speed = value & 0x3F;
-				_volumeIncrease = (value & 0x40) == 0x40;
-				_envelopeOff = (value & 0x80) == 0x80;
+				_volumeIncrease = value & 0x40;
+				_envelopeOff = value & 0x80;
 
 				//"Writing to this register immediately resets the clock timer that ticks the volume envelope (delaying the next tick slightly)."
 				ResetTimer();

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -443,8 +443,8 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 				_irqEnabled = false;
 				//Disabling disk registers forces $4025 = $06 (bit 3 reflected in $4030 reads)
 				SetFdsControlReg(0x06);
-				//TODO Does disabling disk registers force the external connector = 0xFF ?
-				//_extConWriteReg = 0xFF;
+				//Disabling disk registers forces $4026 (external connector) = 0x7F
+				_extConWriteReg = 0x7F;
 				_cpu->ClearIrqSource(IRQSource::External);
 				_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			}
@@ -542,7 +542,7 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 
 			case 0x4033:
 				//Always return good battery
-				return _extConWriteReg;
+				return _extConWriteReg | 0x80;
 		}
 	}
 

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -254,6 +254,13 @@ void Fds::ProcessAutoDiskInsert()
 	}
 }
 
+/**TODO:
+ - Proper byte transfer flag handling (set every 1792 master cycles, or 149+1/3 CPU cycles, under normal conditions)
+   - Should allow for accurate handling of level 2->3 load bug in Ai Senshi Nicol
+ - Verify End of Head handling (may affect Kosodate Gokko and FMC Disk Card Checker)
+ - DRAM refresh watchdog implementation (must track PRG-RAM vs external access cycles...)
+ (Ongoing research, please consult TakuikaNinja for further details)
+**/
 void Fds::ProcessCpuClock()
 {
 	BaseProcessCpuClock();
@@ -389,6 +396,18 @@ void Fds::UpdateCrc(uint8_t value)
 	}
 }
 
+void Fds::SetFdsControlReg(uint8_t value)
+{
+	_motorOn = (value & 0x01) == 0x01;
+	_resetTransfer = (value & 0x02) == 0x02;
+	_readMode = (value & 0x04) == 0x04;
+	SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
+	_crcControl = (value & 0x10) == 0x10;
+	//TODO $4025 bit 5 is unknown, all known software sets it to 1
+	_diskReady = (value & 0x40) == 0x40;
+	_diskIrqEnabled = (value & 0x80) == 0x80;
+}
+
 void Fds::WriteRegister(uint16_t addr, uint8_t value)
 {
 	if((!_diskRegEnabled && addr >= 0x4024 && addr <= 0x4026) || (!_soundRegEnabled && addr >= 0x4040)) {
@@ -417,10 +436,15 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 
 		case 0x4023:
 			_diskRegEnabled = (value & 0x01) == 0x01;
+			//TODO Disabling sound registers should pause audio output?
 			_soundRegEnabled = (value & 0x02) == 0x02;
 
 			if(!_diskRegEnabled) {
 				_irqEnabled = false;
+				//Disabling disk registers forces $4025 = $06 (bit 3 reflected in $4030 reads)
+				SetFdsControlReg(0x06);
+				//TODO Does disabling disk registers force the external connector = 0xFF ?
+				//_extConWriteReg = 0xFF;
 				_cpu->ClearIrqSource(IRQSource::External);
 				_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			}
@@ -435,14 +459,7 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 			break;
 
 		case 0x4025:
-			_motorOn = (value & 0x01) == 0x01;
-			_resetTransfer = (value & 0x02) == 0x02;
-			_readMode = (value & 0x04) == 0x04;
-			SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
-			_crcControl = (value & 0x10) == 0x10;
-			//Bit 6 is not used, always 1
-			_diskReady = (value & 0x40) == 0x40;
-			_diskIrqEnabled = (value & 0x80) == 0x80;
+			SetFdsControlReg(value);
 
 			//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
 			//Fixes issues in some unlicensed games (error $20 at power on)
@@ -464,20 +481,24 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 uint8_t Fds::ReadRegister(uint16_t addr)
 {
 	uint8_t value = _memoryManager->GetOpenBus();
-	if(_soundRegEnabled && addr >= 0x4040) {
+	if(addr >= 0x4040) {
 		return _audio->ReadRegister(addr);
-	} else if(_diskRegEnabled && addr <= 0x4033) {
+	} else if(addr <= 0x4033) {
 		switch(addr) {
 			case 0x4030:
-				//These 3 pins are open bus
+				//These 2 pins are open bus
 				value &= 0x24;
-
+				/**TODO:
+				 - DRAM refresh watchdog IRQ status is returned in bit 1, needs implementation
+				 - End of Head is returned in bit 6, needs verification
+				 - Byte transfer flag is returned in bit 7, not bit 1 (required by Tonkachi Editor)
+				**/
 				value |= _cpu->HasIrqSource(IRQSource::External) ? 0x01 : 0x00;
 				value |= _transferComplete ? 0x02 : 0x00;
 				value |= GetMirroringType() == MirroringType::Horizontal ? 0x08 : 0;
 				value |= _useQdFormat && _badCrc ? 0x10 : 0x00;
 				//value |= _endOfHead ? 0x40 : 0x00;
-				//value |= _diskRegEnabled ? 0x80 : 0x00;
+				//value |= _transferComplete ? 0x80 : 0x00;
 
 				_transferComplete = false;
 				_cpu->ClearIrqSource(IRQSource::External);

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -415,7 +415,16 @@ void Fds::SetFdsControlReg(uint8_t value)
 
 void Fds::WriteRegister(uint16_t addr, uint8_t value)
 {
-	if((!_diskRegEnabled && addr >= 0x4024 && addr <= 0x4026) || (!_soundRegEnabled && addr >= 0x4040)) {
+	if(!_diskRegEnabled && addr >= 0x4024 && addr <= 0x4026) {
+		return;
+	}
+	
+	/**Only $4080 (volume envelope) seems to consistently deny writes during audio reset
+	TODO:
+	 - $4085 (mod counter) denies writes too, but there is an unknown delay before being forced to 0
+	 - Determine $4088 (mod table write) behaviour while in audio reset state
+	**/
+	if(!_soundRegEnabled && (addr == 0x4080 || addr == 0x4085 || addr == 0x4088)) {
 		return;
 	}
 
@@ -441,7 +450,7 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 
 		case 0x4023:
 			_diskRegEnabled = (value & 0x01) == 0x01;
-			//TODO Disabling sound registers should pause audio output?
+			//TODO This is actually an audio reset, rename this variable in Fds.h
 			_soundRegEnabled = (value & 0x02) == 0x02;
 
 			if(!_diskRegEnabled) {
@@ -452,6 +461,18 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 				_extConWriteReg = 0x7F;
 				_cpu->ClearIrqSource(IRQSource::External);
 				_cpu->ClearIrqSource(IRQSource::FdsDisk);
+			}
+			
+			/**TODO Determine/implement audio reset behaviour, should probably go in FdsAudio:
+			 - Proper method of resetting modulation state ($4085 write below doesn't always work)
+			 - Reset wave accumulator to 0
+			 - Mod table appears to init with (or decay to) all 0s?
+			 - There seems to be some kind of analogue "resume" window?
+			(Ongoing research, please consult TakuikaNinja for further details)
+			**/
+			if(!_soundRegEnabled) {
+				_audio->WriteRegister(0x4080, 0x80); //Based on instant muting
+				_audio->WriteRegister(0x4085, 0x00); //Based on $4097 state
 			}
 			break;
 

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -406,6 +406,11 @@ void Fds::SetFdsControlReg(uint8_t value)
 	//TODO $4025 bit 5 is unknown, all known software sets it to 1
 	_diskReady = (value & 0x40) == 0x40;
 	_diskIrqEnabled = (value & 0x80) == 0x80;
+	
+	//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
+	//Fixes issues in some unlicensed games (error $20 at power on)
+	//TODO This probably depends on the bits set?
+	_cpu->ClearIrqSource(IRQSource::FdsDisk);
 }
 
 void Fds::WriteRegister(uint16_t addr, uint8_t value)
@@ -454,20 +459,17 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 			_writeDataReg = value;
 			_transferComplete = false;
 
-			//Unsure about clearing irq here: FCEUX/Nintendulator don't do this, puNES does.
+			//Needed by some Super Magic Card games, which use this IRQ for raster effects
 			_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			break;
 
 		case 0x4025:
 			SetFdsControlReg(value);
-
-			//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
-			//Fixes issues in some unlicensed games (error $20 at power on)
-			_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			break;
 
 		case 0x4026:
-			_extConWriteReg = value;
+			//External connector only wires 7 bits
+			_extConWriteReg = value & 0x7F;
 			break;
 
 		default:
@@ -499,9 +501,11 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				//value |= _endOfHead ? 0x40 : 0x00;
 				value |= _transferComplete ? 0x80 : 0x00;
 
-				_transferComplete = false;
 				_cpu->ClearIrqSource(IRQSource::External);
-				_cpu->ClearIrqSource(IRQSource::FdsDisk);
+
+				//Byte transfer flag is NOT cleared by this register!
+				//_transferComplete = false;
+				//_cpu->ClearIrqSource(IRQSource::FdsDisk);
 				return value;
 
 			case 0x4031:

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -397,24 +397,6 @@ void Fds::UpdateCrc(uint8_t value)
 	}
 }
 
-void Fds::SetFdsControlReg(uint8_t value)
-{
-	_motorOn = (value & 0x01) == 0x01;
-	_resetTransfer = (value & 0x02) == 0x02;
-	_readMode = (value & 0x04) == 0x04;
-	SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
-	_crcControl = (value & 0x10) == 0x10;
-	//TODO $4025 bit 5 is unknown, all known software sets it to 1
-
-	_diskReady = (value & 0x40) == 0x40; //TODO $4025 bit 6 is CRC enable, not disk ready flag
-	_diskIrqEnabled = (value & 0x80) == 0x80;
-
-	//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
-	//Fixes issues in some unlicensed games (error $20 at power on)
-	//TODO This probably depends on the bits set?
-	_cpu->ClearIrqSource(IRQSource::FdsDisk);
-}
-
 void Fds::WriteRegister(uint16_t addr, uint8_t value)
 {
 	if(!_diskRegEnabled && addr >= 0x4024 && addr <= 0x4026) {
@@ -457,10 +439,21 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 
 			if(!_diskRegEnabled) {
 				_irqEnabled = false;
+
 				//Disabling disk registers forces $4025 = $06 (bit 3 reflected in $4030 reads)
-				SetFdsControlReg(0x06);
+				_resetTransfer = true;
+				_motorOn = false;
+				_readMode = true;
+				SetMirroringType(MirroringType::Vertical);
+				_crcControl = false;
+				//TODO Set $4025 bit 5 = 0 here once implemented
+
+				_diskReady = false; //TODO $4025 bit 6 is CRC enable, not disk ready flag
+				_diskIrqEnabled = false;
+
 				//Disabling disk registers forces $4026 (external connector) = 0x7F
 				_extConWriteReg = 0x7F;
+
 				_cpu->ClearIrqSource(IRQSource::External);
 				_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			}
@@ -487,7 +480,20 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 			break;
 
 		case 0x4025:
-			SetFdsControlReg(value);
+			_resetTransfer = !(value & 0x01); // 0 = reset transfer
+			_motorOn = !(value & 0x02); // 0 = start motor
+			_readMode = value & 0x04;
+			SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
+			_crcControl = value & 0x10;
+			//TODO $4025 bit 5 is unknown, all known software sets it to 1
+
+			_diskReady = value & 0x40; //TODO $4025 bit 6 is CRC enable, not disk ready flag
+			_diskIrqEnabled = value & 0x80;
+
+			//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
+			//Fixes issues in some unlicensed games (error $20 at power on)
+			//TODO This probably depends on the bits set?
+			_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			break;
 
 		case 0x4026:
@@ -525,10 +531,6 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				value |= _transferComplete ? 0x80 : 0x00;
 
 				_cpu->ClearIrqSource(IRQSource::External);
-
-				//Byte transfer flag is NOT cleared by this register!
-				//_transferComplete = false;
-				//_cpu->ClearIrqSource(IRQSource::FdsDisk);
 				return value;
 
 			case 0x4031:
@@ -567,7 +569,7 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				return value;
 
 			case 0x4033:
-				//Always return good battery
+				//Always return good battery status in bit 7
 				return _extConWriteReg | 0x80;
 		}
 	}
@@ -690,8 +692,8 @@ vector<MapperStateEntry> Fds::GetMapperStateEntries()
 
 	entries.push_back(MapperStateEntry("", "Disk Drive"));
 	entries.push_back(MapperStateEntry("$4025", "Drive Control"));
-	entries.push_back(MapperStateEntry("$4025.0", "Motor Enabled", _motorOn, MapperStateValueType::Bool));
-	entries.push_back(MapperStateEntry("$4025.1", "Reset Transfer", _resetTransfer, MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4025.0", "Scan Disk", !_resetTransfer, MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4025.1", "Stop Motor", !_motorOn, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.2", "Read Mode", _readMode, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.3", "Mirroring", GetMirroringType() == MirroringType::Horizontal ? "Horizontal" : "Vertical", GetMirroringType() == MirroringType::Horizontal ? 1 : 0));
 	entries.push_back(MapperStateEntry("$4025.4", "Transfer CRC", _crcControl, MapperStateValueType::Bool));

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -152,7 +152,7 @@ void Fds::ClockIrq()
 
 uint8_t Fds::ReadRam(uint16_t addr)
 {
-	if(addr == 0xE18C && !_gameStarted && (_memoryManager->DebugRead(0x100) & 0xC0) != 0) {
+	if(addr == 0xE18C && !_gameStarted && (_memoryManager->DebugRead(0x100) & 0xC0)) {
 		//$E18B is the NMI entry point (using $E18C due to dummy reads)
 		//When NMI occurs while $100 & $C0 != 0, it typically means that the game is starting.
 		_gameStarted = true;
@@ -190,6 +190,7 @@ uint8_t Fds::ReadRam(uint16_t addr)
 		if(matchCount > 1) {
 			//More than 1 disk matches, can happen in unlicensed games - disable auto insert logic
 			_disableAutoInsertDisk = true;
+			MessageManager::Log("[FDS] Multiple disks match, auto-insert disabled.");
 		}
 
 		if(matchIndex >= 0) {
@@ -281,6 +282,13 @@ void Fds::ProcessCpuClock()
 		//Disk has been ejected
 		_endOfHead = true;
 		_scanningDisk = false;
+
+		//It appears the BIOS disk I/O routines can stop the motor well before the end of the disk
+		//(File transfer loop normally runs until accessed files == value in file amount block)
+		//Wait a bit before ejecting the disk (eject in ~77 frames)
+		if(_autoDiskEjectCounter < 0) {
+			_autoDiskEjectCounter = 77;
+		}
 		return;
 	}
 
@@ -422,8 +430,8 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 			break;
 
 		case 0x4022:
-			_irqRepeatEnabled = (value & 0x01) == 0x01;
-			_irqEnabled = (value & 0x02) == 0x02 && _diskRegEnabled;
+			_irqRepeatEnabled = value & 0x01;
+			_irqEnabled = (value & 0x02) && _diskRegEnabled;
 
 			if(_irqEnabled) {
 				_irqCounter = _irqReloadValue;
@@ -433,9 +441,9 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 			break;
 
 		case 0x4023:
-			_diskRegEnabled = (value & 0x01) == 0x01;
+			_diskRegEnabled = value & 0x01;
 			//TODO This is actually an audio reset, rename this variable in Fds.h
-			_soundRegEnabled = (value & 0x02) == 0x02;
+			_soundRegEnabled = value & 0x02;
 
 			if(!_diskRegEnabled) {
 				_irqEnabled = false;
@@ -525,7 +533,7 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				**/
 				value |= _cpu->HasIrqSource(IRQSource::External) ? 0x01 : 0x00;
 				//value |= _transferComplete ? 0x02 : 0x00;
-				value |= GetMirroringType() == MirroringType::Horizontal ? 0x08 : 0;
+				value |= GetMirroringType() == MirroringType::Horizontal ? 0x08 : 0x00;
 				value |= _useQdFormat && _badCrc ? 0x10 : 0x00;
 				//value |= _endOfHead ? 0x40 : 0x00;
 				value |= _transferComplete ? 0x80 : 0x00;
@@ -543,8 +551,9 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				value &= 0xF8;
 
 				value |= !IsDiskInserted() ? 0x01 : 0x00; //Disk not in drive
+				//TODO This should use _diskReady instead
 				value |= (!IsDiskInserted() || !_scanningDisk) ? 0x02 : 0x00; //Disk not ready
-				value |= !IsDiskInserted() ? 0x04 : 0x00; //Disk not writable
+				value |= !IsDiskInserted() ? 0x04 : 0x00; //Simulate inserted disks as always being writable
 
 				if(IsAutoInsertDiskEnabled()) {
 					if(_emu->GetFrameCount() - _lastDiskCheckFrame < 100) {

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -257,6 +257,7 @@ void Fds::ProcessAutoDiskInsert()
 /**TODO:
  - Proper byte transfer flag handling (set every 1792 master cycles, or 149+1/3 CPU cycles, under normal conditions)
    - Should allow for accurate handling of level 2->3 load bug in Ai Senshi Nicol
+ - Proper CRC handling using $4025 bits 4 and 6
  - Verify End of Head handling (may affect Kosodate Gokko and FMC Disk Card Checker)
  - DRAM refresh watchdog implementation (must track PRG-RAM vs external access cycles...)
  (Ongoing research, please consult TakuikaNinja for further details)
@@ -404,7 +405,8 @@ void Fds::SetFdsControlReg(uint8_t value)
 	SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
 	_crcControl = (value & 0x10) == 0x10;
 	//TODO $4025 bit 5 is unknown, all known software sets it to 1
-	_diskReady = (value & 0x40) == 0x40;
+	
+	_diskReady = (value & 0x40) == 0x40; //TODO $4025 bit 6 is CRC enable, not disk ready flag
 	_diskIrqEnabled = (value & 0x80) == 0x80;
 	
 	//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
@@ -675,20 +677,48 @@ bool Fds::IsAutoInsertDiskEnabled()
 vector<MapperStateEntry> Fds::GetMapperStateEntries()
 {
 	vector<MapperStateEntry> entries;
-
+	
+	entries.push_back(MapperStateEntry("", "IRQ"));
+	entries.push_back(MapperStateEntry("$4020-$4022", "Timer IRQ"));
 	entries.push_back(MapperStateEntry("$4020/1", "IRQ Reload Value", _irqReloadValue, MapperStateValueType::Number16));
 	entries.push_back(MapperStateEntry("$4022.0", "IRQ Repeat", _irqRepeatEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4022.1", "IRQ Enabled", _irqEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("", "IRQ Counter", _irqCounter, MapperStateValueType::Number16));
 
+	entries.push_back(MapperStateEntry("$4023", "I/O Control"));
 	entries.push_back(MapperStateEntry("$4023.0", "Disk Registers Enabled", _diskRegEnabled, MapperStateValueType::Bool));
-	entries.push_back(MapperStateEntry("$4023.1", "Sound Registers Enabled", _soundRegEnabled, MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4023.1", "Audio Enabled", _soundRegEnabled, MapperStateValueType::Bool));
 
+	entries.push_back(MapperStateEntry("", "Disk Drive"));
+	entries.push_back(MapperStateEntry("$4025", "Drive Control"));
 	entries.push_back(MapperStateEntry("$4025.0", "Motor Enabled", _motorOn, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.1", "Reset Transfer", _resetTransfer, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.2", "Read Mode", _readMode, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.3", "Mirroring", GetMirroringType() == MirroringType::Horizontal ? "Horizontal" : "Vertical", GetMirroringType() == MirroringType::Horizontal ? 1 : 0));
+	entries.push_back(MapperStateEntry("$4025.4", "Transfer CRC", _crcControl, MapperStateValueType::Bool));
+	//entries.push_back(MapperStateEntry("$4025.6", "CRC Enabled", _crcEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.7", "Disk IRQ Enabled", _diskIrqEnabled, MapperStateValueType::Bool));
+	
+	entries.push_back(MapperStateEntry("$4030", "Drive/IRQ Status"));
+	entries.push_back(MapperStateEntry("$4030.0", "Timer IRQ", _cpu->HasIrqSource(IRQSource::External), MapperStateValueType::Bool));
+	//entries.push_back(MapperStateEntry("$4030.1", "DRAM Refresh Watchdog IRQ", false, MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4030.3", "Mirroring", GetMirroringType() == MirroringType::Horizontal ? "Horizontal" : "Vertical", GetMirroringType() == MirroringType::Horizontal ? 1 : 0));
+	entries.push_back(MapperStateEntry("$4030.5", "CRC Error", (_useQdFormat && _badCrc), MapperStateValueType::Bool));
+	//entries.push_back(MapperStateEntry("$4030.6", "End of Head", _endOfHead, MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4030.7", "Byte Transferred", _transferComplete, MapperStateValueType::Bool));
+	
+	entries.push_back(MapperStateEntry("$4024/$4031", "Disk Data"));
+	entries.push_back(MapperStateEntry("$4024", "Disk Data Output", _writeDataReg, MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4031", "Disk Data Input", _readDataReg, MapperStateValueType::Number8));
+
+	entries.push_back(MapperStateEntry("$4032", "Disk Status"));
+	entries.push_back(MapperStateEntry("$4032.0", "Disk Inserted", IsDiskInserted(), MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4032.1", "Disk Ready", (IsDiskInserted() & _scanningDisk), MapperStateValueType::Bool));
+	entries.push_back(MapperStateEntry("$4032.2", "Write Enabled", IsDiskInserted(), MapperStateValueType::Bool));
+
+	entries.push_back(MapperStateEntry("", "External Connector"));
+	entries.push_back(MapperStateEntry("$4026/$4033.0-6", "External Connector Value", _extConWriteReg, MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4033.7", "Drive Powered", true, MapperStateValueType::Bool));
 
 	_audio->GetMapperStateEntries(entries);
 

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -256,7 +256,7 @@ void Fds::ProcessAutoDiskInsert()
 
 /**TODO:
  - Proper byte transfer flag handling (set every 1792 master cycles, or 149+1/3 CPU cycles, under normal conditions)
-   - Should allow for accurate handling of level 2->3 load bug in Ai Senshi Nicol
+	- Should allow for accurate handling of level 2->3 load bug in Ai Senshi Nicol
  - Proper CRC handling using $4025 bits 4 and 6
  - Verify End of Head handling (may affect Kosodate Gokko and FMC Disk Card Checker)
  - DRAM refresh watchdog implementation (must track PRG-RAM vs external access cycles...)
@@ -405,10 +405,10 @@ void Fds::SetFdsControlReg(uint8_t value)
 	SetMirroringType(value & 0x08 ? MirroringType::Horizontal : MirroringType::Vertical);
 	_crcControl = (value & 0x10) == 0x10;
 	//TODO $4025 bit 5 is unknown, all known software sets it to 1
-	
+
 	_diskReady = (value & 0x40) == 0x40; //TODO $4025 bit 6 is CRC enable, not disk ready flag
 	_diskIrqEnabled = (value & 0x80) == 0x80;
-	
+
 	//Writing to $4025 clears IRQ according to FCEUX, puNES & Nintendulator
 	//Fixes issues in some unlicensed games (error $20 at power on)
 	//TODO This probably depends on the bits set?
@@ -420,7 +420,7 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 	if(!_diskRegEnabled && addr >= 0x4024 && addr <= 0x4026) {
 		return;
 	}
-	
+
 	/**Only $4080 (volume envelope) seems to consistently deny writes during audio reset
 	TODO:
 	 - $4085 (mod counter) denies writes too, but there is an unknown delay before being forced to 0
@@ -464,7 +464,7 @@ void Fds::WriteRegister(uint16_t addr, uint8_t value)
 				_cpu->ClearIrqSource(IRQSource::External);
 				_cpu->ClearIrqSource(IRQSource::FdsDisk);
 			}
-			
+
 			/**TODO Determine/implement audio reset behaviour, should probably go in FdsAudio:
 			 - Proper method of resetting modulation state ($4085 write below doesn't always work)
 			 - Reset wave accumulator to 0
@@ -677,7 +677,7 @@ bool Fds::IsAutoInsertDiskEnabled()
 vector<MapperStateEntry> Fds::GetMapperStateEntries()
 {
 	vector<MapperStateEntry> entries;
-	
+
 	entries.push_back(MapperStateEntry("", "IRQ"));
 	entries.push_back(MapperStateEntry("$4020-$4022", "Timer IRQ"));
 	entries.push_back(MapperStateEntry("$4020/1", "IRQ Reload Value", _irqReloadValue, MapperStateValueType::Number16));
@@ -698,7 +698,7 @@ vector<MapperStateEntry> Fds::GetMapperStateEntries()
 	entries.push_back(MapperStateEntry("$4025.4", "Transfer CRC", _crcControl, MapperStateValueType::Bool));
 	//entries.push_back(MapperStateEntry("$4025.6", "CRC Enabled", _crcEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4025.7", "Disk IRQ Enabled", _diskIrqEnabled, MapperStateValueType::Bool));
-	
+
 	entries.push_back(MapperStateEntry("$4030", "Drive/IRQ Status"));
 	entries.push_back(MapperStateEntry("$4030.0", "Timer IRQ", _cpu->HasIrqSource(IRQSource::External), MapperStateValueType::Bool));
 	//entries.push_back(MapperStateEntry("$4030.1", "DRAM Refresh Watchdog IRQ", false, MapperStateValueType::Bool));
@@ -706,7 +706,7 @@ vector<MapperStateEntry> Fds::GetMapperStateEntries()
 	entries.push_back(MapperStateEntry("$4030.5", "CRC Error", (_useQdFormat && _badCrc), MapperStateValueType::Bool));
 	//entries.push_back(MapperStateEntry("$4030.6", "End of Head", _endOfHead, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4030.7", "Byte Transferred", _transferComplete, MapperStateValueType::Bool));
-	
+
 	entries.push_back(MapperStateEntry("$4024/$4031", "Disk Data"));
 	entries.push_back(MapperStateEntry("$4024", "Disk Data Output", _writeDataReg, MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4031", "Disk Data Input", _readDataReg, MapperStateValueType::Number8));

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -491,14 +491,13 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				/**TODO:
 				 - DRAM refresh watchdog IRQ status is returned in bit 1, needs implementation
 				 - End of Head is returned in bit 6, needs verification
-				 - Byte transfer flag is returned in bit 7, not bit 1 (required by Tonkachi Editor)
 				**/
 				value |= _cpu->HasIrqSource(IRQSource::External) ? 0x01 : 0x00;
-				value |= _transferComplete ? 0x02 : 0x00;
+				//value |= _transferComplete ? 0x02 : 0x00;
 				value |= GetMirroringType() == MirroringType::Horizontal ? 0x08 : 0;
 				value |= _useQdFormat && _badCrc ? 0x10 : 0x00;
 				//value |= _endOfHead ? 0x40 : 0x00;
-				//value |= _transferComplete ? 0x80 : 0x00;
+				value |= _transferComplete ? 0x80 : 0x00;
 
 				_transferComplete = false;
 				_cpu->ClearIrqSource(IRQSource::External);

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -678,14 +678,13 @@ vector<MapperStateEntry> Fds::GetMapperStateEntries()
 {
 	vector<MapperStateEntry> entries;
 
-	entries.push_back(MapperStateEntry("", "IRQ"));
-	entries.push_back(MapperStateEntry("$4020-$4022", "Timer IRQ"));
+	entries.push_back(MapperStateEntry("", "Timer IRQ"));
 	entries.push_back(MapperStateEntry("$4020/1", "IRQ Reload Value", _irqReloadValue, MapperStateValueType::Number16));
 	entries.push_back(MapperStateEntry("$4022.0", "IRQ Repeat", _irqRepeatEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4022.1", "IRQ Enabled", _irqEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("", "IRQ Counter", _irqCounter, MapperStateValueType::Number16));
 
-	entries.push_back(MapperStateEntry("$4023", "I/O Control"));
+	entries.push_back(MapperStateEntry("", "I/O Control"));
 	entries.push_back(MapperStateEntry("$4023.0", "Disk Registers Enabled", _diskRegEnabled, MapperStateValueType::Bool));
 	entries.push_back(MapperStateEntry("$4023.1", "Audio Enabled", _soundRegEnabled, MapperStateValueType::Bool));
 

--- a/Core/NES/Mappers/FDS/Fds.h
+++ b/Core/NES/Mappers/FDS/Fds.h
@@ -106,6 +106,7 @@ protected:
 	void ProcessCpuClock() override;
 	void UpdateCrc(uint8_t value);
 
+	void SetFdsControlReg(uint8_t value);
 	void WriteRegister(uint16_t addr, uint8_t value) override;
 	uint8_t ReadRegister(uint16_t addr) override;
 

--- a/Core/NES/Mappers/FDS/Fds.h
+++ b/Core/NES/Mappers/FDS/Fds.h
@@ -85,7 +85,7 @@ protected:
 	uint32_t GetWorkRamPageSize() override { return 0x8000; }
 	uint32_t GetWorkRamSize() override { return 0x8000; }
 	uint16_t RegisterStartAddress() override { return 0x4020; }
-	uint16_t RegisterEndAddress() override { return 0x4092; }
+	uint16_t RegisterEndAddress() override { return 0x4097; }
 	bool AllowRegisterRead() override { return true; }
 	bool EnableCpuClockHook() override { return true; }
 

--- a/Core/NES/Mappers/FDS/Fds.h
+++ b/Core/NES/Mappers/FDS/Fds.h
@@ -32,6 +32,8 @@ private:
 
 	uint8_t _writeDataReg = 0;
 
+	//TODO Change $4025.D0-D1 namings/meanings so we don't have to invert the read/write logic
+	// (_resetTransfer (bit 0) -> _scanMedia, _motorOn (bit 1) -> _stopMotor)
 	bool _motorOn = false;
 	bool _resetTransfer = false;
 	bool _readMode = false;
@@ -106,7 +108,6 @@ protected:
 	void ProcessCpuClock() override;
 	void UpdateCrc(uint8_t value);
 
-	void SetFdsControlReg(uint8_t value);
 	void WriteRegister(uint16_t addr, uint8_t value) override;
 	uint8_t ReadRegister(uint16_t addr) override;
 

--- a/Core/NES/Mappers/FDS/FdsAudio.cpp
+++ b/Core/NES/Mappers/FDS/FdsAudio.cpp
@@ -158,8 +158,8 @@ void FdsAudio::WriteRegister(uint16_t addr, uint8_t value)
 				break;
 
 			case 0x4083:
-				_disableEnvelopes = (value & 0x40) != 0;
-				_haltWaveform = (value & 0x80) != 0;
+				_disableEnvelopes = value & 0x40;
+				_haltWaveform = value & 0x80;
 				if(_haltWaveform) {
 					_wavePosition = 0;
 				}
@@ -192,7 +192,7 @@ void FdsAudio::WriteRegister(uint16_t addr, uint8_t value)
 
 			case 0x4089:
 				_masterVolume = value & 0x03;
-				_waveWriteEnabled = (value & 0x80) == 0x80;
+				_waveWriteEnabled = value & 0x80;
 				break;
 
 			case 0x408A:

--- a/Core/NES/Mappers/FDS/FdsAudio.cpp
+++ b/Core/NES/Mappers/FDS/FdsAudio.cpp
@@ -112,9 +112,9 @@ uint8_t FdsAudio::ReadRegister(uint16_t addr)
 				break;
 
 			case 0x4094:
-				//Mod counter*gain intermediate result
+				//Mod counter*gain intermediate result (bits 4-11)
 				//value &= 0xC0;
-				value = (_mod.GetOutput() >> 4) & 0xFF;
+				value = (_mod.GetCounter() * _mod.GetGain() >> 4) & 0xFF;
 				break;
 
 			case 0x4095:
@@ -245,7 +245,7 @@ entries.push_back(MapperStateEntry("$4090-$4097", "Audio Debug"));
 	entries.push_back(MapperStateEntry("$4091", "Wave Accumulator", ((GetWaveAccumulator() >> 12) & 0xFF), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4092.0-5", "Mod Gain", _mod.GetGain(), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4093.0-6", "Mod Accumulator", ((_mod.GetModAccumulator() >> 5) & 0x7F), MapperStateValueType::Number8));
-	entries.push_back(MapperStateEntry("$4094", "Mod Counter * Gain", ((_mod.GetOutput() >> 4) & 0xFF), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4094", "Mod Counter * Gain", (((_mod.GetCounter() * _mod.GetGain()) >> 4) & 0xFF), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4095.0-3", "Mod Counter Increment", _mod.GetModIncrement(), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4096.0-5", "Wavetable Value", (_waveTable[_wavePosition] & 0x3F), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4097.0-6", "Mod Counter Value", std::to_string(modCounter), (modCounter & 0x7F)));

--- a/Core/NES/Mappers/FDS/FdsAudio.cpp
+++ b/Core/NES/Mappers/FDS/FdsAudio.cpp
@@ -239,8 +239,8 @@ void FdsAudio::GetMapperStateEntries(vector<MapperStateEntry>& entries)
 	entries.push_back(MapperStateEntry("$4089.7", "Wave Write Enabled", _waveWriteEnabled, MapperStateValueType::Bool));
 
 	entries.push_back(MapperStateEntry("$408A", "Envelope Speed Multiplier", _volume.GetMasterSpeed(), MapperStateValueType::Number8));
-	
-entries.push_back(MapperStateEntry("$4090-$4097", "Audio Debug"));
+
+	entries.push_back(MapperStateEntry("$4090-$4097", "Audio Debug"));
 	entries.push_back(MapperStateEntry("$4090.0-5", "Volume Gain", _volume.GetGain(), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4091", "Wave Accumulator", ((GetWaveAccumulator() >> 12) & 0xFF), MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4092.0-5", "Mod Gain", _mod.GetGain(), MapperStateValueType::Number8));

--- a/Core/NES/Mappers/FDS/FdsAudio.cpp
+++ b/Core/NES/Mappers/FDS/FdsAudio.cpp
@@ -70,6 +70,7 @@ FdsAudio::FdsAudio(NesConsole* console) : BaseExpansionAudio(console)
 {
 }
 
+//TODO Update to switch statement and map read-only FDS audio registers at $4090-$4097
 uint8_t FdsAudio::ReadRegister(uint16_t addr)
 {
 	uint8_t value = _console->GetMemoryManager()->GetOpenBus();

--- a/Core/NES/Mappers/FDS/FdsAudio.cpp
+++ b/Core/NES/Mappers/FDS/FdsAudio.cpp
@@ -66,6 +66,11 @@ void FdsAudio::UpdateOutput()
 	}
 }
 
+uint32_t FdsAudio::GetWaveAccumulator()
+{
+	return (_wavePosition << 18) | _waveOverflowCounter;
+}
+
 FdsAudio::FdsAudio(NesConsole* console) : BaseExpansionAudio(console)
 {
 }
@@ -82,12 +87,55 @@ uint8_t FdsAudio::ReadRegister(uint16_t addr)
 			//"When writing is disabled ($4089.7), reading anywhere in 4040-407F returns the value at the current wave position"
 			value |= _waveTable[_wavePosition];
 		}
-	} else if(addr == 0x4090) {
-		value &= 0xC0;
-		value |= _volume.GetGain();
-	} else if(addr == 0x4092) {
-		value &= 0xC0;
-		value |= _mod.GetGain();
+	} else if(addr >= 0x4090) {
+		switch(addr) {
+			case 0x4090:
+				value &= 0xC0;
+				value |= _volume.GetGain() & 0x3F;
+				break;
+
+			case 0x4091:
+				//Wave accumulator (bits 12-19)
+				//value &= 0xC0;
+				value = (GetWaveAccumulator() >> 12) & 0xFF;
+				break;
+
+			case 0x4092:
+				value &= 0xC0;
+				value |= _mod.GetGain() & 0x3F;
+				break;
+
+			case 0x4093:
+				//Mod accumulator (bits 5-11)
+				value &= 0x80;
+				value |= (_mod.GetModAccumulator() >> 5) & 0x7F;
+				break;
+
+			case 0x4094:
+				//Mod counter*gain intermediate result
+				//value &= 0xC0;
+				value = (_mod.GetOutput() >> 4) & 0xFF;
+				break;
+
+			case 0x4095:
+				//Mod counter increment (lower nybble)
+				//TODO Determine upper nybble
+				value &= 0xC0;
+				value |= _mod.GetModIncrement();
+				break;
+
+			case 0x4096:
+				//Wavetable value
+				//TODO PWM masking
+				value &= 0xC0;
+				value |= _waveTable[_wavePosition] & 0x3F;
+				break;
+
+			case 0x4097:
+				value &= 0x80;
+				value |= _mod.GetCounter() & 0x7F;
+				break;
+		}
 	}
 
 	return value;
@@ -175,7 +223,7 @@ void FdsAudio::GetMapperStateEntries(vector<MapperStateEntry>& entries)
 	entries.push_back(MapperStateEntry("$4084.7", "Envelope Disabled", _mod.IsEnvelopeDisabled(), MapperStateValueType::Bool));
 
 	int8_t modCounter = _mod.GetCounter();
-	entries.push_back(MapperStateEntry("$4085.0-6", "Counter", std::to_string(modCounter), modCounter < 0 ? (modCounter + 128) : modCounter));
+	entries.push_back(MapperStateEntry("$4085.0-6", "Counter", std::to_string(modCounter), (modCounter & 0x7F)));
 
 	entries.push_back(MapperStateEntry("$4086/7.0-11", "Frequency", _mod.GetFrequency(), MapperStateValueType::Number16));
 
@@ -191,4 +239,14 @@ void FdsAudio::GetMapperStateEntries(vector<MapperStateEntry>& entries)
 	entries.push_back(MapperStateEntry("$4089.7", "Wave Write Enabled", _waveWriteEnabled, MapperStateValueType::Bool));
 
 	entries.push_back(MapperStateEntry("$408A", "Envelope Speed Multiplier", _volume.GetMasterSpeed(), MapperStateValueType::Number8));
+	
+entries.push_back(MapperStateEntry("$4090-$4097", "Audio Debug"));
+	entries.push_back(MapperStateEntry("$4090.0-5", "Volume Gain", _volume.GetGain(), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4091", "Wave Accumulator", ((GetWaveAccumulator() >> 12) & 0xFF), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4092.0-5", "Mod Gain", _mod.GetGain(), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4093.0-6", "Mod Accumulator", ((_mod.GetModAccumulator() >> 5) & 0x7F), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4094", "Mod Counter * Gain", ((_mod.GetOutput() >> 4) & 0xFF), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4095.0-3", "Mod Counter Increment", _mod.GetModIncrement(), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4096.0-5", "Wavetable Value", (_waveTable[_wavePosition] & 0x3F), MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4097.0-6", "Mod Counter Value", std::to_string(modCounter), (modCounter & 0x7F)));
 }

--- a/Core/NES/Mappers/FDS/FdsAudio.h
+++ b/Core/NES/Mappers/FDS/FdsAudio.h
@@ -39,6 +39,8 @@ protected:
 	void ClockAudio() override;
 	void UpdateOutput();
 
+	uint32_t GetWaveAccumulator();
+
 public:
 	FdsAudio(NesConsole* console);
 

--- a/Core/NES/Mappers/FDS/ModChannel.h
+++ b/Core/NES/Mappers/FDS/ModChannel.h
@@ -142,4 +142,15 @@ public:
 	{
 		return _modulationDisabled;
 	}
+	
+	uint32_t GetModAccumulator()
+	{
+		return (_modTablePosition << 12) | _overflowCounter;
+	}
+	
+	int8_t GetModIncrement()
+	{
+		int16_t offset = _modLut[_modTable[_modTablePosition]];
+		return offset == ModReset ? 0x0C : offset & 0x0F;
+	}
 };

--- a/Core/NES/Mappers/FDS/ModChannel.h
+++ b/Core/NES/Mappers/FDS/ModChannel.h
@@ -142,12 +142,12 @@ public:
 	{
 		return _modulationDisabled;
 	}
-	
+
 	uint32_t GetModAccumulator()
 	{
 		return (_modTablePosition << 12) | _overflowCounter;
 	}
-	
+
 	int8_t GetModIncrement()
 	{
 		int16_t offset = _modLut[_modTable[_modTablePosition]];

--- a/Core/NES/Mappers/FDS/ModChannel.h
+++ b/Core/NES/Mappers/FDS/ModChannel.h
@@ -42,7 +42,7 @@ public:
 				break;
 			case 0x4087:
 				BaseFdsChannel::WriteReg(addr, value);
-				_modulationDisabled = (value & 0x80) == 0x80;
+				_modulationDisabled = value & 0x80;
 				if(_modulationDisabled) {
 					_overflowCounter = 0;
 				}

--- a/Core/NES/Mappers/NSF/NsfMapper.cpp
+++ b/Core/NES/Mappers/NSF/NsfMapper.cpp
@@ -70,7 +70,7 @@ void NsfMapper::InitMapper(RomData& romData)
 	}
 
 	if(_nsfHeader.SoundChips & NsfSoundChips::FDS) {
-		AddRegisterRange(0x4040, 0x4092, MemoryOperation::Any);
+		AddRegisterRange(0x4040, 0x4097, MemoryOperation::Any);
 	}
 
 	//Reset/IRQ vector
@@ -227,7 +227,7 @@ void NsfMapper::ProcessCpuClock()
 
 uint8_t NsfMapper::ReadRegister(uint16_t addr)
 {
-	if((_nsfHeader.SoundChips & NsfSoundChips::FDS) && addr >= 0x4040 && addr <= 0x4092) {
+	if((_nsfHeader.SoundChips & NsfSoundChips::FDS) && addr >= 0x4040 && addr <= 0x4097) {
 		return _fdsAudio->ReadRegister(addr);
 	} else if((_nsfHeader.SoundChips & NsfSoundChips::Namco) && addr >= 0x4800 && addr <= 0x4FFF) {
 		return _namcoAudio->ReadRegister(addr);
@@ -249,7 +249,7 @@ uint8_t NsfMapper::ReadRegister(uint16_t addr)
 
 void NsfMapper::WriteRegister(uint16_t addr, uint8_t value)
 {
-	if((_nsfHeader.SoundChips & NsfSoundChips::FDS) && addr >= 0x4040 && addr <= 0x4092) {
+	if((_nsfHeader.SoundChips & NsfSoundChips::FDS) && addr >= 0x4040 && addr <= 0x408A) {
 		_fdsAudio->WriteRegister(addr, value);
 	} else if((_nsfHeader.SoundChips & NsfSoundChips::MMC5) && addr >= 0x5000 && addr <= 0x5015) {
 		_mmc5Audio->WriteRegister(addr, value);


### PR DESCRIPTION
This is a redo of #85 which avoids changing the current audio implementation.

## Working
- [x] $4023.D0 only affects writable disk registers, forces certain values for $4025 and $4026
- [x] $4023.D1 only directly affects $4080 (volume envelope), $4085 (mod counter), and $4088 (mod table write), apply instant volume mute for now
- [x] External connector: Mask $4026 writes to 7 bits, and force bit 7 = 1 for $4033 reads (i.e. always return good battery/power status)
- [x] $4030 reads do not clear byte transfer flag/disk IRQs
- [x] Move byte transfer flag to $4030.D7 (eventually needed by Tonkachi Editor)
- [x] $4090-$4097 reads (debug audio registers), handled by manually calculating the necessary values this time
- [x] Add remaining registers to register view
- [x] Fix off-by-one in envelope timer init
- [x] Swap and invert $4025 bits 0 and 1 to reflect current knowledge/documentation

## Not addressing
- Register peeking
- Actual audio reset state when $4023.D1 = 0 (research ongoing) + rename `_soundRegEnabled` to reflect its purpose
- $4095 upper nybble
- DRAM refresh watchdog ($4030.D1)
- CRC handling ($4025.D4 & D6)
- End of head behaviour ($4030.D6)
- Byte transfer flag behaviour ($4030.D7)
- Wavetable volume/modulation accuracy improvements
- Non-linear DAC + volume PWM + filtering (probably not worth the performance hit for a minuscule audio improvement)

## Test programs
- [FDS-Mirroring-Test](https://github.com/TakuikaNinja/FDS-Mirroring-Test) (Passes all tests on latest version)
- [FDS-4023-Test](https://github.com/TakuikaNinja/FDS-4023-Test) (Readable registers stay readable)
- [FDS-Audio-Registers](https://github.com/TakuikaNinja/FDS-Audio-Registers) (Audio plays properly, albeit with inaccurate audio reset state)