### PR TITLE
Build: Remove dependency on powershell/zip utilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/build-sha1-action
 
       - name: Build Mesen
-        run: msbuild -nologo -v:d -clp:ForceConsoleColor -m -p:Configuration=Release -p:Platform=x64 -t:Clean,UI -p:TargetFramework="${{ matrix.platform.targetframework }}"
+        run: msbuild -nologo -v:d -clp:ForceConsoleColor -m -p:Configuration=Release -p:Platform=x64 -t:Clean,UI -p:TargetFramework="${{ matrix.platform.targetframework }}" -p:OptimizeUi="true"
 
       - name: Publish Mesen
         run: dotnet publish --no-restore -c Release -p:PublishAot="${{ matrix.platform.aot }}" -p:SelfContained="${{ matrix.platform.aot }}" -p:PublishSingleFile="${{ matrix.platform.singleFile }}" -p:OptimizeUi="true" -p:Platform="Any CPU" -p:TargetFramework="${{ matrix.platform.targetframework }}" -r win-x64 Mesen.sln /p:PublishProfile=UI\Properties\PublishProfiles\Release.pubxml

--- a/Mesen.sln
+++ b/Mesen.sln
@@ -9,21 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UI", "UI\UI.csproj", "{CF2D
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Core", "Core\Core.vcxproj", "{78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0}"
-	ProjectSection(ProjectDependencies) = postProject
-		{B5330148-E8C7-46BA-B54E-69BE59EA337D} = {B5330148-E8C7-46BA-B54E-69BE59EA337D}
-		{B609E0A0-5050-4871-91D6-E760633BCDD1} = {B609E0A0-5050-4871-91D6-E760633BCDD1}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Utilities", "Utilities\Utilities.vcxproj", "{B5330148-E8C7-46BA-B54E-69BE59EA337D}"
-	ProjectSection(ProjectDependencies) = postProject
-		{52C4BA3A-E699-4305-B23F-C9083FD07AB6} = {52C4BA3A-E699-4305-B23F-C9083FD07AB6}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Windows", "Windows\Windows.vcxproj", "{7761E790-B42C-4179-8550-8365FF9EB23E}"
-	ProjectSection(ProjectDependencies) = postProject
-		{B5330148-E8C7-46BA-B54E-69BE59EA337D} = {B5330148-E8C7-46BA-B54E-69BE59EA337D}
-		{78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0} = {78FEF1A1-6DF1-4CBB-A373-AE6FA7CE5CE0}
-	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InteropDLL", "InteropDLL\InteropDLL.vcxproj", "{37749BB2-FA78-4EC9-8990-5628FC0BBA19}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/UI/UI.csproj
+++ b/UI/UI.csproj
@@ -27,6 +27,7 @@
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 		<SelfContained>false</SelfContained>
+		<DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)'!='net6.0'">
 		<IsAotCompatible>true</IsAotCompatible>
@@ -624,9 +625,6 @@
     <AvaloniaResource Include="ThirdParty\DataBox\Themes\Fluent.axaml" />
   </ItemGroup>
   <ItemGroup>
-    <AvaloniaResource Include="Assets\NesIcon.png" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Debugger\Documentation\WsDocumentation.json" />
     <EmbeddedResource Include="Debugger\Documentation\SmsDocumentation.json" />
     <EmbeddedResource Include="Debugger\Documentation\GbaDocumentation.json" />
@@ -660,16 +658,38 @@
     </AvaloniaXaml>
   </ItemGroup>
 
-  <Target Name="PreBuildWindows" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='win-x64'">
-    <Exec Command="cd $(OutDir)&#xD;&#xA;rd Dependencies /s /q&#xD;&#xA;md Dependencies&#xD;&#xA;xcopy /s $(ProjectDir)Dependencies\* Dependencies&#xD;&#xA;copy libHarfBuzzSharp.dll Dependencies&#xD;&#xA;copy libSkiaSharp.dll Dependencies&#xD;&#xA;copy MesenCore.dll Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;del ..\Dependencies.zip&#xD;&#xA;powershell Compress-Archive -Path * -DestinationPath '..\Dependencies.zip' -Force&#xD;&#xA;copy ..\Dependencies.zip $(ProjectDir)" />
-  </Target>
+	<PropertyGroup>
+		<DllExtension>dll</DllExtension>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'">
+		<DllExtension>so</DllExtension>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'">
+		<DllExtension>dylib</DllExtension>
+	</PropertyGroup>
+	<ItemGroup>
+		<DependencyFiles Include="$(ProjectDir)Dependencies/**/*" />
+		
+		<!-- Only include the core DLL into the zip file for "release" builds (when OptimizeUi is true) -->
+		<DependencyFiles Condition="'$(OptimizeUi)'=='true'" Include="$(OutDir)MesenCore.$(DllExtension)" />
 
