### PR TITLE
Linux: Fix executable name in the desktop file

### DIFF
--- a/Linux/appimage/Mesen.desktop
+++ b/Linux/appimage/Mesen.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Icon=Mesen
-Exec=Mesen %f
+Exec=mesen %f
 Terminal=false
 Type=Application
 Categories=Game;Emulator;


### PR DESCRIPTION
The executable's name is all lowercase, so the desktop file fails to execute anything.