### PR TITLE
GBA: Fixed SWP operation order (should be Read->Write->Idle)

### DIFF
--- a/Core/GBA/GbaCpu.Arm.cpp
+++ b/Core/GBA/GbaCpu.Arm.cpp
@@ -505,8 +505,8 @@ void GbaCpu::ArmSingleDataSwap()
 #endif
 	uint32_t src = R(rn);
 	uint32_t val = Read(mode, src);
-	Idle();
 	Write(mode, src, rm == 15 ? (R(rm) + 4) : R(rm));
+	Idle();
 #ifndef DUMMYCPU
 	_memoryManager->UnlockBus();
 #endif


### PR DESCRIPTION
Fixes new test case in png183's version of the "data_swap" test