### PR TITLE
GBA: DMA should stop if it disables itself

### DIFF
--- a/Core/GBA/GbaDmaController.cpp
+++ b/Core/GBA/GbaDmaController.cpp
@@ -187,7 +187,7 @@ void GbaDmaController::RunDma(GbaDmaChannel& ch, uint8_t chIndex)
 
 	_dmaActiveChannel = chIndex;
 
-	while(length-- > 0) {
+	while(length-- > 0 && ch.Enabled) {
 		uint32_t value;
 		if(srcAddr >= 0x2000000) {
 			if(!isRomSrc) {


### PR DESCRIPTION
Fixes the destoer/dma_priority test (test 5 "after" should be 0, not 2)