### PR TITLE
SNES: MSU-1 should pause after $2005 write, until $2007 is written to start playback

### DIFF
--- a/Core/SNES/Coprocessors/MSU1/Msu1.cpp
+++ b/Core/SNES/Coprocessors/MSU1/Msu1.cpp
@@ -70,6 +70,8 @@ void Msu1::Write(uint16_t addr, uint8_t value)
 			} else {
 				LoadTrack();
 			}
+			_paused = true;
+			_repeat = false;
 			break;
 
 		case 0x2006: _volume = value; break;


### PR DESCRIPTION
The spec states that playback should pause/stop when 2005 is written, and ares implements this, too.