### PR TITLE
Debugger: Lua - Added getPressedKeys API

### DIFF
--- a/Core/Debugger/LuaApi.cpp
+++ b/Core/Debugger/LuaApi.cpp
@@ -29,7 +29,6 @@
 #include "Utilities/HexUtilities.h"
 #include "Utilities/FolderUtilities.h"
 #include "Utilities/magic_enum.hpp"
-#include "Shared/MemoryOperationType.h"
 
 #ifdef _MSC_VER
 	//TODO MSVC seems to trigger this by mistake because of the macros?
@@ -138,6 +137,7 @@ int LuaApi::GetLibrary(lua_State* lua)
 		{ "takeScreenshot", LuaApi::TakeScreenshot },
 
 		{ "isKeyPressed", LuaApi::IsKeyPressed },
+		{ "getPressedKeys", LuaApi::GetPressedKeys },
 		{ "getInput", LuaApi::GetInput },
 		{ "setInput", LuaApi::SetInput },
 
@@ -208,6 +208,51 @@ void LuaApi::GenerateEnumDefinition(lua_State* lua, string enumName, unordered_s
 		}
 	}
 	lua_settable(lua, -3);
+}
+
+string LuaApi::SerializeTable(lua_State* lua)
+{
+	string result = "{ ";
+	bool firstKey = true;
+	lua_pushnil(lua);
+	while(lua_next(lua, -2) != 0) {
+		int keyType = lua_type(lua, -2);
+		if(keyType == LUA_TSTRING || keyType == LUA_TNUMBER) {
+			if(!firstKey) {
+				result += ", ";
+			}
+			firstKey = false;
+			if(keyType == LUA_TSTRING) {
+				size_t len = 0;
+				const char* cstr = lua_tolstring(lua, -2, &len);
+				result += string(cstr, len);
+			} else {
+				if(lua_isinteger(lua, -2)) {
+					lua_Integer integer = lua_tointeger(lua, -2);
+					result += std::to_string(integer);
+				} else {
+					lua_Number number = lua_tonumber(lua, -2);
+					result += std::to_string(number);
+				}
+			}
+			result += " = ";
+
+			if(lua_type(lua, -1) == LUA_TSTRING) {
+				result += "\"";
+				result += lua_tostring(lua, -1);
+				result += "\"";
+			} else if(lua_istable(lua, -1)) {
+				result += SerializeTable(lua);
+			} else {
+				luaL_tolstring(lua, -1, nullptr);
+				result += lua_tostring(lua, -1);
+				lua_pop(lua, 1);
+			}
+		}
+		lua_pop(lua, 1);
+	}
+	result = StringUtilities::Trim(result);
+	return result + (result.size() > 1 ? " }" : "}");
 }
 
 DebugHud* LuaApi::GetHud()
@@ -730,8 +775,18 @@ int LuaApi::GetMouseState(lua_State* lua)
 int LuaApi::Log(lua_State* lua)
 {
 	LuaCallHelper l(lua);
-	string text = l.ReadString();
-	checkparams();
+	l.CheckSpecificParamCount(1);
+
+	string text;
+	if(lua_type(lua, -1) == LUA_TSTRING) {
+		text = lua_tostring(lua, -1);
+	} else if(lua_istable(lua, -1)) {
+		text = LuaApi::SerializeTable(lua);
+	} else {
+		luaL_tolstring(lua, -1, nullptr);
+		text = lua_tostring(lua, -1);
+		lua_pop(lua, 1);
+	}
 	_context->Log(text);
 	return l.ReturnCount();
 }
@@ -831,6 +886,26 @@ int LuaApi::IsKeyPressed(lua_State* lua)
 	errorCond(keyCode == 0, "Invalid key name");
 	l.Return(KeyManager::IsKeyPressed(keyCode));
 	return l.ReturnCount();
+}
+
+int LuaApi::GetPressedKeys(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	checkparams();
+
+	vector<uint16_t> pressedKeys = KeyManager::GetPressedKeys();
+	int size = (int)pressedKeys.size();
+
+	lua_createtable(lua, size, 0);
+	for(size_t i = 0; i < size; i++) {
+		string name = KeyManager::GetKeyName(pressedKeys[i]);
+		if(name.size() > 0) {
+			lua_pushlstring(lua, name.c_str(), name.size());
+			lua_rawseti(lua, -2, i + 1);
+		}
+	}
+
+	return 1;
 }
 
 int LuaApi::GetInput(lua_State* lua)

