### PR TITLE
SNES: FX3: Add battery-backed ROM type

### DIFF
--- a/Core/SNES/BaseCartridge.cpp
+++ b/Core/SNES/BaseCartridge.cpp
@@ -228,6 +228,11 @@ void BaseCartridge::LoadRom()
 
 	_hasBattery = (_cartInfo.RomType & 0x0F) == 0x02 || (_cartInfo.RomType & 0x0F) == 0x05 || (_cartInfo.RomType & 0x0F) == 0x06 || (_cartInfo.RomType & 0x0F) == 0x09 || (_cartInfo.RomType & 0x0F) == 0x0A;
 
+	//Allow FX3 with battery
+	if(_cartInfo.RomType == Gsu::Fx3BatteryRomType) {
+		_hasBattery = true;
+	}
+
 	if(corruptedHeader) {
 		_coprocessorType = CoprocessorType::None;
 	} else {
@@ -533,7 +538,7 @@ void BaseCartridge::InitCoprocessor()
 		_sa1 = dynamic_cast<Sa1*>(_coprocessor.get());
 		_needCoprocSync = true;
 	} else if(_coprocessorType == CoprocessorType::GSU) {
-		_coprocessor.reset(new Gsu(_console, _coprocessorRamSize, _cartInfo.RomType == Gsu::Fx3RomType));
+		_coprocessor.reset(new Gsu(_console, _coprocessorRamSize, (_cartInfo.RomType == Gsu::Fx3RomType || _cartInfo.RomType == Gsu::Fx3BatteryRomType)));
 		_gsu = dynamic_cast<Gsu*>(_coprocessor.get());
 		_needCoprocSync = true;
 	} else if(_coprocessorType == CoprocessorType::SDD1) {
@@ -824,7 +829,7 @@ void BaseCartridge::DisplayCartInfo(bool showCorruptedHeaderWarning)
 			case CoprocessorType::DSP4: coProcMessage += "DSP4"; break;
 
 			case CoprocessorType::GSU:
-				if(_cartInfo.RomType == Gsu::Fx3RomType) {
+				if(_cartInfo.RomType == Gsu::Fx3RomType || _cartInfo.RomType == Gsu::Fx3BatteryRomType) {
 					coProcMessage += "Super FX (FX3)";
 				} else {
 					coProcMessage += "Super FX (GSU1/2)";

--- a/Core/SNES/Coprocessors/GSU/Gsu.h
+++ b/Core/SNES/Coprocessors/GSU/Gsu.h
@@ -177,6 +177,7 @@ private:
 
 public:
 	static constexpr uint8_t Fx3RomType = 0x17;
+	static constexpr uint8_t Fx3BatteryRomType = 0x18; //FX3 with battery
 
 	Gsu(SnesConsole* console, uint32_t gsuRamSize, bool isFx3);
 	virtual ~Gsu();


### PR DESCRIPTION
This PR adds ROM type $18 for FX3 with battery backup. This allows Star Fox 2 and Star Fox EX to save scores/settings after conversion to FX3.

As far as I can tell type $18 isn't reserved for anything else. I'm unsure if the separate check to enable battery with the new FX3 type is needed, as I wanted to avoid conflicting with any other ROM types.

I claim no copyright on these changes and accept any licensing changes.