### PR TITLE
Makefile: add an `install` target (currently Linux-only)

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,7 +4,11 @@
 #The emulation core also requires SDL2.
 #Run "make" to build, "make run" to run, and "make install" to install
 
-MESENFLAGS=
+#set this to where you want
+#Mesen to be installed to
+DEST =
+
+MESENFLAGS =
 
 ifeq ($(USE_GCC),true)
 	CXX := g++
@@ -30,8 +34,6 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	MESENOS := linux
 	SHAREDLIB := MesenCore.so
-	# TODO: what about macOS and Windows?
-	PREFIX := /usr/local
 endif
 
 ifeq ($(UNAME_S),Darwin)
@@ -237,10 +239,8 @@ run:
 	$(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen
 
 install:
-ifeq ($(MESENOS),linux)
-		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/libHarfBuzzSharp.so $(PREFIX)/lib64
-		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/libSkiaSharp.so $(PREFIX)/lib64
-		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen $(PREFIX)/bin
+ifneq ($(DEST),)
+		cp $(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen $(DEST)
 endif
 
 clean:

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 #Welcome to what must be the most terrible makefile ever (but hey, it works)
 #Both clang & gcc work fine - clang seems to output faster code
-#.NET 6 (and its dev tools) must be installed to compile the UI.
+#.NET 8 (and its dev tools) must be installed to compile the UI.
 #The emulation core also requires SDL2.
-#Run "make" to build, "make run" to run
+#Run "make" to build, "make run" to run, and "make install" to install
 
 MESENFLAGS=
 
@@ -30,6 +30,8 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 	MESENOS := linux
 	SHAREDLIB := MesenCore.so
+	# TODO: what about macOS and Windows?
+	PREFIX := /usr/local
 endif
 
 ifeq ($(UNAME_S),Darwin)
@@ -233,6 +235,13 @@ pgo:
 
 run:
 	$(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen
+
+install:
+ifeq ($(MESENOS),linux)
+		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/libHarfBuzzSharp.so $(PREFIX)/lib64
+		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/libSkiaSharp.so $(PREFIX)/lib64
+		install -m755 $(OUTFOLDER)/$(MESENPLATFORM)/publish/Mesen $(PREFIX)/bin
+endif
 
 clean:
 	rm -r -f $(COREOBJ)


### PR DESCRIPTION
It defaults to installing the libraries in `/usr/local/lib64` and Mesen itself in `/usr/local/bin`. I'm not really sure what to do with the other OSes as I haven't programmed much on them, so that part will be missing for now.