-	<Target Name="PreBuildLinux" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='linux-x64' Or '$(RuntimeIdentifier)'=='linux-arm64'">
-    <Exec Command="cd $(OutDir)&#xD;&#xA;rm -rf Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.so Dependencies&#xD;&#xA;cp libSkiaSharp.so Dependencies&#xD;&#xA;cp MesenCore.so Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
-  </Target>
-  
-	<Target Name="PreBuildOsx" BeforeTargets="PreBuildEvent" Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'">
-    <Exec Command="cp ./Assets/MesenIcon.icns $(OutDir)&#xD;&#xA;cd $(OutDir)&#xD;&#xA;rm -R Dependencies&#xD;&#xA;mkdir Dependencies&#xD;&#xA;cp -R $(ProjectDir)/Dependencies/* Dependencies&#xD;&#xA;cp libHarfBuzzSharp.dylib Dependencies&#xD;&#xA;cp libSkiaSharp.dylib Dependencies&#xD;&#xA;cp MesenCore.dylib Dependencies&#xD;&#xA;cd Dependencies&#xD;&#xA;rm ../Dependencies.zip&#xD;&#xA;zip -r ../Dependencies.zip *&#xD;&#xA;cp ../Dependencies.zip $(ProjectDir)" />
-  </Target>
+		<NugetDependencyFiles Include="$(OutDir)libHarfBuzzSharp.$(DllExtension)" />
+		<NugetDependencyFiles Include="$(OutDir)libSkiaSharp.$(DllExtension)" />
+	</ItemGroup>
 
+	<Target Name="ZipDependencies" BeforeTargets="PreBuildEvent" AfterTargets="Restore" Inputs="@(DependencyFiles);@(NugetDependencyFiles);$(OutDir)NugetTimestamp.txt" Outputs="$(ProjectDir)Dependencies.zip">
+		<RemoveDir Directories="$(OutDir)Dependencies" />
+		<Copy SourceFiles="@(DependencyFiles)" DestinationFolder="$(OutDir)Dependencies/%(RecursiveDir)" />
+
+		<Copy SourceFiles="@(NugetDependencyFiles)" DestinationFolder="$(OutDir)Dependencies" ContinueOnError="WarnAndContinue" />
+		<Touch Files="$(OutDir)NugetTimestamp.txt" AlwaysCreate="True" Condition="'$(MSBuildLastTaskResult)' == 'true'" />
+
+		<Copy Condition="'$(RuntimeIdentifier)'=='osx-x64' Or '$(RuntimeIdentifier)'=='osx-arm64'" SourceFiles="./Assets/MesenIcon.icns" DestinationFolder="$(OutDir)" />
+		<ZipDirectory SourceDirectory="$(OutDir)Dependencies" DestinationFile="$(ProjectDir)Dependencies.zip" Overwrite="true" />
+	</Target>
+
+	<Target Name="CleanDependencies" AfterTargets="Clean">
+		<RemoveDir Directories="$(OutDir)Dependencies" />
+		<Delete Files="$(ProjectDir)Dependencies.zip" />
+	</Target>
 </Project>

--- a/UI/Utilities/DependencyHelper.cs
+++ b/UI/Utilities/DependencyHelper.cs
@@ -18,6 +18,20 @@ class DependencyHelper
 				throw new Exception("Missing dependencies.zip");
 			}
 
+#if DEBUG
+			try {
+				//In builds done via VS (without the "OptimizeUi" flag), the core is not embedded in the .exe (to improve build performance)
+				//Copy it directly from the bin folder to the home folder
+				string[] extensions = new string[] { ".dll", ".so", "dylib" };
+				foreach(string ext in extensions) {
+					string src = Path.Join(Program.OriginalFolder, "MesenCore" + ext);
+					if(File.Exists(src)) {
+						File.Copy(src, Path.Join(dest, "MesenCore" + ext), true);
+					}
+				}
+			} catch { }
+#endif
+
 			using ZipArchive zip = new(depStream);
 			foreach(ZipArchiveEntry entry in zip.Entries) {
 				try {


### PR DESCRIPTION
Currently, the UI build requires powershell (Windows) or "zip" (Linux/macOS). But in some environments, powershell may not be allowed to run scripts by default, or the "zip" utility might not be available, etc. This PR replaces these calls with built-in msbuild tasks which should ensure they work identically in all environments. 
This also makes builds slightly faster for dev purposes by avoiding building the UI when not needed.