### PR TITLE
UI: Set MesenCE-specific guid used for restricting to one instance.

### DIFF
--- a/UI/Utilities/SingleInstance.cs
+++ b/UI/Utilities/SingleInstance.cs
@@ -13,7 +13,7 @@ namespace Mesen.Utilities
 	{
 		public static SingleInstance Instance { get; private set; } = new SingleInstance();
 
-		private static Guid _identifier = new Guid("{A46696B7-2D1C-4CC5-A52F-43BCAF094AEF}");
+		private static Guid _identifier = new Guid("{A46696B7-2D1C-4CC5-A52F-40BCAF094AEF}");
 
 		private Mutex? _mutex;
 		private FileStream? _lockFileStream;


### PR DESCRIPTION
We recommend other forks NOT copy this change. We're switching away from the Mesen2 guid to avoid single-instance interactions with other Mesen2 forks. If you change your guid, please do not use ours.