### PR TITLE
Debugger: NES - Fixed "Break on crash" only being triggered once, even after rewinding

### DIFF
--- a/Core/NES/Debugger/NesAssembler.cpp
+++ b/Core/NES/Debugger/NesAssembler.cpp
@@ -89,7 +89,12 @@ AssemblerSpecialCodes NesAssembler::ResolveOpMode(AssemblerLineData& op, uint32_
 		} else if(operand.Type == OperandType::A) {
 			op.AddrMode = NesAddrMode::Acc;
 		} else if(op.OperandCount == 0) {
-			op.AddrMode = IsOpModeAvailable(op.OpCode, NesAddrMode::Acc) ? NesAddrMode::Acc : NesAddrMode::Imp;
+			if(IsOpModeAvailable(op.OpCode, NesAddrMode::None)) {
+				//For STP
+				op.AddrMode = NesAddrMode::None;
+			} else {
+				op.AddrMode = IsOpModeAvailable(op.OpCode, NesAddrMode::Acc) ? NesAddrMode::Acc : NesAddrMode::Imp;
+			}
 		} else if(op.OperandCount == 1) {
 			if(IsOpModeAvailable(op.OpCode, NesAddrMode::Rel)) {
 				op.AddrMode = NesAddrMode::Rel;

--- a/Core/NES/NesCpu.cpp
+++ b/Core/NES/NesCpu.cpp
@@ -97,7 +97,7 @@ void NesCpu::Reset(bool softReset, ConsoleRegion region)
 	_abortDmcDma = false;
 	_isDmcDmaRead = false;
 	_cpuWrite = false;
-	_hideCrashWarning = false;
+	_crashed = false;
 
 	//Use _memoryManager->Read() directly to prevent clocking the PPU/APU when setting PC at reset
 	_state.PC = _memoryManager->Read(NesCpu::ResetVector) | _memoryManager->Read(NesCpu::ResetVector + 1) << 8;
@@ -603,9 +603,8 @@ void NesCpu::HLT()
 	_prevNeedNmi = false;
 
 #if !defined(DUMMYCPU)
-	if(!_hideCrashWarning) {
-		_hideCrashWarning = true;
-
+	if(!_crashed) {
+		_crashed = true;
 		MessageManager::DisplayMessage("Error", "GameCrash", "Invalid OP code - CPU crashed.");
 		_emu->BreakIfDebugging(CpuType::Nes, BreakSource::NesBreakOnCpuCrash);
 
@@ -643,5 +642,6 @@ void NesCpu::Serialize(Serializer& s)
 		SV(_prevNeedNmi);
 		SV(_prevNmiFlag);
 		SV(_needNmi);
+		SV(_crashed);
 	}
 }

--- a/Core/NES/NesCpu.h
+++ b/Core/NES/NesCpu.h
@@ -59,7 +59,7 @@ private:
 	bool _prevNeedNmi = false;
 	bool _needNmi = false;
 
-	uint64_t _hideCrashWarning = 0;
+	bool _crashed = false;
 	bool _isDmcDmaRead = false;
 
 	__forceinline void StartCpuCycle(bool forRead);


### PR DESCRIPTION
Also fixed the assembler not allowing "STP" as a valid instruction