### PR TITLE
Debugger: Added "copy to clipboard" option for tilemap, tile, sprite and event viewer

### DIFF
--- a/UI/Debugger/Controls/PictureViewer.cs
+++ b/UI/Debugger/Controls/PictureViewer.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -11,7 +12,9 @@ using Avalonia.Platform;
 using Avalonia.Rendering.SceneGraph;
 using Avalonia.Skia;
 using Avalonia.Threading;
+using Mesen.Interop;
 using Mesen.Utilities;
+using Mesen.ViewModels;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
@@ -271,10 +274,25 @@ namespace Mesen.Debugger.Controls
 		public async void ExportToPng()
 		{
 			if(Source is Bitmap bitmap) {
-				string? filename = await FileDialogHelper.SaveFile(null, null, this.GetWindow(), FileDialogHelper.PngExt);
+				Window? wnd = this.GetWindow();
+
+				string initialFilename = EmuApi.GetRomInfo().GetRomName();
+				if(wnd != null) {
+					initialFilename += " - " + wnd.Title;
+				}
+				initialFilename += "." + FileDialogHelper.PngExt;
+
+				string? filename = await FileDialogHelper.SaveFile(null, initialFilename, wnd, FileDialogHelper.PngExt);
 				if(filename != null) {
 					bitmap.Save(filename);
 				}
+			}
+		}
+
+		public async void CopyToClipboard()
+		{
+			if(Source is Bitmap bitmap) {
+				this.GetWindow()?.Clipboard?.SetBitmapAsync(bitmap);
 			}
 		}
 

