### PR TITLE
NES: Fix mapper 121, 187's CHR A18 behavior

### DIFF
--- a/Core/NES/Mappers/Mmc3Variants/MMC3_121.h
+++ b/Core/NES/Mappers/Mmc3Variants/MMC3_121.h
@@ -49,7 +49,7 @@ protected:
 			//Hack for Super 3-in-1
 			BaseMapper::SelectChrPage(slot, page | ((_exRegs[3] & 0x80) << 1), memoryType);
 		} else {
-			if((slot < 4 && _chrMode == 0) || (slot >= 4 && _chrMode == 1)) {
+			if(slot >= 4) {
 				page |= 0x100;
 			}
 			BaseMapper::SelectChrPage(slot, page, memoryType);

--- a/Core/NES/Mappers/Mmc3Variants/MMC3_187.h
+++ b/Core/NES/Mappers/Mmc3Variants/MMC3_187.h
@@ -23,7 +23,7 @@ protected:
 
 	void SelectChrPage(uint16_t slot, uint16_t page, ChrMemoryType memoryType = ChrMemoryType::Default) override
 	{
-		if((_chrMode && slot >= 4) || (!_chrMode && slot < 4)) {
+		if(slot >= 4) {
 			page |= 0x100;
 		}
 		BaseMapper::SelectChrPage(slot, page);


### PR DESCRIPTION
According to SF-Human, NewRisingSun in discord, those mappers shouldn't care about MMC3's alternate CHR banking mode. PPU A12 is directly wired to CHR-A18, resulting PPU $0000-$0FFF to always use the top 256K, and PPU $1000-$1FFF to always use the bottom 256K, regardless of $8000.7 bit.