### PR TITLE
NES: Performance improvements (inline CPU read)

### DIFF
--- a/Core/NES/BaseMapper.cpp
+++ b/Core/NES/BaseMapper.cpp
@@ -670,6 +670,7 @@ void BaseMapper::Initialize(NesConsole* console, RomData& romData)
 	_hasCpuClockHook = EnableCpuClockHook();
 	_hasCustomReadVram = EnableCustomVramRead();
 	_hasVramAddressHook = EnableVramAddressHook();
+	_hasCustomReadRam = EnableCustomRamRead();
 
 	memset(_isReadRegisterAddr, 0, sizeof(_isReadRegisterAddr));
 	memset(_isWriteRegisterAddr, 0, sizeof(_isWriteRegisterAddr));
@@ -888,14 +889,7 @@ MirroringType BaseMapper::GetMirroringType()
 
 uint8_t BaseMapper::ReadRam(uint16_t addr)
 {
-	if(_allowRegisterRead && _isReadRegisterAddr[addr]) {
-		return ReadRegister(addr);
-	} else if(_prgMemoryAccess[addr >> 8] & MemoryAccessType::Read) {
-		return _prgPages[addr >> 8][(uint8_t)addr];
-	} else {
-		//assert(false);
-	}
-	return _console->GetMemoryManager()->GetOpenBus();
+	return InternalRead(addr);
 }
 
 uint8_t BaseMapper::PeekRam(uint16_t addr)

--- a/Core/NES/BaseMapper.h
+++ b/Core/NES/BaseMapper.h
@@ -3,6 +3,7 @@
 #include "pch.h"
 #include "NES/INesMemoryHandler.h"
 #include "NES/NesTypes.h"
+#include "NES/NesConsole.h"
 #include "NES/RomData.h"
 #include "Debugger/DebugTypes.h"
 #include "Shared/Emulator.h"
@@ -38,6 +39,7 @@ private:
 	bool _hasBusConflicts = false;
 	bool _hasDefaultWorkRam = false;
 
+	bool _hasCustomReadRam = false;
 	bool _hasCustomReadVram = false;
 	bool _hasCpuClockHook = false;
 	bool _hasVramAddressHook = false;
@@ -115,6 +117,9 @@ protected:
 	virtual bool EnableCpuClockHook() { return false; }
 	virtual bool EnableCustomVramRead() { return false; }
 	virtual bool EnableVramAddressHook() { return false; }
+
+	//Needed when providing an override to ReadRam for addresses above 0x6000
+	virtual bool EnableCustomRamRead() { return false; }
 
 	virtual uint32_t GetDipSwitchCount() { return 0; }
 	virtual uint32_t GetNametableCount() { return 0; }
@@ -225,6 +230,24 @@ public:
 
 	NesRomInfo GetRomInfo();
 	uint32_t GetMapperDipSwitchCount();
+
+	__forceinline uint8_t Read(uint16_t addr)
+	{
+		if(_hasCustomReadRam) {
+			return ReadRam(addr);
+		}
+		return InternalRead(addr);
+	}
+
+	__forceinline uint8_t InternalRead(uint16_t addr)
+	{
+		if(_allowRegisterRead && _isReadRegisterAddr[addr]) {
+			return ReadRegister(addr);
+		} else if(_prgMemoryAccess[addr >> 8] & MemoryAccessType::Read) {
+			return _prgPages[addr >> 8][(uint8_t)addr];
+		}
+		return _console->GetOpenBus();
+	}
 
 	uint8_t ReadRam(uint16_t addr) override;
 	uint8_t PeekRam(uint16_t addr) override;

--- a/Core/NES/Mappers/FDS/Fds.cpp
+++ b/Core/NES/Mappers/FDS/Fds.cpp
@@ -2,7 +2,6 @@
 #include <assert.h>
 #include "NES/NesConsole.h"
 #include "NES/NesCpu.h"
-#include "NES/NesPpu.h"
 #include "NES/NesMemoryManager.h"
 #include "NES/Mappers/FDS/Fds.h"
 #include "NES/Mappers/FDS/FdsAudio.h"
@@ -212,7 +211,7 @@ uint8_t Fds::ReadRam(uint16_t addr)
 		_restartAutoInsertCounter = -1;
 	}
 
-	return BaseMapper::ReadRam(addr);
+	return BaseMapper::InternalRead(addr);
 }
 
 void Fds::ProcessAutoDiskInsert()

--- a/Core/NES/Mappers/FDS/Fds.h
+++ b/Core/NES/Mappers/FDS/Fds.h
@@ -90,11 +90,11 @@ protected:
 	uint16_t RegisterEndAddress() override { return 0x4097; }
 	bool AllowRegisterRead() override { return true; }
 	bool EnableCpuClockHook() override { return true; }
+	bool EnableCustomRamRead() override { return true; }
 
 	void InitMapper() override;
 	void InitMapper(RomData& romData) override;
 	void LoadDiskData(vector<uint8_t> ipsData = vector<uint8_t>());
-	vector<uint8_t> CreateIpsPatch();
 	void Reset(bool softReset) override;
 
 	uint32_t GetFdsDiskSideSize(uint8_t side);

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -113,7 +113,7 @@ uint8_t Rainbow::ReadRam(uint16_t addr)
 		}
 		return (_audio->GetLastOutput() << 1);
 	}
-	return BaseMapper::ReadRam(addr);
+	return BaseMapper::InternalRead(addr);
 }
 
 void Rainbow::GenerateOamClear()

