### PR TITLE
Use OldStyle debug symbols for mixed mode profiling

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -1267,6 +1267,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/Lua/Lua.vcxproj
+++ b/Lua/Lua.vcxproj
@@ -213,6 +213,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/SevenZip/SevenZip.vcxproj
+++ b/SevenZip/SevenZip.vcxproj
@@ -159,6 +159,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <CompileAs>CompileAsC</CompileAs>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Utilities/Utilities.vcxproj
+++ b/Utilities/Utilities.vcxproj
@@ -130,6 +130,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Windows/Windows.vcxproj
+++ b/Windows/Windows.vcxproj
@@ -122,6 +122,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Mesen currently uses the default /Zi setting for the core libraries, but when trying to profile Core, the symbols weren't showing up. It turns out that when building a static .lib file it creates a VC<x>.pdb file instead of a Core.pdb file, and seemingly, when combining the static libs to MesenCore.dll and generating MesenCore.pdb, it leaves out any of the symbols from the .lib files. Using OldStlye /Z7 fixes the issue as it keeps the debugging info inside of the so the MesenCore.dll linking step can include the other symbols.

The documentation for /Zi describes the behavior, but it doesn't tell me why this breaks debugging when building static libs into a dll.
https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format?view=msvc-170

AI Disclosure: Claude Opus 4.8 was used for determining this result. I did the actual code change :p I couldn't find any other way to keep /Zi for the static libs, and this doesn't affect performance or such.

---

Two pictures to show what changed. 

Before, the cpu usage graphics show C++ name mangled symbol names with no source view 
<img width="2280" height="1712" alt="image" src="https://github.com/user-attachments/assets/1b26d85b-2898-413e-9fcd-2bc688952575" />


After, the cpu usage now shows the readable symbol names, along with working source view 
<img width="2280" height="1712" alt="image" src="https://github.com/user-attachments/assets/4114a43f-3d4f-46e4-a1d2-e7f0822ebbb7" />
