### PR TITLE
NES: FDS - Performance improvements

### DIFF
--- a/Core/GBA/GbaConsole.cpp
+++ b/Core/GBA/GbaConsole.cpp
@@ -388,6 +388,11 @@ PpuFrameInfo GbaConsole::GetPpuFrame()
 	return frame;
 }
 
+uint32_t GbaConsole::GetFrameCount()
+{
+	return _ppu->GetFrameCount();
+}
+
 vector<CpuType> GbaConsole::GetCpuTypes()
 {
 	return { CpuType::Gba };

--- a/Core/GBA/GbaConsole.h
+++ b/Core/GBA/GbaConsole.h
@@ -102,6 +102,7 @@ public:
 	ConsoleType GetConsoleType() override;
 	double GetFps() override;
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
 	vector<CpuType> GetCpuTypes() override;
 
 	AddressInfo GetAbsoluteAddress(AddressInfo& relAddress) override;

--- a/Core/GBA/Input/GbaController.h
+++ b/Core/GBA/Input/GbaController.h
@@ -19,6 +19,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::A, keyMapping.A);
 			SetPressedState(Buttons::B, keyMapping.B);
@@ -31,8 +33,6 @@ protected:
 			SetPressedState(Buttons::L, keyMapping.L);
 			SetPressedState(Buttons::R, keyMapping.R);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::A, keyMapping.TurboA);
 				SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/Gameboy/Gameboy.cpp
+++ b/Core/Gameboy/Gameboy.cpp
@@ -680,6 +680,11 @@ PpuFrameInfo Gameboy::GetPpuFrame()
 	return frame;
 }
 
+uint32_t Gameboy::GetFrameCount()
+{
+	return _ppu->GetFrameCount();
+}
+
 vector<CpuType> Gameboy::GetCpuTypes()
 {
 	return { CpuType::Gameboy };

--- a/Core/Gameboy/Gameboy.h
+++ b/Core/Gameboy/Gameboy.h
@@ -131,6 +131,8 @@ public:
 	ConsoleType GetConsoleType() override;
 	double GetFps() override;
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
+
 	vector<CpuType> GetCpuTypes() override;
 
 	AddressInfo GetAbsoluteAddress(AddressInfo& relAddress) override;

--- a/Core/Gameboy/Input/GbController.h
+++ b/Core/Gameboy/Input/GbController.h
@@ -19,6 +19,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::A, keyMapping.A);
 			SetPressedState(Buttons::B, keyMapping.B);
@@ -29,8 +31,6 @@ protected:
 			SetPressedState(Buttons::Left, keyMapping.Left);
 			SetPressedState(Buttons::Right, keyMapping.Right);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::A, keyMapping.TurboA);
 				SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/NES/BaseMapper.h
+++ b/Core/NES/BaseMapper.h
@@ -221,6 +221,8 @@ public:
 
 	virtual void SaveBattery();
 
+	virtual void EndFrame() {}
+
 	NesRomInfo GetRomInfo();
 	uint32_t GetMapperDipSwitchCount();
 

--- a/Core/NES/Input/NesController.h
+++ b/Core/NES/Input/NesController.h
@@ -37,6 +37,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::A, keyMapping.A);
 			SetPressedState(Buttons::B, keyMapping.B);