--- a/Core/NES/Mappers/Nintendo/MMC5.h
+++ b/Core/NES/Mappers/Nintendo/MMC5.h
@@ -301,6 +301,7 @@ protected:
 	bool AllowRegisterRead() override { return true; }
 	bool EnableCpuClockHook() override { return true; }
 	bool EnableCustomVramRead() override { return true; }
+	bool EnableCustomRamRead() override { return true; }
 
 	uint32_t GetSaveRamSize() override
 	{
@@ -443,7 +444,7 @@ protected:
 
 	uint8_t ReadRam(uint16_t addr) override
 	{
-		uint8_t value = BaseMapper::ReadRam(addr);
+		uint8_t value = BaseMapper::InternalRead(addr);
 		if(_audio->GetPcmReadMode()) {
 			_audio->HandlePcmRead(addr, value);
 		}

--- a/Core/NES/NesConsole.cpp
+++ b/Core/NES/NesConsole.cpp
@@ -72,6 +72,11 @@ void NesConsole::ProcessCpuClock()
 	}
 }
 
+uint8_t NesConsole::GetOpenBus()
+{
+	return _memoryManager->GetOpenBus();
+}
+
 Epsm* NesConsole::GetEpsm()
 {
 	return _mapper->GetEpsm();

--- a/Core/NES/NesConsole.h
+++ b/Core/NES/NesConsole.h
@@ -80,6 +80,7 @@ public:
 	NesConfig& GetNesConfig();
 
 	void ProcessCpuClock();
+	uint8_t GetOpenBus();
 
 	Epsm* GetEpsm();
 

--- a/Core/NES/NesMemoryManager.cpp
+++ b/Core/NES/NesMemoryManager.cpp
@@ -2,9 +2,9 @@
 #include "NES/NesMemoryManager.h"
 #include "NES/BaseMapper.h"
 #include "NES/NesConsole.h"
+#include "NES/InternalRamHandler.h"
 #include "Shared/CheatManager.h"
 #include "Shared/Emulator.h"
-#include "Shared/EmuSettings.h"
 #include "Utilities/Serializer.h"
 #include "Shared/MemoryOperationType.h"
 
@@ -120,20 +120,6 @@ uint8_t NesMemoryManager::DebugRead(uint16_t addr)
 uint16_t NesMemoryManager::DebugReadWord(uint16_t addr)
 {
 	return DebugRead(addr) | (DebugRead(addr + 1) << 8);
-}
-
-template<NesCpuBusType busType>
-uint8_t NesMemoryManager::Read(uint16_t addr, MemoryOperationType operationType)
-{
-	uint8_t value = _ramReadHandlers[addr]->ReadRam(addr);
-	if(_cheatManager->HasCheats<CpuType::Nes>()) {
-		_cheatManager->ApplyCheat<CpuType::Nes>(addr, value);
-	}
-	_emu->ProcessMemoryRead<CpuType::Nes>(addr, value, operationType);
-
-	_openBusHandler.SetOpenBus<busType>(value, addr == 0x4015);
-
-	return value;
 }
 
 void NesMemoryManager::Write(uint16_t addr, uint8_t value, MemoryOperationType operationType)

--- a/Core/NES/NesMemoryManager.h
+++ b/Core/NES/NesMemoryManager.h
@@ -5,8 +5,10 @@
 #include "NES/INesMemoryHandler.h"
 #include "NES/NesTypes.h"
 #include "NES/OpenBusHandler.h"
-#include "NES/InternalRamHandler.h"
+#include "NES/BaseMapper.h"
+#include "Shared/Emulator.h"
 #include "Shared/MemoryOperationType.h"
+#include "Shared/CheatManager.h"
 #include "Utilities/ISerializable.h"
 
 class BaseMapper;
@@ -56,7 +58,28 @@ public:
 	uint8_t* GetInternalRam();
 
 	template<NesCpuBusType busType = NesCpuBusType::Both>
-	uint8_t Read(uint16_t addr, MemoryOperationType operationType = MemoryOperationType::Read);
+	__forceinline uint8_t Read(uint16_t addr, MemoryOperationType operationType = MemoryOperationType::Read)
+	{
+		uint8_t value;
+		if(addr >= 0x6000) {
+			//Reading from 0x6000+ is by far the most common CPU operation (e.g CPU loading ROM to execute)
+			//The mapper is always mapped in this address range, allowing us to directly call the
+			//mapper's read function here, which allows it to be inlined and skips a virtual function call
+			//(which isn't possible when called via the ReadRam interface)
+			value = _mapper->Read(addr);
+		} else {
+			value = _ramReadHandlers[addr]->ReadRam(addr);
+		}
+		if(_cheatManager->HasCheats<CpuType::Nes>()) {
+			_cheatManager->ApplyCheat<CpuType::Nes>(addr, value);
+		}
+		_emu->ProcessMemoryRead<CpuType::Nes>(addr, value, operationType);
+
+		_openBusHandler.SetOpenBus<busType>(value, addr == 0x4015);
+
+		return value;
+	}
+
 	void Write(uint16_t addr, uint8_t value, MemoryOperationType operationType);
 
 	uint8_t GetOpenBus(uint8_t mask = 0xFF);


### PR DESCRIPTION
Modified NesMemoryManager & BaseMapper to allow inlining the read logic when the CPU is e.g executing code from ROM. This speeds up execution by around 3-5%.