### PR TITLE
NES: Implement accurate sprite shifters & allow sprites on scanline 0

### DIFF
--- a/Core/NES/BaseNesPpu.h
+++ b/Core/NES/BaseNesPpu.h
@@ -85,9 +85,13 @@ protected:
 	////////////////////////
 	//448 : end of cache line
 	////////////////////////
-	bool _hasSprite[257] = {};
-	//705
 	NesSpriteInfo _spriteTiles[64] = {};
+
+	static constexpr int SpriteShifterDone = 0x8000;
+	uint16_t _spriteShifterList[9] = { SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone }; //Ordered by X coordinate.
+	uint8_t _nextSpriteShifter = 0;
+	uint8_t _activeSpriteShifters = 0;
+	bool _dotSkipped = false;
 
 	Emulator* _emu = nullptr;
 	EmuSettings* _settings = nullptr;

--- a/Core/NES/BaseNesPpu.h
+++ b/Core/NES/BaseNesPpu.h
@@ -91,7 +91,7 @@ protected:
 	uint16_t _spriteShifterList[9] = { SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone, SpriteShifterDone }; //Ordered by X coordinate.
 	uint8_t _nextSpriteShifter = 0;
 	uint8_t _activeSpriteShifters = 0;
-	bool _dotSkipped = false;
+	uint8_t _dotSkipped = 0;
 
 	Emulator* _emu = nullptr;
 	EmuSettings* _settings = nullptr;

--- a/Core/NES/DefaultNesPpu.h
+++ b/Core/NES/DefaultNesPpu.h
@@ -9,7 +9,7 @@ public:
 	{
 	}
 
-	__forceinline void StoreSpriteInformation(bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset) {}
+	__forceinline void StoreSpriteInformation(bool horizontalMirror, bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset, NesSpriteInfo& sprite) {}
 	__forceinline void StoreTileInformation() {}
 	__forceinline bool RemoveSpriteLimit() { return _console->GetNesConfig().RemoveSpriteLimit; }
 	__forceinline bool UseAdaptiveSpriteLimit() { return _console->GetNesConfig().AdaptiveSpriteLimit; }

--- a/Core/NES/HdPacks/HdBuilderPpu.h
+++ b/Core/NES/HdPacks/HdBuilderPpu.h
@@ -26,13 +26,16 @@ public:
 	__forceinline bool UseAdaptiveSpriteLimit() { return _console->GetNesConfig().AdaptiveSpriteLimit; }
 	void* OnBeforeSendFrame() { return nullptr; }
 
-	__forceinline void StoreSpriteInformation(bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset)
+	__forceinline void StoreSpriteInformation(bool horizontalMirror, bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset, NesSpriteInfo& sprite)
 	{
 		NesSpriteInfoEx& info = _exSpriteInfo[_spriteIndex];
 		info.TileAddr = tileAddr;
 		info.AbsoluteTileAddr = _mapper->GetPpuAbsoluteAddress(info.TileAddr).Address;
+		info.HorizontalMirror = horizontalMirror;
 		info.VerticalMirror = verticalMirror;
 		info.OffsetY = lineOffset;
+		info.LowByte = sprite.LowByte;
+		info.HighByte = sprite.HighByte;
 	}
 
 	__forceinline void StoreTileInformation()
@@ -40,7 +43,7 @@ public:
 		_previousTileEx = _currentTileEx;
 		_currentTileEx = _nextTileEx;
 
-		uint8_t tileIndex = ReadVram(GetNameTableAddr());
+		uint8_t tileIndex = _mapper->DebugReadVram(GetNameTableAddr());
 		uint16_t tileAddr = (tileIndex << 4) | (_videoRamAddr >> 12) | _control.BackgroundPatternAddr;
 
 		_nextTileEx.OffsetY = _videoRamAddr >> 12;

--- a/Core/NES/HdPacks/HdNesPpu.h
+++ b/Core/NES/HdPacks/HdNesPpu.h
@@ -2,8 +2,6 @@
 #include "pch.h"
 #include "NES/NesPpu.h"
 #include "NES/NesConsole.h"
-#include "NES/HdPacks/HdPackConditions.h"
-#include "NES/NesMemoryManager.h"
 #include "NES/BaseMapper.h"
 #include "NES/HdPacks/HdData.h"
 
@@ -11,8 +9,11 @@ struct NesSpriteInfoEx
 {
 	uint32_t AbsoluteTileAddr;
 	uint16_t TileAddr;
+	bool HorizontalMirror;
 	bool VerticalMirror;
 	uint8_t OffsetY;
+	uint8_t LowByte;
+	uint8_t HighByte;
 };
 
 struct NesTileInfoEx
@@ -44,13 +45,16 @@ public:
 	__forceinline bool RemoveSpriteLimit() { return _forceRemoveSpriteLimit || _console->GetNesConfig().RemoveSpriteLimit; }
 	__forceinline bool UseAdaptiveSpriteLimit() { return _forceRemoveSpriteLimit || _console->GetNesConfig().AdaptiveSpriteLimit; }
 
-	__forceinline void StoreSpriteInformation(bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset)
+	__forceinline void StoreSpriteInformation(bool horizontalMirror, bool verticalMirror, uint16_t tileAddr, uint8_t lineOffset, NesSpriteInfo& sprite)
 	{
 		NesSpriteInfoEx& info = _exSpriteInfo[_spriteIndex];
 		info.TileAddr = tileAddr;
 		info.AbsoluteTileAddr = _mapper->GetPpuAbsoluteAddress(info.TileAddr).Address;
+		info.HorizontalMirror = horizontalMirror;
 		info.VerticalMirror = verticalMirror;
 		info.OffsetY = lineOffset;
+		info.LowByte = sprite.LowByte;
+		info.HighByte = sprite.HighByte;
 	}
 
 	__forceinline void StoreTileInformation()
