### PR TITLE
WS: Expand ELF importer layout support.

### DIFF
--- a/UI/Debugger/Integration/ElfImporter.cs
+++ b/UI/Debugger/Integration/ElfImporter.cs
@@ -161,15 +161,23 @@ public class ElfImporterWs : ElfImporter
 
 		AddressInfo absAddr = new();
 		uint addr = symbol.Value;
+
 		if((addr & 0x80000000) != 0) {
+			// Wonderful's linker places ROM data in 0x80000000 .. 0xFFFFFFFF/
 			absAddr.Address = (int)((addr & 0xFFFF) | ((addr & 0x7FF00000) >> 4)) & (romSize - 1);
 			absAddr.Type = MemoryType.WsPrgRom;
 		} else if(addr <= 0xFFFF) {
 			absAddr.Address = (int)addr;
 			absAddr.Type = MemoryType.WsWorkRam;
 		} else if((addr & 0xF0000) == 0x10000) {
+			// Wonderful's linker places SRAM data in 0x00010000 .. 0x0071FFFF.
 			absAddr.Address = (int)((addr & 0xFFFF) | ((addr & 0xF00000) >> 4));
 			absAddr.Type = MemoryType.WsCartRam;
+		} else if(addr <= 0xFFFFF) {
+			// Standard ELF linking may place ROM data in 0x00020000 .. 0x000FFFFF,
+			// treating the memory space as unbanked. If so, assume the top of the ROM.
+			absAddr.Address = (((romSize - 1) & ~0xFFFFF) | (int)(addr & 0xFFFFF)) & (romSize - 1);
+			absAddr.Type = MemoryType.WsPrgRom;
 		}
 
 		symbolInfo = new() {


### PR DESCRIPTION
Added support for ELF files which do not have special handling for WS platform banking and instead only map the 20-bit CPU memory space.

One such example is [my FreyaBIOS reimplementation, AthenaBIOS](https://codeberg.org/OpenWitch/AthenaOS/src/branch/main/bios/link.ld).