### PR TITLE
GBA: DMA - On repeat, channels should reload the length from the register

### DIFF
--- a/Core/GBA/GbaDmaController.cpp
+++ b/Core/GBA/GbaDmaController.cpp
@@ -288,6 +288,9 @@ void GbaDmaController::RunDma(GbaDmaChannel& ch, uint8_t chIndex)
 		ch.Enabled = false;
 		ch.Control &= ~0x8000;
 	} else {
+		//Length is reloaded from the register on each repeat
+		ch.LenLatch = ch.Length;
+
 		if(destMode == GbaDmaAddrMode::IncrementReload) {
 			ch.DestLatch = ch.Destination;
 		}


### PR DESCRIPTION
Fixes "DMA count latching" test in latest mGBA Suite test rom (Misc. edge case tests)