### PR TITLE
Runahead: Fixed issue causing runahead X to behave like runahead X-1 for all cores (except NES)

### DIFF
--- a/Core/SNES/SnesConsole.cpp
+++ b/Core/SNES/SnesConsole.cpp
@@ -53,6 +53,10 @@ void SnesConsole::Release()
 
 void SnesConsole::RunFrame()
 {
+	if(_emu->IsRunAheadFrame()) {
+		_ppu->ProcessRunAheadFrameStart();
+	}
+
 	UpdateRegion();
 
 	_frameRunning = true;

--- a/Core/SNES/SnesPpu.cpp
+++ b/Core/SNES/SnesPpu.cpp
@@ -504,8 +504,9 @@ bool SnesPpu::ProcessEndOfScanline(uint16_t& hClock)
 				(_settings->GetEmulationSpeed() == 0 || _settings->GetEmulationSpeed() > 150) &&
 				_frameSkipTimer.GetElapsedMS() < 10;
 
-			if(_emu->IsRunAheadFrame()) {
+			if(_isRunAheadFrame) {
 				_skipRender = true;
+				_isRunAheadFrame = false;
 			}
 
 			//Ensure the SPC is re-enabled for the next frame
@@ -516,6 +517,16 @@ bool SnesPpu::ProcessEndOfScanline(uint16_t& hClock)
 		return true;
 	}
 	return false;
+}
+
+void SnesPpu::ProcessRunAheadFrameStart()
+{
+	if(_state.Scanline >= _vblankStartScanline) {
+		//If the runahead frame starts during vblank (which it normally should,
+		//except if long DMAs were started before vblank and ended after vblank),
+		//skip rendering for this frame.
+		_isRunAheadFrame = true;
+	}
 }
 
 bool SnesPpu::IsInOverclockedScanline()

--- a/Core/SNES/SnesPpu.h
+++ b/Core/SNES/SnesPpu.h
@@ -124,6 +124,7 @@ private:
 	int32_t _debugMode7EndY = 0;
 
 	bool _needFullFrame = false;
+	bool _isRunAheadFrame = false;
 
 	void RenderSprites(const uint8_t priorities[4]);
 
@@ -258,6 +259,7 @@ public:
 	uint8_t* GetSpriteRam();
 
 	void DebugSendFrame();
+	void ProcessRunAheadFrameStart();
 
 	void SetLocationLatchRequest(uint16_t x, uint16_t y);
 	void ProcessLocationLatchRequest();

--- a/Core/Shared/Emulator.cpp
+++ b/Core/Shared/Emulator.cpp
@@ -209,6 +209,13 @@ void Emulator::RunFrameWithRunAhead()
 
 	//Run a single frame and save the state (no audio/video)
 	_isRunAheadFrame = true;
+
+	//Poll controllers again to try to ensure that the next frame starts with
+	//the current inputs instead of the inputs from the save state that just loaded.
+	//Depending on the timing at which each core polls inputs, this prevents
+	//adding a frame's worth of input lag (NES core was not affected by this)
+	_console->GetControlManager()->UpdateInputState();
+
 	_console->RunFrame();
 	Serialize(runAheadState, false, 0);
 


### PR DESCRIPTION
An additional frame's worth of input lag was added by runahead because of the timing at which it loads/saves the state vs when the inputs are polled (NES core was not affected due to the timing at which it polls controllers compared to other cores)

Also fixed a SNES-specific runahead issue when the game starts a very long DMA before vblank that ends after vblank, causing some frames to not be rendered at all and showing older frames instead (this is a rare scenario, but caused issues in Star Fox)