### PR TITLE
SG-1000/CV: Fix bad interaction between sprite magnification and left-shifted sprites

### DIFF
--- a/Core/SMS/SmsVdp.cpp
+++ b/Core/SMS/SmsVdp.cpp
@@ -1090,7 +1090,7 @@ void SmsVdp::ShiftSpriteSg(uint8_t sprIndex)
 	_spriteShifters[sprIndex].SpriteX -= 32;
 	int16_t x = _spriteShifters[sprIndex].SpriteX;
 	if(x < 0) {
-		_spriteShifters[sprIndex].TileData[0] <<= -x;
+		_spriteShifters[sprIndex].TileData[0] <<= (-x) >> _state.EnableDoubleSpriteSize;
 	}
 }
 

--- a/Core/SMS/SmsVdp.cpp
+++ b/Core/SMS/SmsVdp.cpp
@@ -1090,7 +1090,7 @@ void SmsVdp::ShiftSpriteSg(uint8_t sprIndex)
 	_spriteShifters[sprIndex].SpriteX -= 32;
 	int16_t x = _spriteShifters[sprIndex].SpriteX;
 	if(x < 0) {
-		_spriteShifters[sprIndex].TileData[0] <<= (-x) >> _state.EnableDoubleSpriteSize;
+		_spriteShifters[sprIndex].TileData[0] <<= (-x) >> (uint8_t)_state.EnableDoubleSpriteSize;
 	}
 }
 


### PR DESCRIPTION
There is a bug in the TMS9918A emulation (SG-1000/ColecoVision) when a sprite in Early Clock Mode (shifted left 32 pixels) is scrolling off the left edge of the screen when in Magnified Sprite mode. `ShiftSpriteSg` clips a number of pixels out of the sprite shifter based on the negative X coordinate, but when the sprite is magnified, this is twice as many pixels as should be clipped, moving that sprite left further than it should be.

This phenomenon is made even worse when combined with the 4-tile sprite mode; the left and right halves of the sprite will be ripped further and further apart as the sprite leaves the screen. (See test ROM, attached, and the "before" image of `magshift_000`. Each scanline of that image has only one visible sprite, and the left and right halves continuously diverge.)

The fix is to divide the number of pixels clipped by 2 if we're in magnified sprite mode. For cases where we need to clip "half a pixel", rounding down does the right thing; `GetPixelColor` already does an odd/even check to manage when the shifter shifts and its logic is already sound.

Before patch:
<img width="256" height="192" alt="magshift_000" src="https://github.com/user-attachments/assets/a0f000c2-a803-4495-b0ff-f722c99d3da5" />

After patch:
<img width="256" height="192" alt="magshift_001" src="https://github.com/user-attachments/assets/fffcfc78-0f23-4c87-89e8-18129bf3c110" />

Test ROM (SG-1000, assembles with Sjasm):
[magshift_testrom.zip](https://github.com/user-attachments/files/30290926/magshift_testrom.zip)