--- a/UI/Debugger/ViewModels/EventViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/EventViewerViewModel.cs
@@ -72,6 +72,17 @@ namespace Mesen.Debugger.ViewModels
 
 			FileMenuItems = AddDisposables(new List<object>() {
 				new ContextMenuAction() {
+					ActionType = ActionType.ExportToPng,
+					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.SaveAsPng),
+					OnClick = () => _picViewer.ExportToPng()
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
+					OnClick = () => _picViewer.CopyToClipboard()
+				},
+				new ContextMenuSeparator(),
+				new ContextMenuAction() {
 					ActionType = ActionType.Exit,
 					OnClick = () => wnd?.Close()
 				}

--- a/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/SpriteViewerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -93,6 +94,11 @@ namespace Mesen.Debugger.ViewModels
 					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.SaveAsPng),
 					OnClick = () => picViewer.ExportToPng()
 				},
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
+					OnClick = () => picViewer.CopyToClipboard()
+				},
 				new ContextMenuSeparator(),
 				new ContextMenuAction() {
 					ActionType = ActionType.Exit,
@@ -147,6 +153,8 @@ namespace Mesen.Debugger.ViewModels
 			}
 
 			AddDisposables(DebugShortcutManager.CreateContextMenu(picViewer, scrollViewer, new List<object> {
+				GetCopyTileAction(wnd),
+				new ContextMenuSeparator(),
 				GetEditTileAction(wnd),
 				GetViewInMemoryViewerAction(),
 				GetViewInTileViewerAction(),
@@ -155,6 +163,8 @@ namespace Mesen.Debugger.ViewModels
 			}));
 
 			AddDisposables(DebugShortcutManager.CreateContextMenu(_spriteGrid, new List<object> {
+				GetCopyTileAction(wnd),
+				new ContextMenuSeparator(),
 				GetEditTileAction(wnd),
 				GetViewInMemoryViewerAction(),
 				GetViewInTileViewerAction(),
@@ -163,6 +173,8 @@ namespace Mesen.Debugger.ViewModels
 			}));
 
 			AddDisposables(DebugShortcutManager.CreateContextMenu(listView, new List<object> {
+				GetCopyTileAction(wnd),
+				new ContextMenuSeparator(),
 				GetEditTileAction(wnd),
 				GetViewInMemoryViewerAction(),
 				GetViewInTileViewerAction(),
@@ -190,6 +202,20 @@ namespace Mesen.Debugger.ViewModels
 		partial void OnSpritePreviewsChanged(List<SpritePreviewModel> value)
 		{
 			ListView.RefreshList(true);
+		}
+
+		private ContextMenuAction GetCopyTileAction(Window wnd)
+		{
+			return new ContextMenuAction() {
+				ActionType = ActionType.CopyToClipboard,
+				IsEnabled = () => GetSelectedSprite() != null,
+				OnClick = () => {
+					SpritePreviewModel? sprite = GetSelectedSprite();
+					if(sprite != null) {
+						wnd.Clipboard?.SetBitmapAsync(sprite.SpritePreview);
+					}
+				}
+			};
 		}
 
 		private ContextMenuAction GetEditTileAction(Window wnd)

--- a/UI/Debugger/ViewModels/TileEditorViewModel.cs
+++ b/UI/Debugger/ViewModels/TileEditorViewModel.cs
@@ -94,6 +94,11 @@ public partial class TileEditorViewModel : DisposableViewModel
 				Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.SaveAsPng),
 				OnClick = () => picViewer.ExportToPng()
 			},
+			new ContextMenuAction() {
+				ActionType = ActionType.CopyToClipboard,
+				Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
+				OnClick = () => picViewer.CopyToClipboard()
+			},
 			new ContextMenuSeparator(),
 			new ContextMenuAction() {
 				ActionType = ActionType.Exit,

--- a/UI/Debugger/ViewModels/TileViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TileViewerViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Threading;
@@ -72,6 +73,7 @@ namespace Mesen.Debugger.ViewModels
 		private bool _refreshPending;
 		private bool _inGameLoaded;
 		private bool _preventPresetLoad;
+		private PixelRect _previewCropRect;
 
 		[Obsolete("For designer only")]
 		public TileViewerViewModel() : this(CpuType.Snes, new(), new(), null) { }
@@ -93,6 +95,11 @@ namespace Mesen.Debugger.ViewModels
 					ActionType = ActionType.ExportToPng,
 					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.SaveAsPng),
 					OnClick = () => picViewer.ExportToPng()
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
+					OnClick = () => picViewer.CopyToClipboard()
 				},
 				new ContextMenuSeparator(),
 				new ContextMenuAction() {
@@ -139,6 +146,11 @@ namespace Mesen.Debugger.ViewModels
 			});
 
 			AddDisposables(DebugShortcutManager.CreateContextMenu(picViewer, scrollViewer, new List<object> {
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					OnClick = () => wnd.Clipboard?.SetBitmapAsync(ViewerBitmap.CropBitmap(_previewCropRect))
+				},
+				new ContextMenuSeparator(),
 				new ContextMenuAction() {
 					ActionType = ActionType.EditTile,
 					HintText = () => $"{GridSizeX}px x {GridSizeY}px",
@@ -550,6 +562,7 @@ namespace Mesen.Debugger.ViewModels
 
 			PixelSize tileSize = Config.Format.GetTileSize();
 			PixelRect cropRect = new PixelRect(p.X / tileSize.Width * tileSize.Width, p.Y / tileSize.Height * tileSize.Height, tileSize.Width, tileSize.Height);
+			_previewCropRect = cropRect;
 			entries.AddPicture("Tile", ViewerBitmap, 6, cropRect);
 
 			int address = GetTileAddress(cropRect.TopLeft);

--- a/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
+++ b/UI/Debugger/ViewModels/TilemapViewerViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -62,6 +63,7 @@ namespace Mesen.Debugger.ViewModels
 		private bool _refreshDataOnTabChange;
 		private bool _inGameLoaded;
 		private bool _refreshPending;
+		private PixelRect _previewCropRect;
 
 		[Obsolete("For designer only")]
 		public TilemapViewerViewModel() : this(CpuType.Snes, new(), new(), null) { }
@@ -83,6 +85,11 @@ namespace Mesen.Debugger.ViewModels
 					ActionType = ActionType.ExportToPng,
 					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.SaveAsPng),
 					OnClick = () => _picViewer.ExportToPng()
+				},
+				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.Copy),
+					OnClick = () => _picViewer.CopyToClipboard()
 				},
 				new ContextMenuSeparator(),
 				new ContextMenuAction() {
@@ -159,6 +166,11 @@ namespace Mesen.Debugger.ViewModels
 				},
 				new ContextMenuSeparator(),
 				new ContextMenuAction() {
+					ActionType = ActionType.CopyToClipboard,
+					OnClick = () => wnd.Clipboard?.SetBitmapAsync(ViewerBitmap.CropBitmap(_previewCropRect))
+				},
+				new ContextMenuSeparator(),
+				new ContextMenuAction() {
 					ActionType = ActionType.EditTile,
 					Shortcut = () => ConfigManager.Config.Debug.Shortcuts.Get(DebuggerShortcut.TilemapViewer_EditTile),
 					OnClick = () => EditTileGrid(1, 1, wnd)
@@ -203,10 +215,10 @@ namespace Mesen.Debugger.ViewModels
 						}
 					}
 				},
