### PR TITLE
GBA: Debugger: LDM/STM Effective Address & Disabled BIOS Return CDL Label

### DIFF
--- a/Core/GBA/Debugger/GbaDisUtils.cpp
+++ b/Core/GBA/Debugger/GbaDisUtils.cpp
@@ -944,7 +944,7 @@ EffectiveAddressInfo GbaDisUtils::GetEffectiveAddress(DisassemblyInfo& info, Gba
 				uint8_t rb = (opCode >> 8) & 0x07;
 				return { (int)state.R[rb], 0, true, MemoryType::GbaMemory };
 			}
-			
+
 			case GbaThumbOpCategory::InvalidOp:
 			case GbaThumbOpCategory::PushPopReg:
 				return {};
@@ -959,7 +959,7 @@ EffectiveAddressInfo GbaDisUtils::GetEffectiveAddress(DisassemblyInfo& info, Gba
 
 			case ArmOpCategory::BlockDataTransfer: {
 				uint8_t rn = (opCode >> 16) & 0x0F;
-				return { (int)state.R[rn], 0, true, MemoryType::GbaMemory};
+				return { (int)state.R[rn], 0, true, MemoryType::GbaMemory };
 			}
 			
 			case ArmOpCategory::InvalidOp:
@@ -1167,10 +1167,12 @@ CdlFlags::CdlFlags GbaDisUtils::GetOpFlags(uint32_t opCode, uint8_t flags, uint3
 	if(pc == prevPc + GbaDisUtils::GetOpSize(opCode, flags)) {
 		return CdlFlags::None;
 	}
+
 	if((prevPc <= 0x3FFF) && (pc > 0x3FFF)) {
 		// don't create label if returning from BIOS to prevent label clutter
 		return CdlFlags::None;	
 	}
+
 	if(IsJumpToSub(opCode, flags)) {
 		return CdlFlags::SubEntryPoint;
 	} else {

--- a/Core/GBA/Debugger/GbaDisUtils.cpp
+++ b/Core/GBA/Debugger/GbaDisUtils.cpp
@@ -940,8 +940,12 @@ EffectiveAddressInfo GbaDisUtils::GetEffectiveAddress(DisassemblyInfo& info, Gba
 				return {};
 			}
 
+			case GbaThumbOpCategory::MultipleLoadStore: {
+				uint8_t rb = (opCode >> 8) & 0x07;
+				return { (int)state.R[rb], 0, true, MemoryType::GbaMemory };
+			}
+			
 			case GbaThumbOpCategory::InvalidOp:
-			case GbaThumbOpCategory::MultipleLoadStore:
 			case GbaThumbOpCategory::PushPopReg:
 				return {};
 		}
@@ -953,8 +957,12 @@ EffectiveAddressInfo GbaDisUtils::GetEffectiveAddress(DisassemblyInfo& info, Gba
 				return { (int)state.R[rs], 0, true, MemoryType::GbaMemory };
 			}
 
+			case ArmOpCategory::BlockDataTransfer: {
+				uint8_t rn = (opCode >> 16) & 0x0F;
+				return { (int)state.R[rn], 0, true, MemoryType::GbaMemory};
+			}
+			
 			case ArmOpCategory::InvalidOp:
-			case ArmOpCategory::BlockDataTransfer:
 				return {};
 		}
 	}
@@ -1159,7 +1167,10 @@ CdlFlags::CdlFlags GbaDisUtils::GetOpFlags(uint32_t opCode, uint8_t flags, uint3
 	if(pc == prevPc + GbaDisUtils::GetOpSize(opCode, flags)) {
 		return CdlFlags::None;
 	}
-
+	if((prevPc <= 0x3FFF) && (pc > 0x3FFF)) {
+		// don't create label if returning from BIOS to prevent label clutter
+		return CdlFlags::None;	
+	}
 	if(IsJumpToSub(opCode, flags)) {
 		return CdlFlags::SubEntryPoint;
 	} else {

--- a/Core/GBA/Debugger/GbaDisUtils.cpp
+++ b/Core/GBA/Debugger/GbaDisUtils.cpp
@@ -961,7 +961,7 @@ EffectiveAddressInfo GbaDisUtils::GetEffectiveAddress(DisassemblyInfo& info, Gba
 				uint8_t rn = (opCode >> 16) & 0x0F;
 				return { (int)state.R[rn], 0, true, MemoryType::GbaMemory };
 			}
-			
+
 			case ArmOpCategory::InvalidOp:
 				return {};
 		}
@@ -1170,7 +1170,7 @@ CdlFlags::CdlFlags GbaDisUtils::GetOpFlags(uint32_t opCode, uint8_t flags, uint3
 
 	if((prevPc <= 0x3FFF) && (pc > 0x3FFF)) {
 		// don't create label if returning from BIOS to prevent label clutter
-		return CdlFlags::None;	
+		return CdlFlags::None;
 	}
 
 	if(IsJumpToSub(opCode, flags)) {


### PR DESCRIPTION
1. Made it so the LDM/STM instructions show their effective address, like LDR/STR.
2. Prevented jump/sub labels being created for returns from BIOS. This will make it easier to visually follow the code path in regions where IRQs frequently fire, as there will no longer be jump labels after every instruction.