### PR TITLE
Debugger: SNES - GSU - Allow labels on GSU work ram

### DIFF
--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -490,6 +490,7 @@ AddressInfo SnesConsole::GetRelativeAddress(AddressInfo& absAddress, CpuType cpu
 		case MemoryType::SnesPrgRom:
 		case MemoryType::SnesWorkRam:
 		case MemoryType::SnesSaveRam:
+		case MemoryType::GsuWorkRam:
 		case MemoryType::SufamiTurboFirmware: {
 			if(!mappings) {
 				return unmapped;

--- a/UI/Interop/MemoryTypeExtensions.cs
+++ b/UI/Interop/MemoryTypeExtensions.cs
@@ -279,6 +279,7 @@ namespace Mesen.Interop
 				case MemoryType.SpcRam:
 				case MemoryType.SpcRom:
 				case MemoryType.Sa1InternalRam:
+				case MemoryType.GsuWorkRam:
 				case MemoryType.St018Memory:
 				case MemoryType.St018PrgRom:
 				case MemoryType.St018DataRom:


### PR DESCRIPTION
Also fixes GsuWorkRam not being able to lookup its relative CPU address (which caused the "CPU Addr" column to always show "unavailable" in the label list)