@@ -47,8 +49,6 @@ protected:
 			SetPressedState(Buttons::Left, keyMapping.Left);
 			SetPressedState(Buttons::Right, keyMapping.Right);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::A, keyMapping.TurboA);
 				SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -218,19 +218,18 @@ uint8_t Fds::ReadRam(uint16_t addr)
 void Fds::ProcessAutoDiskInsert()
 {
 	if(IsAutoInsertDiskEnabled()) {
-		bool fastForwardEnabled = _settings->FdsFastForwardOnLoad;
-		uint32_t currentFrame = _emu->GetFrameCount();
+		uint32_t currentFrame = _console->GetFrameCount();
 		if(_previousFrame != currentFrame) {
 			_previousFrame = currentFrame;
 			if(_autoDiskEjectCounter > 0) {
 				//After reading a disk, wait until this counter reaches 0 before
 				//automatically ejecting the disk the next time $4032 is read
 				_autoDiskEjectCounter--;
-				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, fastForwardEnabled && _autoDiskEjectCounter != 0);
+				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, _settings->FdsFastForwardOnLoad && _autoDiskEjectCounter != 0);
 			} else if(_autoDiskSwitchCounter > 0) {
 				//After ejecting the disk, wait a bit before we insert a new one
 				_autoDiskSwitchCounter--;
-				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, fastForwardEnabled && _autoDiskSwitchCounter != 0);
+				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, _settings->FdsFastForwardOnLoad && _autoDiskSwitchCounter != 0);
 				if(_autoDiskSwitchCounter == 0) {
 					//Insert a disk (real disk/side will be selected when game executes $E445
 					MessageManager::Log("[FDS] Auto-inserted dummy disk.");
@@ -242,7 +241,7 @@ void Fds::ProcessAutoDiskInsert()
 			} else if(_restartAutoInsertCounter > 0) {
 				//After ejecting the disk, wait a bit before we insert a new one
 				_restartAutoInsertCounter--;
-				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, fastForwardEnabled && _restartAutoInsertCounter != 0);
+				_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, _settings->FdsFastForwardOnLoad && _restartAutoInsertCounter != 0);
 				if(_restartAutoInsertCounter == 0) {
 					//Wait a bit before ejecting the disk (eject in ~34 frames)
 					MessageManager::Log("[FDS] Game failed to load disk, try again.");
@@ -253,6 +252,17 @@ void Fds::ProcessAutoDiskInsert()
 			}
 		}
 	}
