### PR TITLE
SNES: FX3 - Fixed reset behavior

### DIFF
--- a/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
@@ -4,7 +4,7 @@
 
 void Gsu::STOP()
 {
-	if(_state.Fx3) {
+	if(_isFx3) {
 		//The FX3 resets R15 to 0 when done - this allows the CPU to poll R15
 		//to know when it's done running
 		WriteRegister(15, 0);
@@ -204,7 +204,7 @@ void Gsu::ALT3()
 
 void Gsu::MERGE()
 {
-	if(!_state.Fx3) {
+	if(!_isFx3) {
 		uint16_t value = (_state.R[7] & 0xFF00) | (_state.R[8] >> 8);
 		WriteDestReg(value);
 		_state.SFR.Carry = (value & 0xE0E0) != 0;

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -23,7 +23,7 @@ Gsu::Gsu(SnesConsole* console, uint32_t gsuRamSize, bool isFx3)
 	_cpu = console->GetCpu();
 	_settings = _emu->GetSettings();
 
-	_state.Fx3 = isFx3;
+	_isFx3 = isFx3;
 	_state.ProgramReadBuffer = 0x01; //Run a NOP on first cycle
 
 	UpdateClockMultiplier();
@@ -36,14 +36,14 @@ Gsu::Gsu(SnesConsole* console, uint32_t gsuRamSize, bool isFx3)
 
 	for(uint32_t i = 0; i < _gsuRamSize / 0x1000; i++) {
 		_gsuRamHandlers.push_back(unique_ptr<IMemoryHandler>(new RamHandler(_gsuRam, i * 0x1000, _gsuRamSize, MemoryType::GsuWorkRam)));
-		_gsuCpuRamHandlers.push_back(unique_ptr<IMemoryHandler>(new GsuRamHandler(_state, _gsuRamHandlers.back().get())));
+		_gsuCpuRamHandlers.push_back(unique_ptr<IMemoryHandler>(new GsuRamHandler(_state, isFx3, _gsuRamHandlers.back().get())));
 	}
 
 	//CPU mappings
 	MemoryMappings* cpuMappings = _memoryManager->GetMemoryMappings();
 	vector<unique_ptr<IMemoryHandler>>& prgRomHandlers = _console->GetCartridge()->GetPrgRomHandlers();
 	for(unique_ptr<IMemoryHandler>& handler : prgRomHandlers) {
-		_gsuCpuRomHandlers.push_back(unique_ptr<IMemoryHandler>(new GsuRomHandler(_state, handler.get())));
+		_gsuCpuRomHandlers.push_back(unique_ptr<IMemoryHandler>(new GsuRomHandler(_state, isFx3, handler.get())));
 	}
 
 	//GSU registers in CPU memory space
@@ -96,7 +96,7 @@ void Gsu::ProcessEndOfFrame()
 void Gsu::UpdateClockMultiplier()
 {
 	uint8_t clockMultiplier = std::max(1u, _settings->GetSnesConfig().GsuClockSpeed / 100);
-	if(_state.Fx3) {
+	if(_isFx3) {
 		//The FX3 runs around 4x faster than the original GSU
 		clockMultiplier *= 4;
 	}
@@ -464,7 +464,7 @@ void Gsu::Reset()
 uint8_t Gsu::Read(uint32_t addr)
 {
 	addr &= 0x33FF;
-	if(_state.SFR.Running && addr != 0x3030 && addr != 0x3031 && addr != 0x303B && (_state.Fx3 && (addr != 0x301E && addr != 0x301F))) {
+	if(_state.SFR.Running && addr != 0x3030 && addr != 0x3031 && addr != 0x303B && (_isFx3 && (addr != 0x301E && addr != 0x301F))) {
 		//"During GSU operation, only SFR, SCMR, and VCR may be accessed."
 		//Additionally, on the FX3, reading R15 while running is allowed.
 		//The FX3 hardware has no IRQs and the CPU needs to poll R15 to know when execution stops.
@@ -491,7 +491,7 @@ uint8_t Gsu::Read(uint32_t addr)
 
 		case 0x3034: return _state.ProgramBank;
 		case 0x3036: return _state.RomBank;
-		case 0x303B: return _state.Fx3 ? 0x52 : 0x04; //Version (can be 1 or 4?)
+		case 0x303B: return _isFx3 ? 0x52 : 0x04; //Version (can be 1 or 4?)
 		case 0x303C: return _state.RamBank;
 		case 0x303E: return (uint8_t)_state.CacheBase;
 		case 0x303F: return _state.CacheBase >> 8;

--- a/Core/SNES/Coprocessors/GSU/Gsu.h
+++ b/Core/SNES/Coprocessors/GSU/Gsu.h
@@ -31,6 +31,7 @@ private:
 	bool _waitForRamAccess = false;
 	bool _stopped = true;
 	bool _r15Changed = false;
+	bool _isFx3 = false;
 	uint8_t _maxPrgRomBank = 0;
 	uint32_t _lastOpAddr = 0;
 

--- a/Core/SNES/Coprocessors/GSU/GsuRamHandler.h
+++ b/Core/SNES/Coprocessors/GSU/GsuRamHandler.h
@@ -9,17 +9,19 @@ class GsuRamHandler : public IMemoryHandler
 private:
 	GsuState* _state;
 	IMemoryHandler* _handler;
+	bool _isFx3;
 
 public:
-	GsuRamHandler(GsuState& state, IMemoryHandler* handler) : IMemoryHandler(MemoryType::GsuWorkRam)
+	GsuRamHandler(GsuState& state, bool isFx3, IMemoryHandler* handler) : IMemoryHandler(MemoryType::GsuWorkRam)
 	{
 		_handler = handler;
 		_state = &state;
+		_isFx3 = isFx3;
 	}
 
 	uint8_t Read(uint32_t addr) override
 	{
-		if(_state->Fx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
+		if(_isFx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
 			return _handler->Read(addr);
 		}
 
@@ -41,14 +43,14 @@ public:
 
 	void Write(uint32_t addr, uint8_t value) override
 	{
-		if(_state->Fx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
+		if(_isFx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
 			_handler->Write(addr, value);
 		}
 	}
 
 	AddressInfo GetAbsoluteAddress(uint32_t address) override
 	{
-		if(_state->Fx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
+		if(_isFx3 || !_state->SFR.Running || !_state->GsuRamAccess) {
 			return _handler->GetAbsoluteAddress(address);
 		} else {
 			return { -1, MemoryType::None };

--- a/Core/SNES/Coprocessors/GSU/GsuRomHandler.h
+++ b/Core/SNES/Coprocessors/GSU/GsuRomHandler.h
@@ -9,17 +9,19 @@ class GsuRomHandler : public IMemoryHandler
 private:
 	GsuState* _state;
 	IMemoryHandler* _romHandler;
+	bool _isFx3;
 
 public:
-	GsuRomHandler(GsuState& state, IMemoryHandler* romHandler) : IMemoryHandler(MemoryType::SnesPrgRom)
+	GsuRomHandler(GsuState& state, bool isFx3, IMemoryHandler* romHandler) : IMemoryHandler(MemoryType::SnesPrgRom)
 	{
 		_romHandler = romHandler;
 		_state = &state;
+		_isFx3 = isFx3;
 	}
 
 	uint8_t Read(uint32_t addr) override
 	{
-		if(_state->Fx3 || !_state->SFR.Running || !_state->GsuRomAccess) {
+		if(_isFx3 || !_state->SFR.Running || !_state->GsuRomAccess) {
 			return _romHandler->Read(addr);
 		}
 
@@ -60,7 +62,7 @@ public:
 
 	AddressInfo GetAbsoluteAddress(uint32_t address) override
 	{
-		if(_state->Fx3 || !_state->SFR.Running || !_state->GsuRomAccess) {
+		if(_isFx3 || !_state->SFR.Running || !_state->GsuRomAccess) {
 			return _romHandler->GetAbsoluteAddress(address);
 		} else {
 			return { -1, MemoryType::None };

--- a/Core/SNES/Coprocessors/GSU/GsuTypes.h
+++ b/Core/SNES/Coprocessors/GSU/GsuTypes.h
@@ -99,8 +99,6 @@ struct GsuState : BaseState
 
 	GsuPixelCache PrimaryCache;
 	GsuPixelCache SecondaryCache;
-
-	bool Fx3;
 };
 
 enum class Fx3Command

--- a/UI/Interop/ConsoleState/SnesState.cs
+++ b/UI/Interop/ConsoleState/SnesState.cs
@@ -503,8 +503,6 @@ public struct GsuState : BaseState
 
 	public GsuPixelCache PrimaryCache;
 	public GsuPixelCache SecondaryCache;
-
-	[MarshalAs(UnmanagedType.I1)] public bool Fx3;
 }
 
 public struct Cx4Dma


### PR DESCRIPTION
The "Fx3" flag was getting set to false after a reset. Refactor to move the flag out of the state struct to prevent this