--- a/Core/Debugger/LuaApi.h
+++ b/Core/Debugger/LuaApi.h
@@ -21,6 +21,8 @@ public:
 
 	static void LuaPushIntValue(lua_State* lua, string name, int value);
 
+	static string SerializeTable(lua_State* lua);
+
 	static DebugHud* GetHud();
 
 	static int SelectDrawSurface(lua_State* lua);
@@ -74,6 +76,7 @@ public:
 	static int LoadSavestate(lua_State* lua);
 
 	static int IsKeyPressed(lua_State* lua);
+	static int GetPressedKeys(lua_State* lua);
 
 	static int GetInput(lua_State* lua);
 	static int SetInput(lua_State* lua);

--- a/Core/Debugger/LuaCallHelper.cpp
+++ b/Core/Debugger/LuaCallHelper.cpp
@@ -18,8 +18,13 @@ bool LuaCallHelper::CheckParamCount(int minParamCount)
 	if(minParamCount >= 0 && _stackSize < _paramCount && _stackSize >= minParamCount) {
 		return true;
 	}
-	if(_stackSize != _paramCount) {
-		string message = string("too ") + (_stackSize < _paramCount ? "few" : "many") + " parameters.  expected " + std::to_string(_paramCount) + " got " + std::to_string(_stackSize);
+	return CheckSpecificParamCount(_paramCount);
+}
+
+bool LuaCallHelper::CheckSpecificParamCount(int count)
+{
+	if(_stackSize != count) {
+		string message = string("too ") + (_stackSize < count ? "few" : "many") + " parameters.  expected " + std::to_string(count) + " got " + std::to_string(_stackSize);
 		luaL_error(_lua, message.c_str());
 		return false;
 	}

--- a/Core/Debugger/LuaCallHelper.h
+++ b/Core/Debugger/LuaCallHelper.h
@@ -22,6 +22,7 @@ public:
 
 	void ForceParamCount(int paramCount);
 	bool CheckParamCount(int minParamCount = -1);
+	bool CheckSpecificParamCount(int count);
 
 	double ReadDouble();
 	bool ReadBool(bool defaultValue = false);

--- a/Core/Debugger/ScriptingContext.cpp
+++ b/Core/Debugger/ScriptingContext.cpp
@@ -116,7 +116,7 @@ string ScriptingContext::GetErrorMessage()
 		errorMsg = lua_tostring(_lua, -1);
 	} else if(lua_istable(_lua, -1)) {
 		//Serialize tables to Lua-formatted string
-		errorMsg = "error: " + SerializeTable();
+		errorMsg = "error: " + LuaApi::SerializeTable(_lua);
 	} else {
 		//Convert all other values to a string
 		luaL_tolstring(_lua, -1, nullptr);
@@ -124,50 +124,6 @@ string ScriptingContext::GetErrorMessage()
 		lua_pop(_lua, 1);
 	}
 	return errorMsg;
-}
-
-string ScriptingContext::SerializeTable()
-{
-	string result = "{ ";
-	bool firstKey = true;
-	lua_pushnil(_lua);
-	while(lua_next(_lua, -2) != 0) {
-		int keyType = lua_type(_lua, -2);
-		if(keyType == LUA_TSTRING || keyType == LUA_TNUMBER) {
-			if(!firstKey) {
-				result += ", ";
-			}
-			firstKey = false;
-			if(keyType == LUA_TSTRING) {
-				size_t len = 0;
-				const char* cstr = lua_tolstring(_lua, -2, &len);
-				result += string(cstr, len);
-			} else {
-				if(lua_isinteger(_lua, -2)) {
-					lua_Integer integer = lua_tointeger(_lua, -2);
-					result += std::to_string(integer);
-				} else {
-					lua_Number number = lua_tonumber(_lua, -2);
-					result += std::to_string(number);
-				}
-			}
-			result += " = ";
-
-			if(lua_type(_lua, -1) == LUA_TSTRING) {
-				result += "\"";
-				result += lua_tostring(_lua, -1);
-				result += "\"";
-			} else if(lua_istable(_lua, -1)) {
-				result += SerializeTable();
-			} else {
-				luaL_tolstring(_lua, -1, nullptr);
-				result += lua_tostring(_lua, -1);
-				lua_pop(_lua, 1);
-			}
-		}
-		lua_pop(_lua, 1);
-	}
-	return result + " }";
 }
 
 void ScriptingContext::ProcessLuaError()

