### PR TITLE
GBA: Fixed sleep mode issues

### DIFF
--- a/Core/GBA/GbaMemoryManager.cpp
+++ b/Core/GBA/GbaMemoryManager.cpp
@@ -90,11 +90,9 @@ void GbaMemoryManager::RunPrefetch()
 
 void GbaMemoryManager::ProcessStoppedCycle()
 {
-	//What exactly is disabled when stopped?
-	//This at least works for the games that were tested (but is very likely inaccurate)
+	//According to gbatek, basically everything is disabled while in sleep mode
 	_masterClock++;
-	_ppu->Exec(); //keep PPU running to keep emulation running properly
-	_timer->Exec(_masterClock);
+	_ppu->ExecSleep();
 }
 
 void GbaMemoryManager::ProcessPendingUpdates(bool allowStartDma)
@@ -750,7 +748,11 @@ bool GbaMemoryManager::HasPendingIrq()
 bool GbaMemoryManager::IsHaltOver()
 {
 	if(_state.StopMode) {
-		return _controlManager->CheckInputCondition();
+		if(_controlManager->CheckInputCondition()) {
+			_state.StopMode = false;
+			return true;
+		}
+		return false;
 	} else {
 		return (bool)(_state.IrqPending & 0x01);
 	}

--- a/Core/GBA/GbaMemoryManager.h
+++ b/Core/GBA/GbaMemoryManager.h
@@ -163,7 +163,7 @@ public:
 
 	__forceinline void ProcessDma()
 	{
-		if(_dmaController->HasPendingDma()) {
+		if(_dmaController->HasPendingDma() && !_state.StopMode) {
 			_dmaController->RunPendingDma(true);
 		}
 	}

--- a/Core/GBA/GbaPpu.h
+++ b/Core/GBA/GbaPpu.h
@@ -251,6 +251,23 @@ public:
 		_emu->ProcessPpuCycle<CpuType::Gba>();
 	}
 
+	__forceinline void ExecSleep()
+	{
+		_state.Cycle++;
+		if(_state.Cycle == 308 * 4) {
+			_state.Cycle = 0;
+			_state.Scanline++;
+			if(_state.Scanline == 160) {
+				//Show white screen while in sleep mode
+				std::fill(_currentBuffer, _currentBuffer + GbaConstants::PixelCount, 0x7FFF);
+				SendFrame();
+			} else if(_state.Scanline > 227) {
+				_state.Scanline = 0;
+			}
+		}
+		_emu->ProcessPpuCycle<CpuType::Gba>();
+	}
+
 	bool IsAccessingMemory(uint8_t memType)
 	{
 		return _memoryAccess[_state.Cycle] & memType;


### PR DESCRIPTION
Timers, DMAs and the PPU no longer run during sleep (prevents audio DMA from being triggered and executed), and prevents the PPU from triggering DMAs/IRQs during sleep
This also fixes a bug where the GB-style APU channels could stay disabled permanently after leaving sleep mode (because the StopMode flag wasn't being reset to false)