### PR TITLE
NES: Fixed mapper 184, Sunsoft 1

### DIFF
--- a/Core/NES/Mappers/Sunsoft/Sunsoft184.h
+++ b/Core/NES/Mappers/Sunsoft/Sunsoft184.h
@@ -20,6 +20,6 @@ protected:
 		SelectChrPage(0, value & 0x07);
 
 		//"The most significant bit of H is always set in hardware."
-		SelectChrPage(1, 0x80 | ((value >> 4) & 0x07));
+		SelectChrPage(1, 0x40 | ((value >> 4) & 0x07));
 	}
 };


### PR DESCRIPTION
The most significant bit of H is always set in hardware. (i.e. its range is 4 to 7)

https://www.nesdev.org/wiki/INES_Mapper_184