### PR TITLE
Debugger: Tilemap viewer - Added option to pick background color

### DIFF
--- a/Core/Debugger/DebugTypes.h
+++ b/Core/Debugger/DebugTypes.h
@@ -171,6 +171,15 @@ enum class TilemapHighlightMode
 	Writes
 };
 
+enum class TilemapBackground
+{
+	Default,
+	Transparent,
+	Black,
+	White,
+	Magenta,
+};
+
 struct GetTilemapOptions
 {
 	uint8_t Layer;
@@ -182,6 +191,7 @@ struct GetTilemapOptions
 	TilemapHighlightMode AttributeHighlightMode;
 
 	TilemapDisplayMode DisplayMode;
+	TilemapBackground Background;
 };
 
 enum class TileFormat

--- a/Core/Debugger/PpuTools.cpp
+++ b/Core/Debugger/PpuTools.cpp
@@ -49,16 +49,28 @@ void PpuTools::GetTileView(GetTileViewOptions options, uint8_t* source, uint32_t
 	}
 }
 
-uint32_t PpuTools::GetBackgroundColor(TileBackground bgColor, const uint32_t* colors, uint8_t paletteIndex, uint8_t bpp)
+uint32_t PpuTools::GetTilemapBackgroundColor(TilemapBackground bgColor, uint32_t defaultColor)
+{
+	switch(bgColor) {
+		default:
+		case TilemapBackground::Default: return defaultColor;
+		case TilemapBackground::Transparent: return 0;
+		case TilemapBackground::Black: return 0xFF000000;
+		case TilemapBackground::White: return 0xFFFFFFFF;
+		case TilemapBackground::Magenta: return 0xFFFF00FF;
+	}
+}
+
+uint32_t PpuTools::GetTileBackgroundColor(TileBackground bgColor, const uint32_t* colors, uint8_t paletteIndex, uint8_t bpp)
 {
 	switch(bgColor) {
 		default:
 		case TileBackground::Default: return colors[0];
+		case TileBackground::Transparent: return 0;
 		case TileBackground::PaletteColor: return colors[paletteIndex * (1 << bpp)];
 		case TileBackground::Black: return 0xFF000000;
 		case TileBackground::White: return 0xFFFFFFFF;
 		case TileBackground::Magenta: return 0xFFFF00FF;
-		case TileBackground::Transparent: return 0;
 	}
 }
 
@@ -68,10 +80,10 @@ uint32_t PpuTools::GetSpriteBackgroundColor(SpriteBackground bgColor, const uint
 		default:
 		case SpriteBackground::Gray: return useDarkerColor ? 0xFF333333 : 0xFF666666;
 		case SpriteBackground::Background: return useDarkerColor ? (((colors[0] >> 1) & 0x7F7F7F) | 0xFF000000) : colors[0];
+		case SpriteBackground::Transparent: return 0;
 		case SpriteBackground::Black: return useDarkerColor ? 0xFF000000 : 0xFF202020;
 		case SpriteBackground::White: return useDarkerColor ? 0xFFEEEEEE : 0xFFFFFFFF;
 		case SpriteBackground::Magenta: return useDarkerColor ? 0xFFCC00CC : 0xFFFF00FF;
-		case SpriteBackground::Transparent: return 0;
 	}
 }
 
@@ -185,7 +197,7 @@ void PpuTools::InternalGetTileView(GetTileViewOptions options, uint8_t* source, 
 		}
 	}
 
