### PR TITLE
GBA: fix Sprite Viewer vertical mirror on sprites without matrix transform

### DIFF
--- a/Core/GBA/Debugger/GbaPpuTools.cpp
+++ b/Core/GBA/Debugger/GbaPpuTools.cpp
@@ -511,7 +511,6 @@ void GbaPpuTools::GetSpriteInfo(DebugSpriteInfo& sprite, uint32_t* spritePreview
 	int16_t centerY = 0;
 
 	for(int y = 0; y < sprite.Height; y++) {
-		uint8_t yOffset = vMirror ? (sprite.Height - y - 1) : y;
 
 		if(transformEnabled) {
 			uint16_t transformAddr = (sprite.TransformParamIndex << 5) + 6;
@@ -525,6 +524,7 @@ void GbaPpuTools::GetSpriteInfo(DebugSpriteInfo& sprite, uint32_t* spritePreview
 
 			int32_t originX = -(centerX << (uint8_t)doubleSize);
 			int32_t originY = -(centerY << (uint8_t)doubleSize);
+			uint8_t yOffset = vMirror ? (sprite.Height - y - 1) : y;
 
 			xValue = originX * pa + (originY + yOffset) * pb;
 			yValue = originX * pc + (originY + yOffset) * pd;
@@ -542,7 +542,7 @@ void GbaPpuTools::GetSpriteInfo(DebugSpriteInfo& sprite, uint32_t* spritePreview
 				yValue += pc;
 			} else {
 				xRender = hMirror ? (width - x - 1) : x;
-				yRender = vMirror ? (height - yOffset - 1) : yOffset;
+				yRender = vMirror ? (height - y - 1) : y;
 			}
 
 			if(xRender >= width || yRender >= height) {

--- a/Core/GBA/Debugger/GbaPpuTools.cpp
+++ b/Core/GBA/Debugger/GbaPpuTools.cpp
@@ -511,7 +511,6 @@ void GbaPpuTools::GetSpriteInfo(DebugSpriteInfo& sprite, uint32_t* spritePreview
 	int16_t centerY = 0;
 
 	for(int y = 0; y < sprite.Height; y++) {
-
 		if(transformEnabled) {
 			uint16_t transformAddr = (sprite.TransformParamIndex << 5) + 6;
 			pa = oam[transformAddr] | (oam[transformAddr + 1] << 8);


### PR DESCRIPTION
The code for displaying sprites in the Sprite Viewer had applied the vertical mirroring twice in a row for displayed sprites without matrix transform.
This had the consequence of displaying all of those sprites as non-mirrored on that axis.

With this fix, vertical mirroring is only applied once, allowing vertically mirrored sprites to appear correctly.