### PR TITLE
WS: Emulate internal EEPROM unlock bit in cartridge header when a boo…

### DIFF
--- a/Core/WS/WsConsole.cpp
+++ b/Core/WS/WsConsole.cpp
@@ -321,7 +321,9 @@ void WsConsole::InitPostBootRomState()
 	WsEepromState& eeprom = _internalEeprom->GetState();
 	eeprom.ReadDone = true;
 	eeprom.Idle = true;
-	eeprom.InternalEepromWriteProtected = true;
+	if(!(_prgRom[_prgRomSize - 0x10 + 9] & 0x80)) {
+		eeprom.InternalEepromWriteProtected = true;
+	}
 
 	//Copy data from rom header to internal eeprom, like the boot rom would
 	for(int i = 0; i < 3; i++) {


### PR DESCRIPTION
…t ROM is not present.

Source: [https://ws.nesdev.org/wiki/ROM_header](https://ws.nesdev.org/wiki/ROM_header). Tested with [the BootFriend installer](https://wonderful.asie.pl/ws/bootfriend/).