-	uint32_t bgColor = GetBackgroundColor(options.Background, colors, options.Palette, bpp);
+	uint32_t bgColor = GetTileBackgroundColor(options.Background, colors, options.Palette, bpp);
 
 	uint32_t outputSize = tileCount * tileWidth * tileHeight;
 	for(uint32_t i = 0; i < outputSize; i++) {

--- a/Core/Debugger/PpuTools.h
+++ b/Core/Debugger/PpuTools.h
@@ -243,7 +243,8 @@ protected:
 
 	bool IsTileHidden(MemoryType memType, uint32_t addr, GetTileViewOptions& options);
 
-	uint32_t GetBackgroundColor(TileBackground bgColor, const uint32_t* colors, uint8_t paletteIndex = 0, uint8_t bpp = 0);
+	uint32_t GetTilemapBackgroundColor(TilemapBackground bgColor, uint32_t defaultColor);
+	uint32_t GetTileBackgroundColor(TileBackground bgColor, const uint32_t* colors, uint8_t paletteIndex = 0, uint8_t bpp = 0);
 	uint32_t GetSpriteBackgroundColor(SpriteBackground bgColor, const uint32_t* colors, bool useDarkerColor);
 
 	void GetSetTilePixel(AddressInfo tileAddress, TileFormat format, int32_t x, int32_t y, int32_t& color, bool forGet);

--- a/Core/GBA/Debugger/GbaPpuTools.cpp
+++ b/Core/GBA/Debugger/GbaPpuTools.cpp
@@ -44,7 +44,8 @@ DebugTilemapInfo GbaPpuTools::GetTilemap(GetTilemapOptions options, BaseState& b
 		colorMask = 0x0F;
 	}
 
-	std::fill(outBuffer, outBuffer + outputSize.Width * outputSize.Height, palette[0]);
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, palette[0]);
+	std::fill(outBuffer, outBuffer + outputSize.Width * outputSize.Height, bgColor);
 
 	DebugTilemapInfo result = {};
 

--- a/Core/Gameboy/Debugger/GbPpuTools.cpp
+++ b/Core/Gameboy/Debugger/GbPpuTools.cpp
@@ -16,8 +16,6 @@ DebugTilemapInfo GbPpuTools::GetTilemap(GetTilemapOptions options, BaseState& ba
 	uint32_t offset = options.Layer == 1 ? 0x1C00 : 0x1800;
 	bool isCgb = state.CgbEnabled;
 
-	std::fill(outBuffer, outBuffer + 256 * 256, 0xFFFFFFFF);
-
 	uint16_t vramMask = isCgb ? 0x3FFF : 0x1FFF;
 
 	uint8_t colorMask = 0xFF;
@@ -25,6 +23,8 @@ DebugTilemapInfo GbPpuTools::GetTilemap(GetTilemapOptions options, BaseState& ba
 		palette = (uint32_t*)_grayscaleColorsBpp2;
 		colorMask = 0x03;
 	}
+
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, palette[0]);
 
 	for(int row = 0; row < 32; row++) {
 		uint16_t baseOffset = offset + ((row & 0x1F) << 5);
@@ -54,8 +54,12 @@ DebugTilemapInfo GbPpuTools::GetTilemap(GetTilemapOptions options, BaseState& ba
 				for(int x = 0; x < 8; x++) {
 					uint8_t pixelIndex = hMirror ? (7 - x) : x;
 					uint8_t color = GetTilePixelColor<TileFormat::Bpp2>(vram, vramMask, pixelStart, pixelIndex);
-
-					outBuffer[((row * 8) + y) * 256 + column * 8 + x] = palette[(bgPalette + color) & colorMask];
+					int outIndex = ((row * 8) + y) * 256 + column * 8 + x;
+					if(color != 0 || options.Background == TilemapBackground::Default) {
+						outBuffer[outIndex] = palette[(bgPalette + color) & colorMask];
+					} else {
+						outBuffer[outIndex] = bgColor;
+					}
 				}
 			}
 		}

--- a/Core/NES/Debugger/NesPpuTools.cpp
+++ b/Core/NES/Debugger/NesPpuTools.cpp
@@ -7,13 +7,10 @@
 #include "NES/NesConstants.h"
 #include "NES/NesTypes.h"
 #include "NES/NesDefaultVideoFilter.h"
-#include "NES/Mappers/Homebrew/Rainbow.h"
 #include "Debugger/DebugTypes.h"
 #include "Debugger/MemoryDumper.h"
 #include "Debugger/MemoryAccessCounter.h"
 #include "Shared/SettingTypes.h"