@@ -127,12 +131,12 @@ public:
 						}
 
 						tileInfo.Sprite[j].OffsetX = shift;
-						tileInfo.Sprite[j].HorizontalMirroring = sprite.HorizontalMirror;
+						tileInfo.Sprite[j].HorizontalMirroring = spriteEx.HorizontalMirror;
 						tileInfo.Sprite[j].VerticalMirroring = spriteEx.VerticalMirror;
 						tileInfo.Sprite[j].BackgroundPriority = sprite.BackgroundPriority;
 						tileInfo.Sprite[j].PaletteOffset = sprite.PaletteOffset;
 
-						tileInfo.Sprite[j].SpriteColorIndex = ((sprite.LowByte << shift) & 0x80) >> 7 | ((sprite.HighByte << shift) & 0x80) >> 6;
+						tileInfo.Sprite[j].SpriteColorIndex = ((spriteEx.LowByte << shift) & 0x80) >> 7 | ((spriteEx.HighByte << shift) & 0x80) >> 6;
 
 						if(tileInfo.Sprite[j].SpriteColorIndex == 0) {
 							tileInfo.Sprite[j].SpriteColor = ReadPaletteRam(0);

--- a/Core/NES/HdPacks/HdNesPpu.h
+++ b/Core/NES/HdPacks/HdNesPpu.h
@@ -132,11 +132,7 @@ public:
 						tileInfo.Sprite[j].BackgroundPriority = sprite.BackgroundPriority;
 						tileInfo.Sprite[j].PaletteOffset = sprite.PaletteOffset;
 
-						if(sprite.HorizontalMirror) {
-							tileInfo.Sprite[j].SpriteColorIndex = ((sprite.LowByte >> shift) & 0x01) | ((sprite.HighByte >> shift) & 0x01) << 1;
-						} else {
-							tileInfo.Sprite[j].SpriteColorIndex = ((sprite.LowByte << shift) & 0x80) >> 7 | ((sprite.HighByte << shift) & 0x80) >> 6;
-						}
+						tileInfo.Sprite[j].SpriteColorIndex = ((sprite.LowByte << shift) & 0x80) >> 7 | ((sprite.HighByte << shift) & 0x80) >> 6;
 
 						if(tileInfo.Sprite[j].SpriteColorIndex == 0) {
 							tileInfo.Sprite[j].SpriteColor = ReadPaletteRam(0);

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -725,13 +725,12 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 	bool verticalMirror = (attributes & 0x80) == 0x80;
 
 	uint16_t tileAddr;
-	uint16_t rangeResult;
 	const uint8_t spriteSizeMask = _control.LargeSprites ? 15 : 7;
+
 	//This function is only called on rendering scanlines (0-239) or pre-render (-1). We need to handle the pre-render scanline numbers manually.
 	//These are deliberately truncated to 8 bits to match hardware behavior.
 	const uint8_t scanline8Bit = _scanline >= 0 ? _scanline : (_region == ConsoleRegion::Ntsc ? 261 : 311);
-
-	rangeResult = scanline8Bit - spriteY;
+	uint16_t rangeResult = scanline8Bit - spriteY;
 	if(verticalMirror) {
 		rangeResult ^= spriteSizeMask;
 	}
@@ -753,27 +752,27 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 		info.LowByte = ReadVram(tileAddr);
 		info.HighByte = ReadVram(tileAddr + 8);
 	}
-	if(horizontalMirror) {
-		info.LowByte = BitUtilities::ReverseByte(info.LowByte);
-		info.HighByte = BitUtilities::ReverseByte(info.HighByte);
-	}
 	info.SpriteX = spriteX;
 
 	bool inRange = rangeResult <= spriteSizeMask;
 	if(inRange) {
-		((T*)this)->StoreSpriteInformation(horizontalMirror, verticalMirror, tileAddr, rangeResult, info); //Used by HD packs
-		_spriteCount++;
-	}
-
-	if(!extraSprite) {
-		if(inRange) {
-			_spriteShifterList[_spriteIndex] = (((uint16_t)spriteX + 1) << 4) | _spriteIndex;
-		} else {
-			info.LowByte = 0;
-			info.HighByte = 0;
-
-			_spriteShifterList[_spriteIndex] = SpriteShifterDone;
+		if(horizontalMirror) {
+			info.LowByte = BitUtilities::ReverseByte(info.LowByte);
+			info.HighByte = BitUtilities::ReverseByte(info.HighByte);
 		}
+
+		((T*)this)->StoreSpriteInformation(horizontalMirror, verticalMirror, tileAddr, rangeResult, info); //Used by HD packs
+
+		if(!extraSprite) {
+			_spriteShifterList[_spriteIndex] = (((uint16_t)spriteX + 1) << 4) | _spriteIndex;
+		}
+
+		_spriteCount++;
+	} else if(!extraSprite) {
+		info.LowByte = 0;
+		info.HighByte = 0;
+
+		_spriteShifterList[_spriteIndex] = SpriteShifterDone;
 	}
 
 	_spriteIndex++;
@@ -781,7 +780,7 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 
 template<class T> void NesPpu<T>::LoadExtraSprites()
 {
-	if(_spriteCount == 8 && ((T*)this)->RemoveSpriteLimit()) {
+	if(_spriteCount == 8 && ((T*)this)->RemoveSpriteLimit() && _scanline >= 0) {
 		bool loadExtraSprites = true;
 
 		if(((T*)this)->UseAdaptiveSpriteLimit()) {
@@ -854,6 +853,7 @@ template<class T> uint8_t NesPpu<T>::GetPixelColor()
 		uint8_t remainingShifters = _dotSkipped ? 0xff : _activeSpriteShifters;
 		_lastSprite = &_spriteTiles[BitUtilities::GetHighestBitIndex(_activeSpriteShifters)];
 
+		//Output and shift from all active sprite shifters.
 		while(remainingShifters) {
 			uint8_t i = BitUtilities::GetHighestBitIndex(remainingShifters);
 			remainingShifters &= ~(1 << i);
@@ -1011,6 +1011,8 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 				//This behavior is NTSC-specific - PAL frames are always the same number of cycles
 				//"With rendering enabled, each odd PPU frame is one PPU clock shorter than normal" (skip from 339 to 0, going over 340)
 				_cycle = 340;
+
+				//Set a counter for this so it'll be nonzero for GetPixelColor on dot 1, forcing sprite shifter output.
 				_dotSkipped = 3;
 				_needStateUpdate = true;
 				// Delay all sprites by 1 pixel.
@@ -1019,6 +1021,7 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 				}
 			}
 		} else {
+			//If rendering is off, the sprites aren't put into counting mode, so make sure they're output+shift in case they got pattern data.
 			_activeSpriteShifters = 0xff;
 		}
 	}

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -724,9 +724,11 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 	bool verticalMirror = (attributes & 0x80) == 0x80;
 
 	uint16_t tileAddr;
-	int16_t rangeResult;
+	uint16_t rangeResult;
 	const uint8_t spriteSizeMask = _control.LargeSprites ? 15 : 7;
-	const uint8_t scanline8Bit = (_scanline + 256) & 0xff;
+	//This function is only called on rendering scanlines (0-239) or pre-render (-1). We need to handle the pre-render scanline numbers manually.
+	//These are deliberately truncated to 8 bits to match hardware behavior.
+	const uint8_t scanline8Bit = _scanline >= 0 ? _scanline : (_region == ConsoleRegion::Ntsc ? 261 : 311);
 
 	rangeResult = scanline8Bit - spriteY;
 	if(verticalMirror) {
@@ -753,12 +755,14 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 	}
 	info.SpriteX = spriteX;
 
-	if(rangeResult >= 0) {
+	if(rangeResult <= spriteSizeMask) {
 		((T*)this)->StoreSpriteInformation(verticalMirror, tileAddr, rangeResult); //Used by HD packs
 
 		for(int i = 0; i < 8 && spriteX + i + 1 < 257; i++) {
 			_hasSprite[spriteX + i + 1] = true;
 		}
+
+		_spriteCount++;
 	} else {
 		info.LowByte = 0;
 		info.HighByte = 0;
@@ -897,7 +901,12 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 			_console->GetCpu()->ClearNmiFlag();
 		}
 	} else if(_cycle >= 257 && _cycle <= 320) {
-		if(_prevRenderingEnabled) {
+		if(_cycle == 257) {
+			//Initialize this variable so we can count active sprites in OAM2.
+			_spriteCount = 0;
+		}
+		if(IsRenderingEnabled()) {
+			//sprite_0_on_next_scanline is copied to sprite_0_on_this_scanline every dot in this range.
 			_sprite0Visible = _sprite0Added;
 
 			//"OAMADDR is set to 0 during each of ticks 257-320 (the sprite tile loading interval) of the pre-render and visible scanlines." (When rendering)
@@ -982,31 +991,6 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluationStart()
 	_lastVisibleSpriteAddr = _firstVisibleSpriteAddr;
 }
 
-template<class T> void NesPpu<T>::ProcessSpriteEvaluationEnd()
-{
-	//Add 3 to address to count any partially-copied sprite.
-	//If eval is misaligned and wraps back to the start of OAM, the copy can
-	//be stopped mid-sprite (e.g only 1 to 3 bytes are copied to secondary OAM)
-	_spriteCount = ((_secondaryOamAddr + 3) >> 2);
-
-	if(_settings->GetNesConfig().EnablePpuSpriteEvalBug) {
-		//(Not entirely confirmed - but matches observed behavior)
-		//For early PPUs (2C02B and earlier), after sprite eval wraps back to the start of OAM,
-		//all subsequent sprites appear to be considered as "out of range", causing only their
-		//Y coordinate to be copied to secondary OAM, and then skipping to the next sprite.
-		//However, if the last Y position copied to secondary OAM by this process happens to be
-		//"in range", it will be end up being shown as a sprite. The sprite's remaining 3 bytes
-		//will be $FF (because secondary OAM was cleared at the start of the scanline), causing
-		//it to display pixels from sprite tile $FF at X=255, with h+v mirroring and sprite palette 3.
-		bool inRange = (_scanline >= _oamCopybuffer && _scanline < _oamCopybuffer + (_control.LargeSprites ? 16 : 8));
-		if(inRange && _spriteCount < 8) {
-			_spriteCount++;
-		}
-	}
-
-	_secondaryOamAddr = 0;
-}
-
 template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 {
 	if(_prevRenderingEnabled) {
@@ -1028,6 +1012,14 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 				uint8_t spriteAddrH = _spriteRamAddr >> 2;
 				uint8_t spriteAddrL = _spriteRamAddr & 3;
 
+				//(Not entirely confirmed - but matches observed behavior)
+				//For early PPUs (2C02B and earlier), after sprite eval wraps back to the start of OAM,
+				//all subsequent sprites appear to be considered as "out of range", causing only their
+				//Y coordinate to be copied to secondary OAM, and then skipping to the next sprite.
+				//However, if the last Y position copied to secondary OAM by this process happens to be 
+				//"in range", it will be end up being shown as a sprite. The sprite's remaining 3 bytes
+				//will be $FF (because secondary OAM was cleared at the start of the scanline), causing
+				//it to display pixels from sprite tile $FF at X=255, with h+v mirroring and sprite palette 3.
 				if(_oamCopyDone && !_settings->GetNesConfig().EnablePpuSpriteEvalBug) {
 					spriteAddrH = (spriteAddrH + 1) & 0x3F;
 					//"As seen above, a side effect of the OAM write disable signal is to turn writes to the secondary OAM into reads from it."

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -744,7 +744,6 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 
 	NesSpriteInfo& info = _spriteTiles[_spriteIndex];
 	info.BackgroundPriority = backgroundPriority;
-	info.HorizontalMirror = horizontalMirror;
 	info.PaletteOffset = ((attributes & 0x03) << 2) | 0x10;
 	if(extraSprite) {
 		//Use DebugReadVram for extra sprites to prevent side-effects.
@@ -762,7 +761,7 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 
 	bool inRange = rangeResult <= spriteSizeMask;
 	if(inRange) {
-		((T*)this)->StoreSpriteInformation(verticalMirror, tileAddr, rangeResult); //Used by HD packs
+		((T*)this)->StoreSpriteInformation(horizontalMirror, verticalMirror, tileAddr, rangeResult, info); //Used by HD packs
 		_spriteCount++;
 	}
 
@@ -1653,7 +1652,6 @@ template<class T> void NesPpu<T>::Serialize(Serializer& s)
 			SVI(_spriteTiles[i].LowByte);
 			SVI(_spriteTiles[i].HighByte);
 			SVI(_spriteTiles[i].PaletteOffset);
-			SVI(_spriteTiles[i].HorizontalMirror);
 			SVI(_spriteTiles[i].BackgroundPriority);
 		}
 	}

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -850,7 +850,7 @@ template<class T> uint8_t NesPpu<T>::GetPixelColor()
 	int8_t spriteIndex = -1;
 	uint8_t spriteColor = 0;
 	//If the dot is skipped, all sprite shifters are active on the first dot of the scanline.
-	if((_spriteCount | _activeSpriteShifters | (uint8_t)_dotSkipped) && (_mask.BackgroundEnabled | _mask.SpritesEnabled)) {
+	if((_spriteCount | _activeSpriteShifters | _dotSkipped) && (_mask.BackgroundEnabled | _mask.SpritesEnabled)) {
 		uint8_t remainingShifters = _dotSkipped ? 0xff : _activeSpriteShifters;
 		_lastSprite = &_spriteTiles[BitUtilities::GetHighestBitIndex(_activeSpriteShifters)];
 
@@ -1012,7 +1012,8 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 				//This behavior is NTSC-specific - PAL frames are always the same number of cycles
 				//"With rendering enabled, each odd PPU frame is one PPU clock shorter than normal" (skip from 339 to 0, going over 340)
 				_cycle = 340;
-				_dotSkipped = true;
+				_dotSkipped = 3;
+				_needStateUpdate = true;
 				// Delay all sprites by 1 pixel.
 				for(int i = 0; i < 8; i++) {
 					_spriteShifterList[i] += 1 << 4;
@@ -1555,6 +1556,11 @@ template<class T> void NesPpu<T>::UpdateState()
 			}
 			_needVideoRamIncrement = true;
 		}
+		_needStateUpdate = true;
+	}
+
+	if(_dotSkipped > 0) {
+		_dotSkipped--;
 		_needStateUpdate = true;
 	}
 }

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -850,7 +850,7 @@ template<class T> uint8_t NesPpu<T>::GetPixelColor()
 	int8_t spriteIndex = -1;
 	uint8_t spriteColor = 0;
 	//If the dot is skipped, all sprite shifters are active on the first dot of the scanline.
-	if((_spriteCount | _activeSpriteShifters | _dotSkipped) && (_mask.BackgroundEnabled | _mask.SpritesEnabled)) {
+	if((_spriteCount | _activeSpriteShifters | _dotSkipped) && _prevRenderingEnabled) {
 		uint8_t remainingShifters = _dotSkipped ? 0xff : _activeSpriteShifters;
 		_lastSprite = &_spriteTiles[BitUtilities::GetHighestBitIndex(_activeSpriteShifters)];
 

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -931,7 +931,6 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 			ProcessSpriteEvaluation();
 
 			((T*)this)->DrawPixel();
-			_dotSkipped = false;
 
 			if(_prevRenderingEnabled) {
 				ShiftTileRegisters();

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -724,57 +724,44 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 	bool verticalMirror = (attributes & 0x80) == 0x80;
 
 	uint16_t tileAddr;
-	uint8_t lineOffset;
+	int16_t rangeResult;
+	const uint8_t spriteSizeMask = _control.LargeSprites ? 15 : 7;
+	const uint8_t scanline8Bit = (_scanline + 256) & 0xff;
+
+	rangeResult = scanline8Bit - spriteY;
 	if(verticalMirror) {
-		lineOffset = (_control.LargeSprites ? 15 : 7) - (_scanline - spriteY);
-	} else {
-		lineOffset = _scanline - spriteY;
+		rangeResult ^= spriteSizeMask;
 	}
 
 	if(_control.LargeSprites) {
-		tileAddr = (((tileIndex & 0x01) ? 0x1000 : 0x0000) | ((tileIndex & ~0x01) << 4)) + (lineOffset >= 8 ? lineOffset + 8 : lineOffset);
+		tileAddr = (((tileIndex & 0x01) << 12) | ((tileIndex & ~0x01) << 4)) + ((rangeResult & 0x08) << 1) + (rangeResult & 0x07);
 	} else {
-		tileAddr = ((tileIndex << 4) | _control.SpritePatternAddr) + lineOffset;
+		tileAddr = (_control.SpritePatternAddr | (tileIndex << 4)) + (rangeResult & 0x07);
 	}
 
-	bool fetchLastSprite = true;
-	if((_spriteIndex < _spriteCount || extraSprite) && spriteY < 240) {
-		NesSpriteInfo& info = _spriteTiles[_spriteIndex];
-		info.BackgroundPriority = backgroundPriority;
-		info.HorizontalMirror = horizontalMirror;
-		info.PaletteOffset = ((attributes & 0x03) << 2) | 0x10;
-		if(extraSprite) {
-			//Use DebugReadVram for extra sprites to prevent side-effects.
-			info.LowByte = _mapper->DebugReadVram(tileAddr);
-			info.HighByte = _mapper->DebugReadVram(tileAddr + 8);
-		} else {
-			fetchLastSprite = false;
-			info.LowByte = ReadVram(tileAddr);
-			info.HighByte = ReadVram(tileAddr + 8);
-		}
-		info.SpriteX = spriteX;
-		((T*)this)->StoreSpriteInformation(verticalMirror, tileAddr, lineOffset); //Used by HD packs
-
-		if(_scanline >= 0) {
-			//Sprites read on prerender scanline are not shown on scanline 0
-			for(int i = 0; i < 8 && spriteX + i + 1 < 257; i++) {
-				_hasSprite[spriteX + i + 1] = true;
-			}
-		}
+	NesSpriteInfo &info = _spriteTiles[_spriteIndex];
+	info.BackgroundPriority = backgroundPriority;
+	info.HorizontalMirror = horizontalMirror;
+	info.PaletteOffset = ((attributes & 0x03) << 2) | 0x10;
+	if(extraSprite) {
+		//Use DebugReadVram for extra sprites to prevent side-effects.
+		info.LowByte = _mapper->DebugReadVram(tileAddr);
+		info.HighByte = _mapper->DebugReadVram(tileAddr + 8);
+	} else {
+		info.LowByte = ReadVram(tileAddr);
+		info.HighByte = ReadVram(tileAddr + 8);
 	}
+	info.SpriteX = spriteX;
 
-	if(fetchLastSprite) {
-		//Fetches to sprite 0xFF for remaining sprites/hidden - used by MMC3 IRQ counter
-		lineOffset = 0;
-		tileIndex = 0xFF;
-		if(_control.LargeSprites) {
-			tileAddr = (((tileIndex & 0x01) ? 0x1000 : 0x0000) | ((tileIndex & ~0x01) << 4)) + (lineOffset >= 8 ? lineOffset + 8 : lineOffset);
-		} else {
-			tileAddr = ((tileIndex << 4) | _control.SpritePatternAddr) + lineOffset;
+	if(rangeResult >= 0) {
+		((T*)this)->StoreSpriteInformation(verticalMirror, tileAddr, rangeResult); //Used by HD packs
+
+		for(int i = 0; i < 8 && spriteX + i + 1 < 257; i++) {
+			_hasSprite[spriteX + i + 1] = true;
 		}
-
-		ReadVram(tileAddr);
-		ReadVram(tileAddr + 8);
+	} else {
+		info.LowByte = 0;
+		info.HighByte = 0;
 	}
 
 	_spriteIndex++;

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -27,6 +27,8 @@
 
 #include "Shared/EventType.h"
 
+#include "Utilities/BitUtilities.h"
+
 template<class T> NesPpu<T>::NesPpu(NesConsole* console)
 {
 	_console = console;
@@ -123,7 +125,6 @@ template<class T> void NesPpu<T>::Reset(bool softReset)
 	_sprite0Added = false;
 	_oamCopyDone = false;
 
-	memset(_hasSprite, 0, sizeof(_hasSprite));
 	memset(_spriteTiles, 0, sizeof(_spriteTiles));
 	_spriteCount = 0;
 	_secondaryOamAddr = 0;
@@ -741,7 +742,7 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 		tileAddr = (_control.SpritePatternAddr | (tileIndex << 4)) + (rangeResult & 0x07);
 	}
 
-	NesSpriteInfo &info = _spriteTiles[_spriteIndex];
+	NesSpriteInfo& info = _spriteTiles[_spriteIndex];
 	info.BackgroundPriority = backgroundPriority;
 	info.HorizontalMirror = horizontalMirror;
 	info.PaletteOffset = ((attributes & 0x03) << 2) | 0x10;
@@ -753,19 +754,27 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 		info.LowByte = ReadVram(tileAddr);
 		info.HighByte = ReadVram(tileAddr + 8);
 	}
+	if(horizontalMirror) {
+		info.LowByte = BitUtilities::ReverseByte(info.LowByte);
+		info.HighByte = BitUtilities::ReverseByte(info.HighByte);
+	}
 	info.SpriteX = spriteX;
 
-	if(rangeResult <= spriteSizeMask) {
+	bool inRange = rangeResult <= spriteSizeMask;
+	if(inRange) {
 		((T*)this)->StoreSpriteInformation(verticalMirror, tileAddr, rangeResult); //Used by HD packs
-
-		for(int i = 0; i < 8 && spriteX + i + 1 < 257; i++) {
-			_hasSprite[spriteX + i + 1] = true;
-		}
-
 		_spriteCount++;
-	} else {
-		info.LowByte = 0;
-		info.HighByte = 0;
+	}
+
+	if(!extraSprite) {
+		if(inRange) {
+			_spriteShifterList[_spriteIndex] = (((uint16_t)spriteX + 1) << 4) | _spriteIndex;
+		} else {
+			info.LowByte = 0;
+			info.HighByte = 0;
+
+			_spriteShifterList[_spriteIndex] = SpriteShifterDone;
+		}
 	}
 
 	_spriteIndex++;
@@ -804,7 +813,6 @@ template<class T> void NesPpu<T>::LoadExtraSprites()
 				uint8_t spriteY = _spriteRam[i];
 				if(_scanline >= spriteY && _scanline < spriteY + (_control.LargeSprites ? 16 : 8)) {
 					LoadSprite(spriteY, _spriteRam[i + 1], _spriteRam[i + 2], _spriteRam[i + 3], true);
-					_spriteCount++;
 				}
 			}
 		}
@@ -813,6 +821,8 @@ template<class T> void NesPpu<T>::LoadExtraSprites()
 
 template<class T> void NesPpu<T>::LoadSpriteTileInfo()
 {
+	//Set it to whatever shifter we're filling.
+	_spriteIndex = (_cycle - 257) >> 3;
 	uint8_t* spriteAddr = _secondarySpriteRam + _spriteIndex * 4;
 	LoadSprite(*spriteAddr, *(spriteAddr + 1), *(spriteAddr + 2), *(spriteAddr + 3), false);
 }
@@ -838,40 +848,69 @@ template<class T> uint8_t NesPpu<T>::GetPixelColor()
 		}
 	}
 
-	if(_hasSprite[_cycle] && _cycle > _minimumDrawSpriteCycle) {
-		//SpriteMask = true: Hide sprites in leftmost 8 pixels of screen
-		for(uint8_t i = 0; i < _spriteCount; i++) {
-			int32_t shift = (int32_t)_cycle - _spriteTiles[i].SpriteX - 1;
-			if(shift >= 0 && shift < 8) {
-				_lastSprite = &_spriteTiles[i];
-				uint8_t spriteColor;
-				if(_spriteTiles[i].HorizontalMirror) {
-					spriteColor = ((_lastSprite->LowByte >> shift) & 0x01) | ((_lastSprite->HighByte >> shift) & 0x01) << 1;
-				} else {
-					spriteColor = ((_lastSprite->LowByte << shift) & 0x80) >> 7 | ((_lastSprite->HighByte << shift) & 0x80) >> 6;
+	int8_t spriteIndex = -1;
+	uint8_t spriteColor = 0;
+	//If the dot is skipped, all sprite shifters are active on the first dot of the scanline.
+	if((_spriteCount | _activeSpriteShifters | (uint8_t)_dotSkipped) && (_mask.BackgroundEnabled | _mask.SpritesEnabled)) {
+		uint8_t remainingShifters = _dotSkipped ? 0xff : _activeSpriteShifters;
+		_lastSprite = &_spriteTiles[BitUtilities::GetHighestBitIndex(_activeSpriteShifters)];
+
+		while(remainingShifters) {
+			uint8_t i = BitUtilities::GetHighestBitIndex(remainingShifters);
+			remainingShifters &= ~(1 << i);
+
+			NesSpriteInfo& sprite = _spriteTiles[i];
+
+			//Get the color. We start with the lowest priority shifter first so the higher priority ones override it.
+			uint8_t currColor = ((sprite.HighByte >> 6) & 0x2) | (sprite.LowByte >> 7);
+			if(currColor != 0) {
+				spriteIndex = i;
+				spriteColor = currColor;
+				_lastSprite = &sprite;
+			}
+			sprite.HighByte <<= 1;
+			sprite.LowByte <<= 1;
+
+			//If the shifter is empty, deactivate it.
+			if(!(sprite.HighByte | sprite.LowByte)) {
+				_activeSpriteShifters &= ~(1 << i);
+			}
+		}
+
+		if(_cycle > _minimumDrawSpriteCycle && _mask.SpritesEnabled) {
+			if(_spriteCount > 8 && spriteColor == 0) {
+				for(spriteIndex = 8; spriteIndex < _spriteCount; spriteIndex++) {
+					NesSpriteInfo& sprite = _spriteTiles[spriteIndex];
+					uint32_t shift = (int32_t)_cycle - sprite.SpriteX - 1;
+					if(shift < 8) {
+						_lastSprite = &sprite;
+						spriteColor = ((sprite.LowByte << shift) & 0x80) >> 7 | ((sprite.HighByte << shift) & 0x80) >> 6;
+						if(spriteColor) {
+							break;
+						}
+					}
+				}
+			}
+
+			if(spriteColor != 0) {
+				if(_sprite0Visible && spriteIndex == 0 && spriteColor != 0 && spriteBgColor != 0 && _cycle != 256 && _mask.BackgroundEnabled && !_statusFlags.Sprite0Hit && _cycle > _minimumDrawSpriteStandardCycle) {
+					//"The hit condition is basically sprite zero is in range AND the first sprite output unit is outputting a non-zero pixel AND the background drawing unit is outputting a non-zero pixel."
+					//"Sprite zero hits do not register at x=255" (cycle 256)
+					//"... provided that background and sprite rendering are both enabled"
+					//"Should always miss when Y >= 239"
+					_statusFlags.Sprite0Hit = true;
+
+					_emu->AddDebugEvent<CpuType::Nes>(DebugEventType::SpriteZeroHit);
 				}
 
-				if(spriteColor != 0) {
-					//First sprite without a 00 color, use it.
-					if(i == 0 && spriteBgColor != 0 && _sprite0Visible && _cycle != 256 && _mask.BackgroundEnabled && !_statusFlags.Sprite0Hit && _cycle > _minimumDrawSpriteStandardCycle) {
-						//"The hit condition is basically sprite zero is in range AND the first sprite output unit is outputting a non-zero pixel AND the background drawing unit is outputting a non-zero pixel."
-						//"Sprite zero hits do not register at x=255" (cycle 256)
-						//"... provided that background and sprite rendering are both enabled"
-						//"Should always miss when Y >= 239"
-						_statusFlags.Sprite0Hit = true;
-
-						_emu->AddDebugEvent<CpuType::Nes>(DebugEventType::SpriteZeroHit);
-					}
-
-					if(_emulatorSpritesEnabled && (backgroundColor == 0 || !_spriteTiles[i].BackgroundPriority)) {
-						//Check sprite priority
-						return _lastSprite->PaletteOffset + spriteColor;
-					}
-					break;
+				if(_emulatorSpritesEnabled && (backgroundColor == 0 || !_spriteTiles[spriteIndex].BackgroundPriority)) {
+					//Check sprite priority
+					return _spriteTiles[spriteIndex].PaletteOffset + spriteColor;
 				}
 			}
 		}
 	}
+
 	return ((offset + ((_cycle - 1) & 0x07) < 8) ? _previousTilePalette : _currentTilePalette) + backgroundColor;
 }
 
@@ -889,23 +928,22 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 		}
 
 		if(_scanline >= 0) {
+			//"Secondary OAM clear and sprite evaluation do not occur on the pre-render line"
+			ProcessSpriteEvaluation();
+
 			((T*)this)->DrawPixel();
+			_dotSkipped = false;
+
 			if(_prevRenderingEnabled) {
 				ShiftTileRegisters();
 			}
-			//"Secondary OAM clear and sprite evaluation do not occur on the pre-render line"
-			ProcessSpriteEvaluation();
 		} else if(_cycle == 1) {
 			//Pre-render scanline logic
 			_statusFlags.VerticalBlank = false;
 			_console->GetCpu()->ClearNmiFlag();
 		}
 	} else if(_cycle >= 257 && _cycle <= 320) {
-		if(_cycle == 257) {
-			//Initialize this variable so we can count active sprites in OAM2.
-			_spriteCount = 0;
-		}
-		if(IsRenderingEnabled()) {
+		if(_prevRenderingEnabled) {
 			//sprite_0_on_next_scanline is copied to sprite_0_on_this_scanline every dot in this range.
 			_sprite0Visible = _sprite0Added;
 
@@ -939,7 +977,7 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 		}
 		if(_cycle == 257) {
 			_spriteIndex = 0;
-			memset(_hasSprite, 0, sizeof(_hasSprite));
+			_spriteCount = 0;
 			if(_prevRenderingEnabled) {
 				//copy horizontal scrolling value from t
 				_videoRamAddr = (_videoRamAddr & ~0x041F) | (_tmpVideoRamAddr & 0x041F);
@@ -961,15 +999,28 @@ template<class T> void NesPpu<T>::ProcessScanlineImpl()
 			_highBitShift <<= 8;
 			IncHorizontalScrolling();
 		}
-	} else if(_cycle == 337 || _cycle == 339) {
+	} else if(_cycle == 337) {
 		if(IsRenderingEnabled()) {
 			_tile.TileAddr = ReadVram(GetNameTableAddr());
+		}
+	} else if(_cycle == 339) {
+		if(IsRenderingEnabled()) {
+			_tile.TileAddr = ReadVram(GetNameTableAddr());
+
+			_activeSpriteShifters = 0;
 
 			if(_scanline == -1 && _cycle == 339 && (_frameCount & 0x01) && _region == ConsoleRegion::Ntsc && GetPpuModel() == PpuModel::Ppu2C02) {
 				//This behavior is NTSC-specific - PAL frames are always the same number of cycles
 				//"With rendering enabled, each odd PPU frame is one PPU clock shorter than normal" (skip from 339 to 0, going over 340)
 				_cycle = 340;
+				_dotSkipped = true;
+				// Delay all sprites by 1 pixel.
+				for(int i = 0; i < 8; i++) {
+					_spriteShifterList[i] += 1 << 4;
+				}
 			}
+		} else {
+			_activeSpriteShifters = 0xff;
 		}
 	}
 }
@@ -993,6 +1044,13 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluationStart()
 
 template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 {
+	//Handle sprite shifter counting.
+	while(static_cast<uint32_t>(_spriteShifterList[_nextSpriteShifter] >> 4) == _cycle) {
+		_activeSpriteShifters |= (1 << (_spriteShifterList[_nextSpriteShifter] & 7));
+		_spriteShifterList[_nextSpriteShifter] = SpriteShifterDone;
+		_nextSpriteShifter++;
+	}
+
 	if(_prevRenderingEnabled) {
 		if(_cycle < 65) {
 			//Clear secondary OAM at between cycle 1 and 64
@@ -1016,7 +1074,7 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 				//For early PPUs (2C02B and earlier), after sprite eval wraps back to the start of OAM,
 				//all subsequent sprites appear to be considered as "out of range", causing only their
 				//Y coordinate to be copied to secondary OAM, and then skipping to the next sprite.
-				//However, if the last Y position copied to secondary OAM by this process happens to be 
+				//However, if the last Y position copied to secondary OAM by this process happens to be
 				//"in range", it will be end up being shown as a sprite. The sprite's remaining 3 bytes
 				//will be $FF (because secondary OAM was cleared at the start of the scanline), causing
 				//it to display pixels from sprite tile $FF at X=255, with h+v mirroring and sprite palette 3.
@@ -1122,9 +1180,6 @@ template<class T> void NesPpu<T>::ProcessSpriteEvaluation()
 					}
 				}
 				_spriteRamAddr = (spriteAddrL & 0x03) | (spriteAddrH << 2);
-				if(_cycle == 256) {
-					ProcessSpriteEvaluationEnd();
-				}
 			}
 		}
 	}
@@ -1332,6 +1387,9 @@ template<class T> void NesPpu<T>::ProcessScanlineFirstCycle()
 
 	//Cycle = 0
 	if(_scanline < 240) {
+		_nextSpriteShifter = 0;
+		std::sort(_spriteShifterList, _spriteShifterList + 8);
+
 		if(_scanline == -1) {
 			_statusFlags.SpriteOverflow = false;
 			_statusFlags.Sprite0Hit = false;
@@ -1571,6 +1629,11 @@ template<class T> void NesPpu<T>::Serialize(Serializer& s)
 		SV(_openBus);
 		SV(_ignoreVramRead);
 
+		SVArray(_spriteShifterList, 8);
+		SV(_nextSpriteShifter);
+		SV(_activeSpriteShifters);
+		SV(_dotSkipped);
+
 		SV(_oamCopyDone);
 		SV(_needStateUpdate);
 		SV(_preventVblFlag);
@@ -1605,9 +1668,7 @@ template<class T> void NesPpu<T>::Serialize(Serializer& s)
 			_oamDecayCycles[i] = _console->GetCpu()->GetCycleCount();
 		}
 
-		for(int i = 0; i < 257; i++) {
-			_hasSprite[i] = true;
-		}
+		_spriteShifterList[8] = SpriteShifterDone;
 
 		_lastUpdatedPixel = -1;
 

--- a/Core/NES/NesPpu.h
+++ b/Core/NES/NesPpu.h
@@ -56,7 +56,6 @@ protected:
 	__forceinline void ProcessScanlineImpl();
 	__forceinline void ProcessSpriteEvaluation();
 	__noinline void ProcessSpriteEvaluationStart();
-	__noinline void ProcessSpriteEvaluationEnd();
 
 	void BeginVBlank();
 	void TriggerNmi();

--- a/Core/NES/NesTypes.h
+++ b/Core/NES/NesTypes.h
@@ -230,7 +230,6 @@ struct TileInfo
 
 struct NesSpriteInfo
 {
-	bool HorizontalMirror;
 	bool BackgroundPriority;
 	uint8_t SpriteX;
 	uint8_t LowByte;

--- a/Utilities/BitUtilities.h
+++ b/Utilities/BitUtilities.h
@@ -31,4 +31,38 @@ public:
 	{
 		return (uint8_t)((array[(position / 8) % byteCount] >> (position % 8)) & 0x01);
 	}
+
+	//mask must not equal 0.
+	__forceinline static uint32_t GetLowestBitIndex(uint32_t mask)
+	{
+#ifdef _MSC_VER
+		unsigned long index;
+		_BitScanForward(&index, mask);
+		return (uint32_t)index;
+#else
+		return (uint32_t)__builtin_ctz(mask);
+#endif
+	}
+
+	//mask must not equal 0.
+	__forceinline static uint32_t GetHighestBitIndex(uint32_t mask)
+	{
+#ifdef _MSC_VER
+		unsigned long index;
+		_BitScanReverse(&index, mask);
+		return (uint32_t)index;
+#else
+		// __builtin_clz returns leading zeros from the top (bit 31).
+		// To get the index (0-31), we subtract from 31.
+		return 31 - (uint32_t)__builtin_clz(mask);
+#endif
+	}
+
+	__forceinline static uint8_t ReverseByte(uint8_t b)
+	{
+		b = (b & 0xF0) >> 4 | (b & 0x0F) << 4; // Swap nybbles
+		b = (b & 0xCC) >> 2 | (b & 0x33) << 2; // Swap quarters
+		b = (b & 0xAA) >> 1 | (b & 0x55) << 1; // Swap bits
+		return b;
+	}
 };


### PR DESCRIPTION
This change reworks sprite rendering to use sprite shifters and allows sprites to show on scanline 0. It has a performance cost, but I've tried to keep that to a minimum.

NES sprites work by loading data into 8 sprite shifters during each set of 8 dots in 257-320. These shifters have two modes: output+shift, and counting. In counting mode, they count regardless of whether rendering is enabled. They are put into counting mode by a signal generated on dot 339, which arrives just in time for them to start counting on dot 1. Notably, when the dot is skipped at the end of prerender, this signal arrives a dot late, so all shifters output a pixel on dot 1 and start counting on dot 2, outputting the remaining pixels at their normal positions. This quirk allows for detection of NTSC composite vs RGB PPUs using sprite 0 hit in the top left corner, as almost all RGB PPUs lack dot skipping.

If rendering is turned off mid-frame, the shifters continue counting, and they flip to output+shift mode as normal when the counter expires. Turning rendering back on allows all expired shifters to immediately start outputting their contents; the shifting only happens during visible rendering pixels.

Care was taken to ensure HD packs do not break from this change. Changes were tested with automated tests, AccuracyCoin, Pac-Man (which should have one sprite pixel flipping between the top 2 corners), Metroid HD, and a basic Mega Man 2 HD pack.