### PR TITLE
NES: Improve CHR-NVRAM support.

### DIFF
--- a/Core/NES/BaseMapper.cpp
+++ b/Core/NES/BaseMapper.cpp
@@ -720,17 +720,21 @@ void BaseMapper::Initialize(NesConsole* console, RomData& romData)
 		_chrMemoryAccess[i] = MemoryAccessType::NoAccess;
 	}
 
+	//TODO This includes a hack to make CHR-NVRAM work for properly-specified headers that have just one
+	//type of CHR-RAM. Most correct would be another memory type for CHR-NVRAM, but that would basically
+	//just matter for RacerMate Challenge II, which uses a bike we don't currently support, anyway.
 	if(_chrRomSize == 0) {
 		//Assume there is CHR RAM if no CHR ROM exists
-		InitializeChrRam(romData.ChrRamSize);
+		InitializeChrRam(romData.ChrRamSize + romData.SaveChrRamSize);
 
 		//Map CHR RAM to 0x0000-0x1FFF by default when no CHR ROM exists
 		SetPpuMemoryMapping(0x0000, 0x1FFF, 0, ChrMemoryType::ChrRam);
-	} else if(romData.ChrRamSize >= 0) {
-		InitializeChrRam(romData.ChrRamSize);
+	} else if(romData.ChrRamSize >= 0 || romData.SaveChrRamSize >= 0) {
+		InitializeChrRam(romData.ChrRamSize + romData.SaveChrRamSize);
 	} else if(GetChrRamSize()) {
 		InitializeChrRam();
 	}
+	_saveChrRamSize = romData.SaveChrRamSize > 0 ? romData.SaveChrRamSize : 0;
 
 	if(romData.Info.HasTrainer) {
 		if(_workRamSize >= 0x2000) {

--- a/Core/NES/BaseMapper.h
+++ b/Core/NES/BaseMapper.h
@@ -76,6 +76,7 @@ protected:
 	uint32_t _prgSize = 0;
 	uint32_t _chrRomSize = 0;
 	uint32_t _chrRamSize = 0;
+	uint32_t _saveChrRamSize = 0;
 
 	uint8_t* _saveRam = nullptr;
 	uint32_t _saveRamSize = 0;

--- a/Core/NES/Loaders/iNesLoader.cpp
+++ b/Core/NES/Loaders/iNesLoader.cpp
@@ -126,6 +126,9 @@ void iNesLoader::LoadRom(RomData& romData, vector<uint8_t>& romFile, NesHeader* 
 	} else if(chrSize == 0) {
 		Log("[iNes] CHR RAM: 8 KB");
 	}
+	if(romData.SaveChrRamSize > 0 && romData.Info.IsNes20Header) {
+		Log("[iNes] CHR Save RAM: " + StringUtilities::SizeToString(romData.SaveChrRamSize));
+	}
 	if(romData.WorkRamSize > 0 || romData.Info.IsNes20Header) {
 		Log("[iNes] Work RAM: " + StringUtilities::SizeToString(romData.WorkRamSize));
 	}

--- a/Core/NES/Loaders/iNesLoader.cpp
+++ b/Core/NES/Loaders/iNesLoader.cpp
@@ -126,7 +126,7 @@ void iNesLoader::LoadRom(RomData& romData, vector<uint8_t>& romFile, NesHeader* 
 	} else if(chrSize == 0) {
 		Log("[iNes] CHR RAM: 8 KB");
 	}
-	if(romData.SaveChrRamSize > 0 && romData.Info.IsNes20Header) {
+	if(romData.SaveChrRamSize > 0 || romData.Info.IsNes20Header) {
 		Log("[iNes] CHR Save RAM: " + StringUtilities::SizeToString(romData.SaveChrRamSize));
 	}
 	if(romData.WorkRamSize > 0 || romData.Info.IsNes20Header) {

--- a/Core/NES/Mappers/Unlicensed/Racermate.h
+++ b/Core/NES/Mappers/Unlicensed/Racermate.h
@@ -12,7 +12,7 @@ protected:
 	uint16_t GetChrPageSize() override { return 0x1000; }
 	uint32_t GetChrRamSize() override { return 0x10000; }
 	uint32_t GetSaveRamSize() override { return 0; }
-	bool ForceChrBattery() override { return true; }
+	bool ForceChrBattery() override { return !_romInfo.IsNes20Header; }
 	bool EnableCpuClockHook() override { return true; }
 
 	void InitMapper() override
@@ -52,6 +52,32 @@ protected:
 				_irqCounter = 1024;
 				_console->GetCpu()->ClearIrqSource(IRQSource::External);
 				break;
+		}
+	}
+
+	void LoadBattery() override
+	{
+		if(HasBattery() && _saveRamSize > 0) {
+			_emu->GetBatteryManager()->LoadBattery(".sav", _saveRam, _saveRamSize);
+		}
+
+		if(_hasChrBattery && _saveChrRamSize > 0) {
+			_emu->GetBatteryManager()->LoadBattery(".chr.sav", _chrRam + (_chrRamSize - _saveChrRamSize), _saveChrRamSize);
+		} else if(_hasChrBattery) {
+			_emu->GetBatteryManager()->LoadBattery(".chr.sav", _chrRam + (_chrRamSize / 2), _chrRamSize / 2);
+		}
+	}
+
+	void SaveBattery() override
+	{
+		if(HasBattery() && _saveRamSize > 0) {
+			_emu->GetBatteryManager()->LoadBattery(".sav", _saveRam, _saveRamSize);
+		}
+
+		if(_hasChrBattery && _saveChrRamSize > 0) {
+			_emu->GetBatteryManager()->SaveBattery(".chr.sav", _chrRam + (_chrRamSize - _saveChrRamSize), _saveChrRamSize);
+		} else if(_hasChrBattery) {
+			_emu->GetBatteryManager()->SaveBattery(".chr.sav", _chrRam + (_chrRamSize / 2), _chrRamSize / 2);
 		}
 	}
 };


### PR DESCRIPTION
Right now, Mesen uses the NES 2.0 CHR-NVRAM field simply to enable battery saves for the volatile CHR-RAM type, so it only cares if it's zero or nonzero. This means that a game using CHR-NVRAM needs to specify volatile CHR-RAM to get the CHR-NVRAM it's actually requesting. Mesen also doesn't currently distinguish between CHR-RAM types in any way; there is a single CHR-RAM memory type and so it's not capable of saving just some of CHR-RAM. The only contemporary game that uses CHR-NVRAM, RacerMate Challenge II, has both types.

This change makes Mesen sum the two CHR-RAM types and save all of the data. This is still not correct, as it doesn't make sense to specify both types of CHR-RAM for any mapper other than mapper 168, but it will at least allow correctly-specified headers to work. It also allows RacerMate Challenge II to get the full 64 KiB of CHR-RAM (normally 32 KiB of each type) that it requests when using NES 2.0 ROMs, and it now saves however much of this is CHR-NVRAM (either the 2nd half or all of it).

This change also makes the log window print the CHR-NVRAM size as "CHR save RAM" if nonzero.