-
-static constexpr uint32_t grayscalePalette[4] = { 0xFF000000, 0xFF808080, 0xFFC0C0C0, 0xFFFFFFFF };
 
 NesPpuTools::NesPpuTools(Debugger* debugger, Emulator* emu, NesConsole* console) : PpuTools(debugger, emu)
 {
@@ -36,6 +33,7 @@ void NesPpuTools::GetPpuToolsState(BaseState& state)
 void NesPpuTools::DrawNametable(uint8_t* ntSource, uint32_t ntBaseAddr, uint8_t ntIndex, GetTilemapOptions options, NesPpuState& state, IExtModeMapperDebug* exMode, ExtModeConfig& extCfg, uint8_t* vram, uint32_t* palette, uint32_t* outBuffer, uint32_t bufferWidth)
 {
 	uint16_t baseAttributeAddr = ntBaseAddr + 960;
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, options.DisplayMode == TilemapDisplayMode::Grayscale ? _grayscaleColorsBpp2[0] : palette[0]);
 
 	for(uint8_t row = 0; row < 30; row++) {
 		for(uint8_t column = 0; column < 32; column++) {
@@ -74,8 +72,10 @@ void NesPpuTools::DrawNametable(uint8_t* ntSource, uint32_t ntBaseAddr, uint8_t 
 					uint32_t offset = (row * bufferWidth * 8) + (column << 3) + (y * bufferWidth);
 					for(uint8_t x = 0; x < 8; x++) {
 						uint8_t color = ((lowByte >> (7 - x)) & 0x01) | (((highByte >> (7 - x)) & 0x01) << 1);
-						if(options.DisplayMode == TilemapDisplayMode::Grayscale) {
-							outBuffer[offset + x] = grayscalePalette[color];
+						if(color == 0) {
+							outBuffer[offset + x] = bgColor;
+						} else if(options.DisplayMode == TilemapDisplayMode::Grayscale) {
+							outBuffer[offset + x] = _grayscaleColorsBpp2[color];
 						} else {
 							outBuffer[offset + x] = palette[paletteBaseAddr + color];
 						}

--- a/Core/PCE/Debugger/PceVdcTools.cpp
+++ b/Core/PCE/Debugger/PceVdcTools.cpp
@@ -105,6 +105,8 @@ DebugTilemapInfo PceVdcTools::InternalGetTilemap(GetTilemapOptions options, PceV
 		}
 	}
 
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, palette[0]);
+
 	for(uint8_t row = 0; row < state.HvLatch.RowCount; row++) {
 		for(uint8_t column = 0; column < state.HvLatch.ColumnCount; column++) {
 			uint16_t entryAddr = (row * state.HvLatch.ColumnCount + column) * 2;
@@ -116,9 +118,8 @@ DebugTilemapInfo PceVdcTools::InternalGetTilemap(GetTilemapOptions options, PceV
 				uint16_t tileAddr = tileIndex * 32 + y * 2;
 				for(int x = 0; x < 8; x++) {
 					uint8_t color = GetTilePixelColor<format>(vram, 0xFFFF, tileAddr, x);
-					uint16_t palAddr = color == 0 ? 0 : (palIndex * 16 + color);
 					uint32_t outPos = (row * 8 + y) * state.HvLatch.ColumnCount * 8 + column * 8 + x;
-					outBuffer[outPos] = palette[palAddr & colorMask];
+					outBuffer[outPos] = color == 0 ? bgColor : palette[(palIndex * 16 + color) & colorMask];
 				}
 			}
 		}

--- a/Core/SMS/Debugger/SmsVdpTools.cpp
+++ b/Core/SMS/Debugger/SmsVdpTools.cpp
@@ -81,6 +81,8 @@ DebugTilemapInfo SmsVdpTools::GetTilemap(GetTilemapOptions options, BaseState& b
 	}
 
 	if(state.UseMode4) {
+		uint32_t bgColor = GetTilemapBackgroundColor(options.Background, palette[0]);
+
 		result.ScrollX = 256 - state.HorizontalScroll + (isGameGear ? 48 : 0);
 		result.ScrollY = state.VerticalScroll + (isGameGear ? 24 : 0);
 		result.TilemapAddress = state.EffectiveNametableAddress;
@@ -102,9 +104,8 @@ DebugTilemapInfo SmsVdpTools::GetTilemap(GetTilemapOptions options, BaseState& b
 						uint8_t tileColumn = hMirror ? 7 - (x & 0x07) : (x & 0x07);
 
 						uint8_t color = GetTilePixelColor<TileFormat::SmsBpp4>(vram, 0x3FFF, tileAddr, tileColumn);
-						uint16_t palAddr = color == 0 ? 0 : (paletteOffset + color);
 						uint32_t outPos = (row * 8 + y) * 32 * 8 + column * 8 + x;
-						outBuffer[outPos] = palette[palAddr & colorMask];
+						outBuffer[outPos] = color == 0 ? bgColor : palette[(paletteOffset + color) & colorMask];
 					}
 				}
 			}

--- a/Core/SNES/Debugger/SnesPpuTools.cpp
+++ b/Core/SNES/Debugger/SnesPpuTools.cpp
@@ -5,7 +5,6 @@
 #include "Shared/SettingTypes.h"
 #include "SNES/SnesPpu.h"
 #include "Shared/ColorUtilities.h"
-#include "Shared/MessageManager.h"
 
 static constexpr uint8_t layerBpp[8][4] = {
 	{ 2, 2, 2, 2 },
@@ -66,7 +65,8 @@ DebugTilemapInfo SnesPpuTools::GetTilemap(GetTilemapOptions options, BaseState& 
 
 	LayerConfig layer = state.Layers[options.Layer];
 
-	std::fill(outBuffer, outBuffer + outputSize.Width * outputSize.Height, palette[0]);
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, options.DisplayMode == TilemapDisplayMode::Grayscale ? _grayscaleColorsBpp4[0] : palette[0]);
+	std::fill(outBuffer, outBuffer + outputSize.Width * outputSize.Height, bgColor);
 
 	uint8_t bpp = layerBpp[state.BgMode][options.Layer];
 	if(bpp == 0) {

--- a/Core/WS/Debugger/WsPpuTools.cpp
+++ b/Core/WS/Debugger/WsPpuTools.cpp
@@ -17,14 +17,22 @@ FrameInfo WsPpuTools::GetTilemapSize(GetTilemapOptions options, BaseState& baseS
 	return { 256, 256 };
 }
 
+uint32_t WsPpuTools::GetBgColor(WsPpuState& state, uint8_t* vram)
+{
+	if(state.Mode == WsVideoMode::Monochrome) {
+		uint8_t bgBrightness = state.BwShades[state.BgColor & 0x07] ^ 0x0F;
+		return ColorUtilities::Bgr444ToArgb(bgBrightness | (bgBrightness << 4) | (bgBrightness << 8));
+	} else {
+		return ColorUtilities::Bgr444ToArgb(vram[0xFE00 | (state.BgColor << 1)] | ((vram[0xFE00 | (state.BgColor << 1) | 1] & 0x0F) << 8));
+	}
+}
+
 DebugTilemapInfo WsPpuTools::GetTilemap(GetTilemapOptions options, BaseState& baseState, BaseState& ppuToolsState, uint8_t* vram, uint32_t* palette, uint32_t* outBuffer)
 {
 	WsPpuState& state = (WsPpuState&)baseState;
 
 	uint16_t ramMask = state.Mode == WsVideoMode::Monochrome ? 0x3FFF : 0xFFFF;
 	uint16_t baseAddr = state.BgLayers[options.Layer].MapAddress;
-
-	std::fill(outBuffer, outBuffer + 256 * 256, 0xFFFFFFFF);
 
 	int tileSize = state.Mode >= WsVideoMode::Color4bpp ? 32 : 16;
 	int bpp = state.Mode >= WsVideoMode::Color4bpp ? 4 : 2;
@@ -37,6 +45,9 @@ DebugTilemapInfo WsPpuTools::GetTilemap(GetTilemapOptions options, BaseState& ba
 		palette = (uint32_t*)_grayscaleColorsBpp2;
 		colorMask = 0x03;
 	}
+
+	uint32_t bgColor = GetTilemapBackgroundColor(options.Background, GetBgColor(state, vram));
+	std::fill(outBuffer, outBuffer + 256 * 256, bgColor);
 
 	for(int row = 0; row < 32; row++) {
 		uint16_t baseOffset = baseAddr + row * 64;
@@ -349,7 +360,7 @@ DebugPaletteInfo WsPpuTools::GetPaletteInfo(GetPaletteInfoOptions options)
 		for(int i = 0; i < 64; i++) {
 			info.RawPalette[i] = state.BwPalettes[i];
 			uint8_t brightness = state.BwShades[state.BwPalettes[i]] ^ 0x0F;
-			info.RgbPalette[i] = ColorUtilities::Rgb444ToArgb(brightness | (brightness << 4) | (brightness << 8));
+			info.RgbPalette[i] = ColorUtilities::Bgr444ToArgb(brightness | (brightness << 4) | (brightness << 8));
 		}
 	} else {
 		info.ColorCount = 256;
@@ -364,7 +375,7 @@ DebugPaletteInfo WsPpuTools::GetPaletteInfo(GetPaletteInfoOptions options)
 
 		uint8_t* palette = _debugger->GetMemoryDumper()->GetMemoryBuffer(MemoryType::WsWorkRam);
 
-		info.RawFormat = RawPaletteFormat::Rgb444;
+		info.RawFormat = RawPaletteFormat::Bgr444;
 		for(int i = 0; i < 256; i++) {
 			int addr = 0xFE00 + i * 2;
 			info.RawPalette[i] = palette[addr] | ((palette[addr + 1] & 0x0F) << 8);

--- a/Core/WS/Debugger/WsPpuTools.h
+++ b/Core/WS/Debugger/WsPpuTools.h
@@ -15,6 +15,8 @@ private:
 	void GetSpriteInfo(DebugSpriteInfo& sprite, uint32_t* spritePreview, uint16_t spriteIndex, GetSpritePreviewOptions& options, WsPpuState& state, uint8_t* vram, uint8_t* oamRam, uint32_t* palette);
 	void GetSpritePreview(GetSpritePreviewOptions options, BaseState& state, DebugSpriteInfo* sprites, uint32_t* spritePreviews, uint32_t* palette, uint32_t* outBuffer);
 
+	uint32_t GetBgColor(WsPpuState& state, uint8_t* vram);
+
 public:
 	WsPpuTools(Debugger* debugger, Emulator* emu, WsConsole* console);
 

--- a/UI/Config/Debugger/TilemapViewerConfig.cs
+++ b/UI/Config/Debugger/TilemapViewerConfig.cs
@@ -1,5 +1,5 @@
-﻿using Mesen.Interop;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Mesen.Interop;
 
 namespace Mesen.Config
 {
@@ -19,6 +19,7 @@ namespace Mesen.Config
 		[ObservableProperty] public partial TilemapHighlightMode TileHighlightMode { get; set; } = TilemapHighlightMode.None;
 		[ObservableProperty] public partial TilemapHighlightMode AttributeHighlightMode { get; set; } = TilemapHighlightMode.None;
 		[ObservableProperty] public partial TilemapDisplayMode DisplayMode { get; set; } = TilemapDisplayMode.Default;
+		[ObservableProperty] public partial TilemapBackground Background { get; set; } = TilemapBackground.Default;
 
 		[ObservableProperty] public partial RefreshTimingConfig RefreshTiming { get; set; } = new();
 

--- a/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
@@ -443,7 +443,8 @@ namespace Mesen.Debugger.ViewModels
 				AccessCounters = accessCounters,
 				TileHighlightMode = Config.TileHighlightMode,
 				AttributeHighlightMode = Config.AttributeHighlightMode,
-				DisplayMode = Config.DisplayMode
+				DisplayMode = Config.DisplayMode,
+				Background = Config.Background
 			};
 		}
 

--- a/UI/Debugger/Windows/TilemapViewerWindow.axaml
+++ b/UI/Debugger/Windows/TilemapViewerWindow.axaml
@@ -49,14 +49,17 @@
 
 		<ScrollViewer DockPanel.Dock="Right" IsVisible="{Binding Config.ShowSettingsPanel}">
 			<StackPanel Margin="3">
-				<StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" IsVisible="{Binding IsTilemapInfoVisible}">
+				<Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,Auto" IsVisible="{Binding IsTilemapInfoVisible}">
 					<TextBlock Text="{l:Translate lblDisplayMode}" />
 					<c:EnumComboBox
 						SelectedItem="{Binding Config.DisplayMode}"
 						AvailableValues="{Binding AvailableDisplayModes}"
 						Width="100"
+						Grid.Column="1"
 					/>
-				</StackPanel>
+					<TextBlock Text="{l:Translate lblBackground}" Grid.Row="1" />
+					<c:EnumComboBox SelectedItem="{Binding Config.Background}" Width="100" Grid.Column="1" Grid.Row="1" />
+				</Grid>
 				<CheckBox Content="{l:Translate chkShowGrid}" IsChecked="{Binding Config.ShowGrid}" />
 				<CheckBox Content="{l:Translate chkNesShowAttributeGrid}" IsChecked="{Binding Config.NesShowAttributeGrid}" IsVisible="{Binding IsNes}" />
 				<CheckBox Content="{l:Translate chkNesShowAttributeByteGrid}" IsChecked="{Binding Config.NesShowAttributeByteGrid}" IsVisible="{Binding IsNes}" />

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -1050,6 +1050,15 @@ namespace Mesen.Interop
 		[MarshalAs(UnmanagedType.I1)] public bool ShowPreviousFrameEvents;
 	}
 
+	public enum TilemapBackground
+	{
+		Default,
+		Transparent,
+		Black,
+		White,
+		Magenta
+	}
+
 	public enum TilemapDisplayMode
 	{
 		Default,
@@ -1075,6 +1084,7 @@ namespace Mesen.Interop
 		public TilemapHighlightMode AttributeHighlightMode;
 
 		public TilemapDisplayMode DisplayMode;
+		public TilemapBackground Background;
 
 		public InteropGetTilemapOptions ToInterop()
 		{
@@ -1083,7 +1093,8 @@ namespace Mesen.Interop
 				MasterClock = MasterClock,
 				TileHighlightMode = TileHighlightMode,
 				AttributeHighlightMode = AttributeHighlightMode,
-				DisplayMode = DisplayMode
+				DisplayMode = DisplayMode,
+				Background = Background
 			};
 		}
 	}
@@ -1099,6 +1110,7 @@ namespace Mesen.Interop
 		public TilemapHighlightMode AttributeHighlightMode;
 
 		public TilemapDisplayMode DisplayMode;
+		public TilemapBackground Background;
 	}
 
 	public enum TileBackground

--- a/UI/Localization/resources.en.xml
+++ b/UI/Localization/resources.en.xml
@@ -1078,6 +1078,7 @@
 
 			<Control ID="btnToggleSettings">Toggle settings panel</Control>
 
+			<Control ID="lblBackground">Background: </Control>
 			<Control ID="lblDisplayMode">Display mode: </Control>
 			<Control ID="lblSelectedTile">Selected Tile</Control>
 			<Control ID="lblTilemap">Tilemap</Control>
@@ -2968,6 +2969,13 @@ E
 			<Value ID="None">None</Value>
 			<Value ID="HideUsed">Hide used tiles</Value>
 			<Value ID="HideUnused">Hide unused tiles</Value>
+		</Enum>
+		<Enum ID="TilemapBackground">
+			<Value ID="Default">Default</Value>
+			<Value ID="Transparent">Transparent</Value>
+			<Value ID="Black">Black</Value>
+			<Value ID="White">White</Value>
+			<Value ID="Magenta">Magenta</Value>
 		</Enum>
 		<Enum ID="TileBackground">
 			<Value ID="Default">Default (Color 0)</Value>


### PR DESCRIPTION
Also, minor bug fixes for WS:
-Fixed tilemap viewer sometimes using the wrong background color
-Fixed the 4-bit RGB color values in the palette viewer having the R and B values swapped