### PR TITLE
SNES: Small accuracy fix for Turbo File TFII mode unlock behavior

### DIFF
--- a/Core/SNES/Input/AsciiTurboFileTwinTf2.h
+++ b/Core/SNES/Input/AsciiTurboFileTwinTf2.h
@@ -52,8 +52,6 @@ public:
 	{
 		_stateBuffer = 0b111111110111000000000000; // Controller type $E, and then disambiguated with $FF
 		if(_unlocked) {
-			// TODOSNES - When a game increments _unlockCounter without doing a $4017 read without strobe,
-			// this bit can somehow get set. That's not implemented here.
 			_stateBuffer |= 1 << 11;
 		}
 	}
@@ -65,15 +63,12 @@ public:
 		if(addr == 0x4017) {
 			StrobeProcessRead();
 
-			// TODOSNES - The unlock and position reset logic does not match hardware in all cases,
-			// but does seem to match what happens when games read $4017 without strobe after changing _unlockCounter,
-			// which ASCII games do. More research is required to figure out what really happens.
+			_unlocked = _unlockCounter == 0xF;
 			if(_strobe) {
 				_unlockCounter = (_unlockCounter + 1) & 0xF;
+			}
+			if(!_unlocked) {
 				_position = 0;
-				_unlocked = false;
-			} else {
-				_unlocked = _unlockCounter == 0xF;
 			}
 
 			// Return one bit from the status


### PR DESCRIPTION
Turbo File Adapter is made from discrete logic, so I was able to look at what the board's actually doing.  It's pretty close to what I had implemented previously. This fix implements a behavior I noticed while reverse engineering TFII mode but didn't know how to implement properly. Like the other accuracy fix PR (#126) this won't affect games and is just for completeness sake.

Marked as draft because I'd like to try adding a few more tests to my test suite and verifying them on hardware I merge this.