### PR TITLE
Clang: Fixed all compilation warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [
-          {netversion: 8.x, targetframework: net8.0, aot: false, singleFile: true}
+          {netversion: 10.x, targetframework: net10.0, aot: false, singleFile: true}
         ]
       fail-fast: false
     runs-on: windows-2025-vs2026

--- a/Core/Gameboy/GbDmaController.cpp
+++ b/Core/Gameboy/GbDmaController.cpp
@@ -173,7 +173,7 @@ void GbDmaController::ProcessHdma()
 
 void GbDmaController::ProcessDmaBlock()
 {
-	bool isInvalidSource = _state.CgbDmaSource >= 0x8000 && _state.CgbDmaSource <= 0x9FFF || _state.CgbDmaSource >= 0xE000;
+	bool isInvalidSource = (_state.CgbDmaSource >= 0x8000 && _state.CgbDmaSource <= 0x9FFF) || _state.CgbDmaSource >= 0xE000;
 	for(int i = 0; i < 16; i++) {
 		uint16_t dst = 0x8000 | ((_state.CgbDmaDest + i) & 0x1FFF);
 

--- a/Core/NES/Mappers/Audio/Mmc5Audio.h
+++ b/Core/NES/Mappers/Audio/Mmc5Audio.h
@@ -46,7 +46,7 @@ public:
 	}
 };
 
