### PR TITLE
Debugger: Enforce 64kb maximum length for labels in all scenarios

### DIFF
--- a/UI/Debugger/Labels/LabelManager.cs
+++ b/UI/Debugger/Labels/LabelManager.cs
@@ -15,6 +15,7 @@ namespace Mesen.Debugger.Labels
 {
 	public class LabelManager
 	{
+		public const int MaxLength = 65536;
 		public static Regex LabelRegex { get; } = new Regex("^[@_a-zA-Z]+[@_a-zA-Z0-9]*$", RegexOptions.Compiled);
 		public static Regex InvalidLabelRegex { get; } = new Regex("[^@_a-zA-Z0-9]", RegexOptions.Compiled);
 		public static Regex AssertRegex { get; } = new Regex(@"assert\((.*)\)", RegexOptions.Compiled);
@@ -119,6 +120,10 @@ namespace Mesen.Debugger.Labels
 
 		public static bool SetLabel(CodeLabel label, bool raiseEvent)
 		{
+			if(label.Length > LabelManager.MaxLength) {
+				label.Length = LabelManager.MaxLength;
+			}
+
 			if(_reverseLookup.ContainsKey(label.Label)) {
 				//Another identical label exists, we need to remove it
 				DeleteLabel(_reverseLookup[label.Label], false);

--- a/UI/Debugger/ViewModels/LabelEditViewModel.cs
+++ b/UI/Debugger/ViewModels/LabelEditViewModel.cs
@@ -127,7 +127,7 @@ namespace Mesen.Debugger.ViewModels
 				Comment = label.Comment;
 				MemoryType = label.MemoryType;
 				Flags = label.Flags;
-				Length = label.Length;
+				Length = label.Length > LabelManager.MaxLength ? LabelManager.MaxLength : label.Length;
 			}
 
 			public void Commit()


### PR DESCRIPTION
When importing labels via .dbg/.elf/etc. files, the 64kb length limit for labels was ignored. This prevents several performance problems when a label is defined as having a length of e.g 1+mb