--- a/Core/Debugger/ScriptingContext.h
+++ b/Core/Debugger/ScriptingContext.h
@@ -53,7 +53,6 @@ private:
 	void LuaOpenLibs(lua_State* L, bool allowIoOsAccess);
 	void ProcessLuaError();
 	string GetErrorMessage();
-	string SerializeTable();
 
 protected:
 	string _scriptName;

--- a/Core/Gameboy/APU/GbApu.cpp
+++ b/Core/Gameboy/APU/GbApu.cpp
@@ -76,7 +76,7 @@ void GbApu::Run()
 	uint64_t clockCount = _gameboy->GetApuCycleCount();
 	uint32_t clocksToRun = (uint32_t)(clockCount - _prevClockCount);
 	_prevClockCount = clockCount;
-	if(!_apuEnabled) {
+	if(!_overclockApuEnabled) {
 		//During overclock scanlines, the APU doesn't run
 		return;
 	}
@@ -529,7 +529,7 @@ void GbApu::Serialize(Serializer& s)
 	SV(_prevClockCount);
 	SV(_skipFirstEventCounter);
 	SV(_powerOnCycle);
-	SV(_apuEnabled);
+	SV(_overclockApuEnabled);
 
 	SV(_square1);
 	SV(_square2);

--- a/Core/Gameboy/APU/GbApu.h
+++ b/Core/Gameboy/APU/GbApu.h
@@ -42,7 +42,7 @@ private:
 
 	uint32_t _skipFirstEventCounter = 0;
 	uint64_t _powerOnCycle = 0;
-	bool _apuEnabled = true;
+	bool _overclockApuEnabled = true;
 
 	GbApuState _state = {};
 
@@ -63,7 +63,7 @@ public:
 	uint64_t GetElapsedApuCycles();
 
 	void Run();
-	void SetEnabled(bool enabled) { _apuEnabled = enabled; }
+	void SetEnabled(bool enabled) { _overclockApuEnabled = enabled; }
 
 	void PlayQueuedAudio();
 

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -237,6 +237,12 @@
 	"returnValue": { "type": "Int", "description": "ARGB color" }
 },
 {
+	"name": "getPressedKeys",
+	"category": "Input",
+	"description": "Returns an array containing the name of all keys/buttons currently pressed.",
+	"returnValue": { "type": "Array", "description": "Array of key/button names (strings)" }
+},
+{
 	"name": "getRomInfo",
 	"category": "Miscellaneous",
 	"subcategory": "Others",
@@ -289,9 +295,9 @@
 {
 	"name": "log",
 	"category": "Logging",
-	"description": "Logs the specified string in the script's log window - useful for debugging scripts.",
+	"description": "Displays the provided data (string, number, table/array) in the script window's log.",
 	"parameters": [
-		{ "name": "text", "type": "String", "description": "Text to log" }
+		{ "name": "data", "type": "Any", "description": "String, number or table/array to log" }
 	]
 },
 {

--- a/Utilities/StringUtilities.h
+++ b/Utilities/StringUtilities.h
@@ -36,10 +36,8 @@ public:
 		size_t endIndex = str.find_last_not_of("\t\r\n ");
 		if(endIndex == string::npos) {
 			return "";
-		} else if(endIndex > 0) {
-			return str.substr(0, endIndex + 1);
 		}
-		return str;
+		return str.substr(0, endIndex + 1);
 	}
 
 	static string Trim(string str)


### PR DESCRIPTION
Also:
-Improved emu.log() to support tables/arrays and numeric values, instead of only strings.
-Fixed TrimRight logic not working properly when the string had a single non-space character followed by spaces (e.g TrimRight("A ") returned "A ")
-Fixed duplicate save state variable key name for GB ("apuEnabled")