-				new ContextMenuSeparator() { IsVisible = () => CpuType == CpuType.Nes },
+				new ContextMenuSeparator() { IsVisible = () => IsNes },
 				new ContextMenuAction() {
 					ActionType = ActionType.CopyToHdPackFormat,
-					IsVisible = () => CpuType == CpuType.Nes,
+					IsVisible = () => IsNes,
 					IsEnabled = () => HdPackCopyHelper.IsActionAllowed(GetVramMemoryType()),
 					OnClick = () => {
 						DebugTilemapTileInfo? tile = GetSelectedTileInfo();
@@ -217,6 +229,7 @@ namespace Mesen.Debugger.ViewModels
 				}
 			}));
 
+			picViewer.ContextMenu?.Opening += ContextMenu_Opening;
 
 			AddDisposable(this.ObserveProp(nameof(Tabs), () => ShowTabs = Tabs.Count > 1));
 			AddDisposable(this.ObserveProp(nameof(SelectionRect), () => UpdatePreviewPanel()));
@@ -240,6 +253,13 @@ namespace Mesen.Debugger.ViewModels
 
 			DebugShortcutManager.RegisterActions(wnd, FileMenuActions);
 			DebugShortcutManager.RegisterActions(wnd, ViewMenuActions);
+		}
+
+		private void ContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e)
+		{
+			if(GetSelectedTileInfo() == null) {
+				e.Cancel = true;
+			}
 		}
 
 		private void InitNesGridOptions()
@@ -610,6 +630,8 @@ namespace Mesen.Debugger.ViewModels
 
 			TooltipEntries entries = tooltipToUpdate?.Items ?? new();
 			PixelRect cropRect = new PixelRect(p.X / tileInfo.Width * tileInfo.Width, p.Y / tileInfo.Height * tileInfo.Height, tileInfo.Width, tileInfo.Height);
+
+			_previewCropRect = cropRect;
 
 			entries.StartUpdate();
 

--- a/UI/Utilities/BitmapExtensions.cs
+++ b/UI/Utilities/BitmapExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+
+namespace Mesen.Utilities;
+
+static class BitmapExtensions
+{
+	public static Bitmap CropBitmap(this Bitmap src, PixelRect rect)
+	{
+		PixelSize size = new PixelSize(rect.Width, rect.Height);
+		WriteableBitmap bmp = new WriteableBitmap(size, src.Dpi, src.Format, src.AlphaFormat);
+		using(ILockedFramebuffer dst = bmp.Lock()) {
+			src.CopyPixels(rect, dst.Address, dst.RowBytes * dst.Size.Height, dst.RowBytes);
+		}
+		return bmp;
+	}
+
+}


### PR DESCRIPTION
Also:
-Disabled context menu in the tilemap viewer when in "custom" tabs that don't actually display tiles (e.g the mem access tab on GBA, or the main/sub tabs on SNES, etc.)
-Set a default initial filename for "export to png"