### PR TITLE
Video: Fixed black screen when toggling VRR while in fullscreen mode

### DIFF
--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -141,7 +141,7 @@
 			<Control ID="chkBilinearInterpolation">Use bilinear interpolation when scaling</Control>
 			<Control ID="chkUseSrgbTextureFormat">Use sRGB when applying interpolation</Control>
 			<Control ID="chkEnableVariableRefreshRate">Enable variable refresh rate (fullscreen only)</Control>
-			<Control ID="chkEnableVariableRefreshRateHint">When using a monitor that supports VRR (FreeSync, G-Sync), VRR will be enabled when running in borderless (not exclusive) fullscreen mode. This improves frame pacing and is recommended when supported.&#13;&#13;Warning: When enabled on a display that does not support VRR at all (or using a core that runs at an FPS outside of the monitor's supported VRR range), enabling this option will cause screen tearing when in fullscreen mode.</Control>
+			<Control ID="chkEnableVariableRefreshRateHint">When using a monitor that supports VRR (FreeSync, G-Sync), VRR will be enabled when running in borderless (not exclusive) fullscreen mode. This improves frame pacing and is recommended when supported.&#13;&#13;Note: Enabling or disabling this option while in fullscreen mode has no effect.&#13;&#13;Warning: When enabled on a display that does not support VRR at all (or using a core that runs at an FPS outside of the monitor's supported VRR range), enabling this option will cause screen tearing when in fullscreen mode.</Control>
 			<Control ID="lblFullscreenResolution">Fullscreen Resolution:</Control>
 			<Control ID="chkFullscreenForceIntegerScale">Use integer scale values when entering fullscreen mode</Control>
 			<Control ID="chkUseExclusiveFullscreen">Use exclusive fullscreen mode</Control>

--- a/UI/Windows/MainWindow.axaml.cs
+++ b/UI/Windows/MainWindow.axaml.cs
@@ -616,9 +616,6 @@ namespace Mesen.Windows
 
 			_preventFullscreenToggle = true;
 			if(WindowState == WindowState.FullScreen) {
-				if(ConfigManager.Config.Video.EnableVariableRefreshRate && !ConfigManager.Config.Video.UseExclusiveFullscreen && OperatingSystem.IsWindows()) {
-					_needRendererReset = true;
-				}
 				ResetRenderer();
 
 				Task.Run(() => {


### PR DESCRIPTION
When the user turned on fullscreen mode without VRR enabled, then enabled the VRR option, and then turned off fullscreen mode, it would cause the screen to be black until Mesen is shut down.