### PR TITLE
Debugger: Fixed crash in debug builds when loading a save state while the debugger is opened

### DIFF
--- a/Core/Shared/Audio/SoundResampler.cpp
+++ b/Core/Shared/Audio/SoundResampler.cpp
@@ -80,8 +80,9 @@ void SoundResampler::UpdateTargetSampleRate(uint32_t sourceRate, uint32_t sample
 
 	if(_emu->GetSettings()->GetVideoConfig().IntegerFpsMode) {
 		//Adjust input sample rate when using integer fps values
-		double baseFps = _emu->GetConsoleUnsafe()->GetFps();
-		double roundedFps = _emu->GetFps();
+		shared_ptr<IConsole> console = _emu->GetConsole();
+		double baseFps = console->GetFps();
+		double roundedFps = std::round(baseFps);
 		inputRate = sourceRate * (roundedFps / baseFps);
 	}
 


### PR DESCRIPTION
Crash only occurred for NES games and only if the "integer fps" option was enabled.