### PR TITLE
Debugger: Memory search usability improvements

### DIFF
--- a/UI/Debugger/ViewModels/MemorySearchViewModel.cs
+++ b/UI/Debugger/ViewModels/MemorySearchViewModel.cs
@@ -31,7 +31,7 @@ public class MemorySearchViewModel : DisposableViewModel
 	[Reactive] public MemorySearchFormat Format { get; set; } = MemorySearchFormat.Hex;
 	[Reactive] public MemorySearchValueSize ValueSize { get; set; } = MemorySearchValueSize.Byte;
 
-	[Reactive] public MemorySearchCompareTo CompareTo { get; set; } = MemorySearchCompareTo.PreviousRefreshValue;
+	[Reactive] public MemorySearchCompareTo CompareTo { get; set; } = MemorySearchCompareTo.PreviousSearchValue;
 	[Reactive] public MemorySearchOperator Operator { get; set; } = MemorySearchOperator.Equal;
 
 	[Reactive] public MesenList<MemoryAddressViewModel> ListData { get; private set; } = new();
@@ -56,6 +56,7 @@ public class MemorySearchViewModel : DisposableViewModel
 	public int[] AddressLookup => _addressLookup;
 	public byte[] MemoryState => _memoryState;
 	public byte[] PrevMemoryState => _prevMemoryState;
+	public byte[] LastSearchSnapshot => _lastSearchSnapshot;
 
 	private List<MemoryAddressViewModel> _innerData = new();
 
@@ -294,6 +295,16 @@ public class MemorySearchViewModel : DisposableViewModel
 		RefreshList(true);
 	}
 
+	public void UpdateValues()
+	{
+		//Add an "empty" filter that only updates the "last values" that the next filter will be based on
+		_undoHistory.Add(new SearchHistory(_hiddenAddresses, _lastSearchSnapshot));
+		IsUndoEnabled = true;
+		UpdateAddressLookup();
+		_lastSearchSnapshot = DebugApi.GetMemoryState(MemoryType);
+		RefreshList(true);
+	}
+
 	private void UpdateAddressLookup()
 	{
 		int count = _lastSearchSnapshot.Length;
@@ -429,11 +440,13 @@ public class MemoryAddressViewModel : INotifyPropertyChanged
 		int address = _search.AddressLookup[_index];
 		_addressString = address.ToString("X4");
 
+		byte[] prevData = _search.CompareTo == MemorySearchCompareTo.PreviousRefreshValue ? _search.PrevMemoryState : _search.LastSearchSnapshot;
+
 		uint value = 0;
 		uint prevValue = 0;
 		for(int i = 0; i < (int)_search.ValueSize && address + i < _search.MemoryState.Length; i++) {
 			value |= (uint)_search.MemoryState[address + i] << (i * 8);
-			prevValue |= (uint)_search.PrevMemoryState[address + i] << (i * 8);
+			prevValue |= (address + i < prevData.Length) ? (uint)prevData[address + i] << (i * 8) : 0;
 		}
 
 		switch(_search.Format) {

--- a/UI/Debugger/Windows/MemorySearchWindow.axaml
+++ b/UI/Debugger/Windows/MemorySearchWindow.axaml
@@ -70,6 +70,7 @@
 								Grid.Row="1"
 								Value="{Binding CompareTo}"
 								CheckedWhen="{x:Static dvm:MemorySearchCompareTo.PreviousRefreshValue}"
+								IsVisible="False"
 							/>
 							<c:EnumRadioButton
 								Grid.Row="2"
@@ -133,14 +134,22 @@
 					</c:GroupBox>
 				
 					<DockPanel>
-						<c:ButtonWithIcon
-							Icon="Assets/Find.png"
-							DockPanel.Dock="Left"
-							HorizontalAlignment="Right"
-							VerticalAlignment="Top"
-							Text="{l:Translate btnApplyFilter}"
-							Command="{Binding AddFilter}"
-						/>
+						<StackPanel DockPanel.Dock="Left">
+							<c:ButtonWithIcon
+								Icon="Assets/Find.png"
+								HorizontalAlignment="Left"
+								VerticalAlignment="Top"
+								Text="{l:Translate btnApplyFilter}"
+								Command="{Binding AddFilter}"
+							/>
+							<c:ButtonWithIcon
+								Icon="Assets/Reload.png"
+								HorizontalAlignment="Left"
+								VerticalAlignment="Top"
+								Text="{l:Translate btnUpdateValues}"
+								Command="{Binding UpdateValues}"
+							/>
+						</StackPanel>
 						<StackPanel>
 							<c:ButtonWithIcon
 								Icon="Assets/Undo.png"

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -1625,6 +1625,7 @@
 		<Form ID="MemorySearchWindow">
 			<Control ID="wndTitle">Memory Search</Control>
 			<Control ID="btnApplyFilter">Apply filter</Control>
+			<Control ID="btnUpdateValues">Update values</Control>
 			<Control ID="btnReset">Reset</Control>
 			<Control ID="btnUndo">Undo</Control>
 
@@ -3115,7 +3116,7 @@ E
 			<Value ID="Dword">32-bit</Value>
 		</Enum>
 		<Enum ID="MemorySearchCompareTo">
-			<Value ID="PreviousSearchValue">Previous search value</Value>
+			<Value ID="PreviousSearchValue">Last value</Value>
 			<Value ID="PreviousRefreshValue">Previous refresh value</Value>
 			<Value ID="SpecificValue">Specific value:</Value>
 			<Value ID="SpecificAddress">Specific address:</Value>


### PR DESCRIPTION
-Removed the confusing/hard-to-use "previous refresh value" "compare to" option
-The "last value" column now shows the values that "previous search value" will compare against
-Added "update values" button to apply an empty filter that does not hide any addresses, but updates the "last value" that will be used for subsequent filters