### PR TITLE
NES: Fixed screen size when loading a PAL game using the "Auto" aspect ratio

### DIFF
--- a/Core/Shared/Emulator.cpp
+++ b/Core/Shared/Emulator.cpp
@@ -638,8 +638,12 @@ PpuFrameInfo Emulator::GetPpuFrame()
 
 ConsoleRegion Emulator::GetRegion()
 {
+	//Returns last active region when no console is active
 	shared_ptr<IConsole> console = GetConsole();
-	return console ? console->GetRegion() : ConsoleRegion::Ntsc;
+	if(console) {
+		_lastRegion = console->GetRegion();
+	}
+	return _lastRegion;
 }
 
 shared_ptr<IConsole> Emulator::GetConsole()

--- a/Core/Shared/Emulator.h
+++ b/Core/Shared/Emulator.h
@@ -112,6 +112,7 @@ private:
 
 	RomInfo _rom;
 	ConsoleType _consoleType = {};
+	ConsoleRegion _lastRegion = ConsoleRegion::Ntsc;
 
 	ConsoleMemoryInfo _consoleMemory[DebugUtilities::GetMemoryTypeCount()] = {};
 


### PR DESCRIPTION
On the NES, loading a PAL game with the "auto" aspect ratio, powering off the console, and then loading a PAL game again would result in the screen being the incorrect aspect ratio/ratio, until the user's mouse goes over the menu, or the window is resized, etc. This was caused by the region being reset to NTSC when the game is unloaded, despite the screen keeping the PAL aspect ratio's dimensions,.