+}
+
+void Fds::EndFrame()
+{
+	if(_settings->FdsFastForwardOnLoad) {
+		_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, _scanningDisk || !_gameStarted);
+	} else {
+		_emu->GetSettings()->ClearFlag(EmulationFlags::MaximumSpeed);
+	}
+
+	ProcessAutoDiskInsert();
 }
 
 /**TODO:
@@ -266,14 +276,6 @@ void Fds::ProcessAutoDiskInsert()
 void Fds::ProcessCpuClock()
 {
 	BaseProcessCpuClock();
-
-	if(_settings->FdsFastForwardOnLoad) {
-		_emu->GetSettings()->SetFlagState(EmulationFlags::MaximumSpeed, _scanningDisk || !_gameStarted);
-	} else {
-		_emu->GetSettings()->ClearFlag(EmulationFlags::MaximumSpeed);
-	}
-
-	ProcessAutoDiskInsert();
 
 	ClockIrq();
 	_audio->Clock();
@@ -556,12 +558,12 @@ uint8_t Fds::ReadRegister(uint16_t addr)
 				value |= !IsDiskInserted() ? 0x04 : 0x00; //Simulate inserted disks as always being writable
 
 				if(IsAutoInsertDiskEnabled()) {
-					if(_emu->GetFrameCount() - _lastDiskCheckFrame < 100) {
+					if(_console->GetFrameCount() - _lastDiskCheckFrame < 100) {
 						_successiveChecks++;
 					} else {
 						_successiveChecks = 0;
 					}
-					_lastDiskCheckFrame = _emu->GetFrameCount();
+					_lastDiskCheckFrame = _console->GetFrameCount();
 
 					if(_successiveChecks > 20 && _autoDiskEjectCounter == 0 && _autoDiskSwitchCounter == -1) {
 						//Game tried to check if a disk was inserted or not - this is usually done when the disk needs to be changed

--- a/Core/NES/Mappers/FDS/Fds.h
+++ b/Core/NES/Mappers/FDS/Fds.h
@@ -120,6 +120,7 @@ public:
 	~Fds();
 
 	void SaveBattery() override;
+	void EndFrame() override;
 
 	uint32_t GetSideCount();
 

--- a/Core/NES/NesConsole.cpp
+++ b/Core/NES/NesConsole.cpp
@@ -307,6 +307,7 @@ void NesConsole::InternalRunFrame()
 		}
 	}
 
+	_mapper->EndFrame();
 	_apu->EndFrame();
 
 	if(!_nextFrameOverclockDisabled) {
@@ -351,6 +352,11 @@ double NesConsole::GetFps()
 	} else {
 		return 50.0069789081886;
 	}
+}
+
+uint32_t NesConsole::GetFrameCount()
+{
+	return _ppu->GetFrameCount();
 }
 
 PpuFrameInfo NesConsole::GetPpuFrame()

--- a/Core/NES/NesConsole.h
+++ b/Core/NES/NesConsole.h
@@ -98,6 +98,7 @@ public:
 	void RunFrame() override;
 	BaseControlManager* GetControlManager() override;
 	double GetFps() override;
+	uint32_t GetFrameCount() override;
 	PpuFrameInfo GetPpuFrame() override;
 	ConsoleRegion GetRegion() override;
 	ConsoleType GetConsoleType() override;

--- a/Core/PCE/Input/PceAvenuePad6.h
+++ b/Core/PCE/Input/PceAvenuePad6.h
@@ -22,6 +22,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::I, keyMapping.A);
 			SetPressedState(Buttons::II, keyMapping.B);
@@ -36,8 +38,6 @@ protected:
 			SetPressedState(Buttons::Left, keyMapping.Left);
 			SetPressedState(Buttons::Right, keyMapping.Right);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::I, keyMapping.TurboA);
 				SetPressedState(Buttons::II, keyMapping.TurboB);

--- a/Core/PCE/Input/PceController.h
+++ b/Core/PCE/Input/PceController.h
@@ -21,6 +21,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::I, keyMapping.A);
 			SetPressedState(Buttons::II, keyMapping.B);
@@ -31,8 +33,6 @@ protected:
 			SetPressedState(Buttons::Left, keyMapping.Left);
 			SetPressedState(Buttons::Right, keyMapping.Right);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::I, keyMapping.TurboA);
 				SetPressedState(Buttons::II, keyMapping.TurboB);
@@ -45,7 +45,7 @@ protected:
 			ClearBit(Buttons::Select);
 		}
 
-		if(!_emu->GetSettings()->GetPcEngineConfig().AllowInvalidInput) {
+		if(!cfg.AllowInvalidInput) {
 			//If both U+D or L+R are pressed at the same time, act as if neither is pressed
 			if(IsPressed(Buttons::Up) && IsPressed(Buttons::Down)) {
 				ClearBit(Buttons::Down);

--- a/Core/PCE/PceConsole.cpp
+++ b/Core/PCE/PceConsole.cpp
@@ -281,8 +281,7 @@ BaseVideoFilter* PceConsole::GetVideoFilter(bool getDefaultFilter)
 PpuFrameInfo PceConsole::GetPpuFrame()
 {
 	PpuFrameInfo frame = {};
-	PceVdcState& state = _vdc->GetState();
-	frame.FrameCount = state.FrameCount;
+	frame.FrameCount = _vdc->GetFrameCount();
 	frame.CycleCount = PceConstants::ClockPerScanline;
 
 	frame.FirstScanline = 0;
@@ -294,6 +293,11 @@ PpuFrameInfo PceConsole::GetPpuFrame()
 	frame.Width = PceConstants::InternalOutputWidth;
 	frame.FrameBufferSize = PceConstants::MaxScreenWidth * (PceConstants::ScreenHeight + 1) * sizeof(uint16_t);
 	return frame;
+}
+
+uint32_t PceConsole::GetFrameCount()
+{
+	return _vdc->GetFrameCount();
 }
 
 RomFormat PceConsole::GetRomFormat()

--- a/Core/PCE/PceConsole.h
+++ b/Core/PCE/PceConsole.h
@@ -85,6 +85,8 @@ public:
 	BaseVideoFilter* GetVideoFilter(bool getDefaultFilter) override;
 
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
+
 	RomFormat GetRomFormat() override;
 
 	void InitHesPlayback(uint8_t selectedTrack);

--- a/Core/SMS/Input/SmsController.h
+++ b/Core/SMS/Input/SmsController.h
@@ -19,6 +19,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			SetPressedState(Buttons::A, keyMapping.A);
 			SetPressedState(Buttons::B, keyMapping.B);
@@ -29,8 +31,6 @@ protected:
 
 			SetPressedState(Buttons::Pause, keyMapping.Start);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::A, keyMapping.TurboA);
 				SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/SMS/SmsConsole.cpp
+++ b/Core/SMS/SmsConsole.cpp
@@ -292,6 +292,11 @@ PpuFrameInfo SmsConsole::GetPpuFrame()
 	return frame;
 }
 
+uint32_t SmsConsole::GetFrameCount()
+{
+	return _vdp->GetFrameCount();
+}
+
 RomFormat SmsConsole::GetRomFormat()
 {
 	return _romFormat;

--- a/Core/SMS/SmsConsole.h
+++ b/Core/SMS/SmsConsole.h
@@ -71,6 +71,7 @@ public:
 	RomFormat GetRomFormat() override;
 	double GetFps() override;
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
 	BaseVideoFilter* GetVideoFilter(bool getDefaultFilter) override;
 
 	uint64_t GetMasterClock() override;

--- a/Core/SNES/Input/SnesController.cpp
+++ b/Core/SNES/Input/SnesController.cpp
@@ -16,6 +16,8 @@ string SnesController::GetKeyNames()
 
 void SnesController::InternalSetStateFromInput()
 {
+	bool turboOn = IsTurboOn(_turboSpeed);
+
 	for(KeyMapping& keyMapping : _keyMappings) {
 		SetPressedState(Buttons::A, keyMapping.A);
 		SetPressedState(Buttons::B, keyMapping.B);
@@ -30,8 +32,6 @@ void SnesController::InternalSetStateFromInput()
 		SetPressedState(Buttons::Left, keyMapping.Left);
 		SetPressedState(Buttons::Right, keyMapping.Right);
 
-		uint8_t turboFreq = 1 << (4 - _turboSpeed);
-		bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 		if(turboOn) {
 			SetPressedState(Buttons::A, keyMapping.TurboA);
 			SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/SNES/Input/SnesNttDataKeypad.cpp
+++ b/Core/SNES/Input/SnesNttDataKeypad.cpp
@@ -16,6 +16,8 @@ string SnesNttDataKeypad::GetKeyNames()
 
 void SnesNttDataKeypad::InternalSetStateFromInput()
 {
+	bool turboOn = IsTurboOn(_turboSpeed);
+
 	for(KeyMapping& keyMapping : _keyMappings) {
 		SetPressedState(Buttons::A, keyMapping.A);
 		SetPressedState(Buttons::B, keyMapping.B);
@@ -45,8 +47,6 @@ void SnesNttDataKeypad::InternalSetStateFromInput()
 		SetPressedState(Buttons::C, keyMapping.CustomKeys[13]);
 		SetPressedState(Buttons::EndCommunication, keyMapping.CustomKeys[14]);
 
-		uint8_t turboFreq = 1 << (4 - _turboSpeed);
-		bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 		if(turboOn) {
 			SetPressedState(Buttons::A, keyMapping.TurboA);
 			SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/SNES/Input/SnesRumbleController.cpp
+++ b/Core/SNES/Input/SnesRumbleController.cpp
@@ -3,7 +3,6 @@
 #include "SNES/SnesConsole.h"
 #include "SNES/InternalRegisters.h"
 #include "Shared/Emulator.h"
-#include "Shared/EmuSettings.h"
 #include "Shared/KeyManager.h"
 
 SnesRumbleController::SnesRumbleController(Emulator* emu, SnesConsole* console, uint8_t port, KeyMappingSet keyMappings) : SnesController(emu, port, keyMappings)
@@ -32,7 +31,7 @@ void SnesRumbleController::RefreshStateBuffer()
 	//The LRG rumble controller stops rumbling shortly after the last rumble command.
 	//Not accurate, assumes the game regularly latches the controller.
 	if(_rumbleActive) {
-		if(_emu->GetFrameCount() - _lastRumbleFrame > 2) {
+		if(_console->GetFrameCount() - _lastRumbleFrame > 2) {
 			KeyManager::SetForceFeedback(0, 0);
 			_rumbleActive = false;
 		}
@@ -63,7 +62,7 @@ uint8_t SnesRumbleController::ReadRam(uint16_t addr)
 			KeyManager::SetForceFeedback(rightRumble, leftRumble);
 
 			_rumbleActive = true;
-			_lastRumbleFrame = _emu->GetFrameCount();
+			_lastRumbleFrame = _console->GetFrameCount();
 		}
 	}
 

--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -4,17 +4,15 @@
 #include "SNES/SnesPpu.h"
 #include "SNES/Spc.h"
 #include "SNES/InternalRegisters.h"
+#include "SNES/RegisterHandlerB.h"
 #include "SNES/SnesControlManager.h"
 #include "SNES/SnesMemoryManager.h"
 #include "SNES/SnesDmaController.h"
 #include "SNES/BaseCartridge.h"
-#include "SNES/RamHandler.h"
-#include "SNES/CartTypes.h"
 #include "SNES/SpcFileData.h"
 #include "SNES/SnesDefaultVideoFilter.h"
 #include "SNES/SnesNtscFilter.h"
 #include "Gameboy/Gameboy.h"
-#include "Gameboy/GbPpu.h"
 #include "Debugger/Debugger.h"
 #include "Debugger/DebugTypes.h"
 #include "SNES/SnesState.h"
@@ -29,11 +27,8 @@
 #include "Shared/EmuSettings.h"
 #include "Shared/BaseControlManager.h"
 #include "Utilities/Serializer.h"
-#include "Utilities/Timer.h"
 #include "Utilities/VirtualFile.h"
-#include "Utilities/PlatformUtilities.h"
 #include "Utilities/FolderUtilities.h"
-#include "Shared/EventType.h"
 #include "SNES/RegisterHandlerA.h"
 #include "SNES/RegisterHandlerB.h"
 #include "Utilities/ArchiveReader.h"
@@ -236,6 +231,11 @@ PpuFrameInfo SnesConsole::GetPpuFrame()
 	frame.ScanlineCount = _ppu->GetVblankEndScanline() + 1;
 	frame.CycleCount = 341;
 	return frame;
+}
+
+uint32_t SnesConsole::GetFrameCount()
+{
+	return _ppu->GetFrameCount();
 }
 
 TimingInfo SnesConsole::GetTimingInfo(CpuType cpuType)

--- a/Core/SNES/SnesConsole.h
+++ b/Core/SNES/SnesConsole.h
@@ -1,12 +1,9 @@
 #pragma once
 #include "pch.h"
-#include "SNES/CartTypes.h"
 #include "Debugger/DebugTypes.h"
 #include "Debugger/Debugger.h"
 #include "Shared/Interfaces/IConsole.h"
-#include "Utilities/Timer.h"
 #include "Utilities/VirtualFile.h"
-#include "Utilities/SimpleLock.h"
 #include "Shared/RomInfo.h"
 
 class SnesCpu;
@@ -118,6 +115,7 @@ public:
 
 	double GetFps() override;
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
 
 	TimingInfo GetTimingInfo(CpuType cpuType) override;
 

--- a/Core/Shared/BaseControlDevice.cpp
+++ b/Core/Shared/BaseControlDevice.cpp
@@ -20,6 +20,13 @@ BaseControlDevice::~BaseControlDevice()
 {
 }
 
+bool BaseControlDevice::IsTurboOn(uint8_t turboSpeed)
+{
+	uint8_t turboFreq = 1 << (4 - turboSpeed);
+	bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
+	return turboOn;
+}
+
 uint8_t BaseControlDevice::GetPort()
 {
 	return _port;

--- a/Core/Shared/BaseControlDevice.h
+++ b/Core/Shared/BaseControlDevice.h
@@ -51,6 +51,8 @@ protected:
 
 	virtual void InternalSetStateFromInput();
 
+	bool IsTurboOn(uint8_t turboSpeed);
+
 public:
 	static constexpr int DeviceXCoordButtonId = 0xFFFE;
 	static constexpr int DeviceYCoordButtonId = 0xFFFF;

--- a/Core/Shared/Emulator.cpp
+++ b/Core/Shared/Emulator.cpp
@@ -699,7 +699,12 @@ uint32_t Emulator::GetMasterClockRate()
 
 uint32_t Emulator::GetFrameCount()
 {
-	return GetPpuFrame().FrameCount;
+	if(IsEmulationThread()) {
+		return _console ? _console->GetFrameCount() : 0;
+	} else {
+		shared_ptr<IConsole> console = GetConsole();
+		return console ? console->GetFrameCount() : 0;
+	}
 }
 
 uint32_t Emulator::GetLagCounter()

--- a/Core/Shared/Interfaces/IConsole.h
+++ b/Core/Shared/Interfaces/IConsole.h
@@ -90,6 +90,7 @@ public:
 	virtual BaseVideoFilter* GetVideoFilter(bool getDefaultFilter) = 0;
 	virtual void GetScreenRotationOverride(uint32_t& rotation) {}
 
+	virtual uint32_t GetFrameCount() = 0;
 	virtual PpuFrameInfo GetPpuFrame() = 0;
 
 	virtual string GetHash(HashType hashType) { return {}; }

--- a/Core/WS/Input/Pcv2Controller.h
+++ b/Core/WS/Input/Pcv2Controller.h
@@ -17,6 +17,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		for(KeyMapping& keyMapping : _keyMappings) {
 			for(int i = Buttons::Up; i <= Buttons::View; i++) {
 				SetPressedState(Buttons::Clear, keyMapping.A);
@@ -30,8 +32,6 @@ protected:
 				SetPressedState(Buttons::Right, keyMapping.Right);
 			}
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::Clear, keyMapping.TurboA);
 				SetPressedState(Buttons::Circle, keyMapping.TurboB);

--- a/Core/WS/Input/WsController.h
+++ b/Core/WS/Input/WsController.h
@@ -20,6 +20,8 @@ protected:
 
 	void InternalSetStateFromInput() override
 	{
+		bool turboOn = IsTurboOn(_turboSpeed);
+
 		vector<KeyMapping>& keyMappings = _console->IsVerticalMode() ? _verticalMappings : _keyMappings;
 		for(KeyMapping& keyMapping : keyMappings) {
 			SetPressedState(Buttons::A, keyMapping.A);
@@ -36,8 +38,6 @@ protected:
 			SetPressedState(Buttons::Left2, keyMapping.L);
 			SetPressedState(Buttons::Right2, keyMapping.R);
 
-			uint8_t turboFreq = 1 << (4 - _turboSpeed);
-			bool turboOn = (uint8_t)(_emu->GetFrameCount() % turboFreq) < turboFreq / 2;
 			if(turboOn) {
 				SetPressedState(Buttons::A, keyMapping.TurboA);
 				SetPressedState(Buttons::B, keyMapping.TurboB);

--- a/Core/WS/WsConsole.cpp
+++ b/Core/WS/WsConsole.cpp
@@ -438,6 +438,11 @@ PpuFrameInfo WsConsole::GetPpuFrame()
 	return frame;
 }
 
+uint32_t WsConsole::GetFrameCount()
+{
+	return _ppu->GetFrameCount();
+}
+
 RomFormat WsConsole::GetRomFormat()
 {
 	return RomFormat::Ws;

--- a/Core/WS/WsConsole.h
+++ b/Core/WS/WsConsole.h
@@ -94,6 +94,7 @@ public:
 	double GetFps() override;
 	BaseVideoFilter* GetVideoFilter(bool getDefaultFilter) override;
 	PpuFrameInfo GetPpuFrame() override;
+	uint32_t GetFrameCount() override;
 	RomFormat GetRomFormat() override;
 	AudioTrackInfo GetAudioTrackInfo() override;
 	void ProcessAudioPlayerAction(AudioPlayerActionParams p) override;


### PR DESCRIPTION
-ProcessCpuClock was used to check for events that don't need to be checked that often (auto-switch disk + auto fast-forward options). This has been moved to a new EndFrame callback.
-This was even slower than intended because of the call to _emu->GetFrameCount() which was, relatively speaking, fairly slow. To improve its performance (since it's also used rarely for some things like turbo button processing), a separate GetFrameCount function was added on all console classes, and Emulator::GetFrameCount was also optimized to be faster when called from the emulation thread.
-Controllers were also modified to remove duplicated code for turbo buttons (and to reduce the number of calls to GetFrameCount)

When the auto-switch disk option is enabled, this can improve performance by about 25-30%. When the option is not enabled, this still improves performance by 4-5%.