### PR TITLE
Debugger: SNES - Fixed DSP-n trace logger not logging the correct instructions

### DIFF
--- a/Core/Debugger/MemoryAccessCounter.cpp
+++ b/Core/Debugger/MemoryAccessCounter.cpp
@@ -106,4 +106,5 @@ template void MemoryAccessCounter::ProcessMemoryWrite<4>(AddressInfo& addressInf
 
 template void MemoryAccessCounter::ProcessMemoryExec<1>(AddressInfo& addressInfo, uint64_t masterClock);
 template void MemoryAccessCounter::ProcessMemoryExec<2>(AddressInfo& addressInfo, uint64_t masterClock);
+template void MemoryAccessCounter::ProcessMemoryExec<3>(AddressInfo& addressInfo, uint64_t masterClock);
 template void MemoryAccessCounter::ProcessMemoryExec<4>(AddressInfo& addressInfo, uint64_t masterClock);

--- a/Core/SNES/Debugger/NecDspDebugger.cpp
+++ b/Core/SNES/Debugger/NecDspDebugger.cpp
@@ -79,6 +79,7 @@ void NecDspDebugger::ProcessInstruction()
 void NecDspDebugger::ProcessRead(uint32_t addr, uint8_t value, MemoryOperationType type)
 {
 	if(type == MemoryOperationType::ExecOpCode) {
+		addr *= 3;
 		AddressInfo addressInfo = { (int32_t)addr, MemoryType::DspProgramRom };
 		MemoryOperationInfo operation(addr, value, MemoryOperationType::ExecOpCode, MemoryType::NecDspMemory);
 		InstructionProgress.LastMemOperation = operation;
@@ -87,6 +88,7 @@ void NecDspDebugger::ProcessRead(uint32_t addr, uint8_t value, MemoryOperationTy
 			DisassemblyInfo disInfo = _disassembler->GetDisassemblyInfo(addressInfo, addr, 0, CpuType::NecDsp);
 			_traceLogger->Log(_dsp->GetState(), disInfo, operation, addressInfo);
 		}
+		_memoryAccessCounter->ProcessMemoryExec<3>(addressInfo, _memoryManager->GetMasterClock());
 	} else {
 		MemoryType memType = (addr & NecDsp::DataRomReadFlag) ? MemoryType::DspDataRom : MemoryType::DspDataRam;
 		addr &= ~NecDsp::DataRomReadFlag;

--- a/Core/SNES/Debugger/TraceLogger/NecDspTraceLogger.h
+++ b/Core/SNES/Debugger/TraceLogger/NecDspTraceLogger.h
@@ -25,7 +25,7 @@ public:
 	void GetTraceRow(string& output, NecDspState& cpuState, TraceLogPpuState& ppuState, DisassemblyInfo& disassemblyInfo);
 	void LogPpuState();
 
-	__forceinline uint32_t GetProgramCounter(NecDspState& state) { return state.PC; }
+	__forceinline uint32_t GetProgramCounter(NecDspState& state) { return state.PC * 3; }
 	__forceinline uint64_t GetCycleCount(NecDspState& state) { return state.CycleCount; }
 	__forceinline uint8_t GetStackPointer(NecDspState& state) { return state.SP; }
 };


### PR DESCRIPTION
Also fixes missing "exec" highlight for "DSP-n Program ROM" in the memory viewer