### PR TITLE
NES: Fix mapper 184 (SUNSOFT-1) to force CHR banks 4-7 for $1000-$1FFF.

### DIFF
--- a/Core/NES/Mappers/Sunsoft/Sunsoft184.h
+++ b/Core/NES/Mappers/Sunsoft/Sunsoft184.h
@@ -20,6 +20,7 @@ protected:
 		SelectChrPage(0, value & 0x07);
 
 		//"The most significant bit of H is always set in hardware."
-		SelectChrPage(1, 0x80 | ((value >> 4) & 0x07));
+		//H is bits 6-4. This limits the banks to 4-7 instead of 0-7.
+		SelectChrPage(1, 0x04 | ((value >> 4) & 0x03));
 	}
 };


### PR DESCRIPTION
This forces the second CHR slot to always use the upper 16 KiB of CHR. Wing of Madoola seems to be the only game using this mapper that has more than 16 KiB of CHR-ROM, but it appears to always explicitly set this bit, so it's not affected either way.