### PR TITLE
MacOS: Enable GameController background events

### DIFF
--- a/MacOS/MacOSKeyManager.mm
+++ b/MacOS/MacOSKeyManager.mm
@@ -43,6 +43,10 @@ MacOSKeyManager::MacOSKeyManager(Emulator* emu)
 
 	_disableAllKeys = false;
 
+	if(@available(macOS 11.3, *)) {
+		GCController.shouldMonitorBackgroundEvents = YES;
+	}
+
 	NSEventMask eventMask = NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged;
 
 	_eventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:eventMask handler:^ NSEvent* (NSEvent* event) {


### PR DESCRIPTION
Ran into this while doing ALTTPR yesterday. This PR fixes controller inputs not being picked up while Mesen is in the background on Mac by enabling GameController background event monitoring (Required as of some years back).