-class Mmc5Audio : public ISerializable
+class Mmc5Audio final : public ISerializable
 {
 private:
 	NesConsole* _console = nullptr;

--- a/Core/NES/Mappers/Audio/Namco163Audio.h
+++ b/Core/NES/Mappers/Audio/Namco163Audio.h
@@ -4,7 +4,7 @@
 #include "NES/APU/NesApu.h"
 #include "Utilities/Serializer.h"
 
-class Namco163Audio : public ISerializable
+class Namco163Audio final : public ISerializable
 {
 public:
 	static constexpr uint32_t AudioRamSize = 0x80;

--- a/Core/NES/Mappers/Audio/Sunsoft5bAudio.h
+++ b/Core/NES/Mappers/Audio/Sunsoft5bAudio.h
@@ -4,7 +4,7 @@
 #include "NES/APU/NesApu.h"
 #include "Utilities/Serializer.h"
 
-class Sunsoft5bAudio : public ISerializable
+class Sunsoft5bAudio final : public ISerializable
 {
 private:
 	NesConsole* _console = nullptr;

--- a/Core/NES/Mappers/Audio/Vrc6Audio.h
+++ b/Core/NES/Mappers/Audio/Vrc6Audio.h
@@ -5,7 +5,7 @@
 #include "NES/NesConsole.h"
 #include "Utilities/Serializer.h"
 
-class Vrc6Audio : public ISerializable
+class Vrc6Audio final : public ISerializable
 {
 private:
 	NesConsole* _console = nullptr;

--- a/Core/NES/Mappers/Audio/Vrc7Audio.h
+++ b/Core/NES/Mappers/Audio/Vrc7Audio.h
@@ -6,7 +6,7 @@
 #include "Shared/Utilities/Emu2413Serializer.h"
 #include "Utilities/Serializer.h"
 
-class Vrc7Audio : public ISerializable
+class Vrc7Audio final : public ISerializable
 {
 private:
 	static constexpr int OpllSampleRate = 49716;

--- a/Core/NES/Mappers/FDS/FdsAudio.h
+++ b/Core/NES/Mappers/FDS/FdsAudio.h
@@ -8,7 +8,7 @@
 class NesConsole;
 struct MapperStateEntry;
 
-class FdsAudio : public ISerializable
+class FdsAudio final : public ISerializable
 {
 private:
 	const uint32_t WaveVolumeTable[4] = { 36, 24, 17, 14 };

--- a/Core/NES/Mappers/Homebrew/RainbowAudio.h
+++ b/Core/NES/Mappers/Homebrew/RainbowAudio.h
@@ -5,7 +5,7 @@
 #include "NES/NesConsole.h"
 #include "Utilities/Serializer.h"
 
-class RainbowAudio : public ISerializable
+class RainbowAudio final : public ISerializable
 {
 private:
 	NesConsole* _console = nullptr;

--- a/Core/NES/Mappers/Homebrew/UnlDripGameAudio.h
+++ b/Core/NES/Mappers/Homebrew/UnlDripGameAudio.h
@@ -3,7 +3,7 @@
 #include "NES/APU/NesApu.h"
 #include "NES/NesConsole.h"
 
-class UnlDripGameAudio : public ISerializable
+class UnlDripGameAudio final : public ISerializable
 {
 private:
 	NesConsole* _console = nullptr;

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -731,7 +731,7 @@ template<class T> void NesPpu<T>::LoadSprite(uint8_t spriteY, uint8_t tileIndex,
 
 	//This function is only called on rendering scanlines (0-239) or pre-render (-1). We need to handle the pre-render scanline numbers manually.
 	//These are deliberately truncated to 8 bits to match hardware behavior.
-	const uint8_t scanline8Bit = _scanline >= 0 ? _scanline : (_region == ConsoleRegion::Ntsc ? 261 : 311);
+	const uint8_t scanline8Bit = (uint8_t)(_scanline >= 0 ? _scanline : (_region == ConsoleRegion::Ntsc ? 261 : 311));
 	uint16_t rangeResult = scanline8Bit - spriteY;
 	if(verticalMirror) {
 		rangeResult ^= spriteSizeMask;

--- a/Core/SNES/Coprocessors/SGB/SuperGameboy.h
+++ b/Core/SNES/Coprocessors/SGB/SuperGameboy.h
@@ -23,7 +23,6 @@ private:
 	BaseCartridge* _cart = nullptr;
 	Spc* _spc = nullptr;
 	Gameboy* _gameboy = nullptr;
-	GbPpu* _ppu = nullptr;
 
 	uint8_t _control = 0;
 	uint64_t _resetClock = 0;

--- a/Core/SNES/Debugger/DummySnesCpu.cpp
+++ b/Core/SNES/Debugger/DummySnesCpu.cpp
@@ -10,6 +10,7 @@
 DummySnesCpu::DummySnesCpu(SnesConsole* console, CpuType type)
 {
 	_console = console;
+	_emu = nullptr;
 	_memoryMappings = type == CpuType::Snes ? console->GetMemoryManager()->GetMemoryMappings() : console->GetCartridge()->GetSa1()->GetMemoryMappings();
 	_dmaController = nullptr;
 	_memoryManager = nullptr;

--- a/Core/SNES/SnesCpu.Shared.h
+++ b/Core/SNES/SnesCpu.Shared.h
@@ -387,7 +387,7 @@ uint8_t SnesCpu::GetOpCode()
 
 void SnesCpu::IdleOrRead()
 {
-	if(!_state.IrqLock && ((_state.IrqSource != 0 || _state.PrevIrqSource != 0) && !CheckFlag(ProcFlags::IrqDisable)) || (_state.NmiFlagCounter == 1 || _state.NeedNmi)) {
+	if(!_state.IrqLock && (((_state.IrqSource != 0 || _state.PrevIrqSource != 0) && !CheckFlag(ProcFlags::IrqDisable)) || _state.NmiFlagCounter == 1 || _state.NeedNmi)) {
 		//If an IRQ or NMI will be triggered on the next instruction/cycle, the 6-clock idle cycle turns into a dummy read at the current PC
 		ReadCode(_state.PC);
 	} else {

--- a/Core/SNES/SnesCpu.cpp
+++ b/Core/SNES/SnesCpu.cpp
@@ -9,7 +9,6 @@
 #include "SNES/SnesDmaController.h"
 #include "SNES/SnesCpu.Instructions.h"
 #include "SNES/SnesCpu.Shared.h"
-#include "Shared/EventType.h"
 #include "Shared/MemoryOperationType.h"
 
 #ifndef DUMMYCPU

--- a/Core/SNES/SnesDefaultVideoFilter.h
+++ b/Core/SNES/SnesDefaultVideoFilter.h
@@ -8,13 +8,11 @@ class SnesDefaultVideoFilter : public BaseVideoFilter
 {
 private:
 	uint32_t _calculatedPalette[0x8000] = {};
-	uint16_t* _prevFrame = nullptr;
 	VideoConfig _videoConfig = {};
 
 	SnesHighResBlendMode _highResBlendMode = SnesHighResBlendMode::None;
 	SnesColorCorrectionMode _colorCorrection = SnesColorCorrectionMode::None;
 	bool _forceFixedRes = false;
-	bool _needFrameClear = false;
 
 	void InitLookupTable();
 

--- a/Core/SNES/SnesPpu.cpp
+++ b/Core/SNES/SnesPpu.cpp
@@ -1552,8 +1552,8 @@ bool SnesPpu::ProcessMaskWindow(uint8_t activeWindowCount, int x)
 		case 2:
 			switch(_state.MaskLogic[layerIndex]) {
 				default:
-				case WindowMaskLogic::Or: return _state.Window[0].PixelNeedsMasking<layerIndex>(x) | _state.Window[1].PixelNeedsMasking<layerIndex>(x);
-				case WindowMaskLogic::And: return _state.Window[0].PixelNeedsMasking<layerIndex>(x) & _state.Window[1].PixelNeedsMasking<layerIndex>(x);
+				case WindowMaskLogic::Or: return _state.Window[0].PixelNeedsMasking<layerIndex>(x) || _state.Window[1].PixelNeedsMasking<layerIndex>(x);
+				case WindowMaskLogic::And: return _state.Window[0].PixelNeedsMasking<layerIndex>(x) && _state.Window[1].PixelNeedsMasking<layerIndex>(x);
 				case WindowMaskLogic::Xor: return _state.Window[0].PixelNeedsMasking<layerIndex>(x) ^ _state.Window[1].PixelNeedsMasking<layerIndex>(x);
 				case WindowMaskLogic::Xnor: return !(_state.Window[0].PixelNeedsMasking<layerIndex>(x) ^ _state.Window[1].PixelNeedsMasking<layerIndex>(x));
 			}

--- a/Core/Shared/Utilities/AvMergeUtilities.h
+++ b/Core/Shared/Utilities/AvMergeUtilities.h
@@ -1,19 +1,20 @@
 #include "Shared/RenderedFrame.h"
 
+template<class T>
 struct VideoMergeResult
 {
 	RenderedFrame Frame;
 
 	~VideoMergeResult()
 	{
-		delete[] Frame.FrameBuffer;
+		delete[]((T*)Frame.FrameBuffer);
 	}
 };
 
 class AvMergeUtilities
 {
 public:
-	template<class T> static VideoMergeResult MergeFrames(RenderedFrame& leftFrame, T* rightFrame)
+	template<class T> static VideoMergeResult<T> MergeFrames(RenderedFrame& leftFrame, T* rightFrame)
 	{
 		//Merge both video frames into a single frame with twice the width
 		uint32_t originalWidth = leftFrame.Width;
@@ -36,7 +37,7 @@ public:
 			in2 += originalWidth;
 		}
 
-		return VideoMergeResult { mergedFrame };
+		return VideoMergeResult<T> { mergedFrame };
 	}
 
 	static void MergeAudio(int16_t* inOutA, size_t& sampleCountA, int16_t* inB, size_t& sampleCountB)

--- a/Core/WS/WsDefaultVideoFilter.h
+++ b/Core/WS/WsDefaultVideoFilter.h
@@ -14,8 +14,6 @@ private:
 	uint32_t _calculatedPalette[0x1000] = {};
 	VideoConfig _videoConfig = {};
 
-	FrameInfo _prevFrameSize = {};
-	uint16_t* _prevFrame = nullptr;
 	bool _adjustColors = false;
 
 	bool _applyNtscFilter = false;

--- a/InteropDLL/EmuApiWrapper.cpp
+++ b/InteropDLL/EmuApiWrapper.cpp
@@ -47,7 +47,7 @@ bool _softwareRenderer = false;
 static void* _windowHandle = nullptr;
 static void* _viewerHandle = nullptr;
 
-static constexpr char* _buildDateTime = __DATE__ ", " __TIME__;
+static constexpr const char* _buildDateTime = __DATE__ ", " __TIME__;
 
 static InteropNotificationListeners _listeners;
 
@@ -74,7 +74,7 @@ extern "C"
 		return _emu->GetSettings()->GetVersion();
 	}
 
-	DllExport char* __stdcall GetMesenBuildDate()
+	DllExport const char* __stdcall GetMesenBuildDate()
 	{
 		return _buildDateTime;
 	}

--- a/InteropDLL/TestApiWrapper.cpp
+++ b/InteropDLL/TestApiWrapper.cpp
@@ -135,7 +135,6 @@ extern "C"
 		std::cout << "Test count: " << tests.size() << "\n";
 		std::cout << "Tests to skip: " << skipCount << "\n\n";
 
-		std::atomic<bool> failed = false;
 		std::atomic<int> testNumber = 0;
 		std::atomic<int> failCount = 0;
 		std::atomic<int> passCount = 0;

--- a/Lua/select.c
+++ b/Lua/select.c
@@ -116,7 +116,12 @@ static int dirty(lua_State *L) {
 
 static void collect_fd(lua_State *L, int tab, int itab,
         fd_set *set, t_socket *max_fd) {
-    int i = 1, n = 0;
+    int i = 1;
+
+#ifdef _WIN32
+    int n = 0;
+#endif
+
     /* nil is the same as an empty table */
     if (lua_isnil(L, tab)) return;
     /* otherwise we need it to be a table */
@@ -136,12 +141,12 @@ static void collect_fd(lua_State *L, int tab, int itab,
 #ifdef _WIN32
             if (n >= FD_SETSIZE)
                 luaL_argerror(L, tab, "too many sockets");
+            n++;
 #else
             if (fd >= FD_SETSIZE)
                 luaL_argerror(L, tab, "descriptor too large for set size");
 #endif
             FD_SET(fd, set);
-            n++;
             /* keep track of the largest descriptor so far */
             if (*max_fd == SOCKET_INVALID || *max_fd < fd)
                 *max_fd = fd;

--- a/makefile
+++ b/makefile
@@ -14,6 +14,9 @@ ifeq ($(USE_GCC),true)
 else
 	CXX := clang++
 	CC := clang
+	ifeq ($(UNAME_S),Linux)
+		MESENFLAGS += -Werror -Wno-undefined-inline -Wno-return-type-c-linkage
+	endif
 	PROFILE_GEN_FLAG := -fprofile-instr-generate=$(CURDIR)/PGOHelper/pgo.profraw
 	PROFILE_USE_FLAG := -fprofile-instr-use=$(CURDIR)/PGOHelper/pgo.profdata
 endif

--- a/makefile
+++ b/makefile
@@ -4,6 +4,8 @@
 #The emulation core also requires SDL2.
 #Run "make" to build, "make run" to run
 
+UNAME_S := $(shell uname -s)
+
 MESENFLAGS=
 
 ifeq ($(USE_GCC),true)
@@ -28,7 +30,6 @@ LINKCHECKUNRESOLVED := -Wl,-z,defs
 
 LINKOPTIONS :=
 MESENOS :=
-UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Linux)
 	MESENOS := linux


### PR DESCRIPTION
-Some warnings were suppressed (undefined-inline and return-type-c-linkage)
-Warnings as errors was enabled to make CI builds fail when warnings are introduced
-Slightly altered the behavior of SnesCpu::IdleOrRead, but this should match what ares does.