### PR TITLE
Debugger: GBA - Show byte code as a single 16/32-bit value

### DIFF
--- a/Core/Debugger/BaseTraceLogger.h
+++ b/Core/Debugger/BaseTraceLogger.h
@@ -173,7 +173,7 @@ protected:
 	void WriteByteCode(DisassemblyInfo& info, RowPart& rowPart, string& output)
 	{
 		string byteCode;
-		info.GetByteCode(byteCode);
+		info.GetByteCode(byteCode, _settings->GetDebugConfig().UseLowerCaseDisassembly);
 		if(!rowPart.DisplayInHex) {
 			//Remove $ marks if not in "hex" mode (but still display the bytes as hex)
 			byteCode.erase(std::remove(byteCode.begin(), byteCode.end(), '$'), byteCode.end());

--- a/Core/Debugger/DebugTypes.h
+++ b/Core/Debugger/DebugTypes.h
@@ -556,3 +556,9 @@ struct DebugControllerState
 		return A || B || X || Y || L || R || U || D || Up || Down || Left || Right || Select || Start;
 	}
 };
+
+enum class ByteCodeFormat
+{
+	Bytes,
+	HexValue
+};

--- a/Core/Debugger/DebugUtilities.h
+++ b/Core/Debugger/DebugUtilities.h
@@ -49,6 +49,17 @@ public:
 		throw std::runtime_error("Invalid CPU type");
 	}
 
+	static constexpr ByteCodeFormat GetByteCodeFormat(CpuType type)
+	{
+		switch(type) {
+			case CpuType::St018:
+			case CpuType::Gba:
+				return ByteCodeFormat::HexValue;
+		}
+
+		return ByteCodeFormat::Bytes;
+	}
+
 	static constexpr CpuType ToCpuType(MemoryType type)
 	{
 		switch(type) {

--- a/Core/Debugger/DisassemblyInfo.cpp
+++ b/Core/Debugger/DisassemblyInfo.cpp
@@ -164,13 +164,19 @@ void DisassemblyInfo::GetByteCode(uint8_t copyBuffer[8])
 	memcpy(copyBuffer, _byteCode, _opSize);
 }
 
-void DisassemblyInfo::GetByteCode(string& out)
+void DisassemblyInfo::GetByteCode(string& out, bool lowerCase)
 {
-	FastString str;
-	for(int i = 0; i < _opSize; i++) {
-		str.WriteAll('$', HexUtilities::ToHex(_byteCode[i]));
-		if(i < _opSize - 1) {
-			str.Write(' ');
+	FastString str(lowerCase);
+	if(DebugUtilities::GetByteCodeFormat(_cpuType) == ByteCodeFormat::HexValue) {
+		for(int i = _opSize - 1; i >= 0; i--) {
+			str.WriteAll(HexUtilities::ToHex(_byteCode[i]));
+		}
+	} else {
+		for(int i = 0; i < _opSize; i++) {
+			str.WriteAll('$', HexUtilities::ToHex(_byteCode[i]));
+			if(i < _opSize - 1) {
+				str.Write(' ');
+			}
 		}
 	}
 	out += str.ToString();

--- a/Core/Debugger/DisassemblyInfo.h
+++ b/Core/Debugger/DisassemblyInfo.h
@@ -59,7 +59,7 @@ public:
 	uint8_t* GetByteCode();
 
 	void GetByteCode(uint8_t copyBuffer[8]);
-	void GetByteCode(string& out);
+	void GetByteCode(string& out, bool lowerCase);
 
 	static uint8_t GetOpSize(uint32_t opCode, uint8_t flags, CpuType type, uint32_t cpuAddress, MemoryType memType, MemoryDumper* memoryDumper);
 	bool IsJumpToSub();

--- a/UI/Debugger/Controls/DisassemblyViewer.cs
+++ b/UI/Debugger/Controls/DisassemblyViewer.cs
@@ -274,7 +274,7 @@ namespace Mesen.Debugger.Controls
 
 			double symbolMargin = Math.Floor(LetterSize.Width * 2.5);
 			double addressMargin = Math.Floor(LetterSize.Width * addressMaxCharCount) + 9;
-			double byteCodeMargin = Math.Floor(LetterSize.Width * (3 * styleProvider.ByteCodeSize));
+			double byteCodeMargin = Math.Floor(LetterSize.Width * (styleProvider.ByteCodeStringLength + 1));
 			double codeIndent = Math.Floor(LetterSize.Width * 2) + 0.5;
 
 			//Draw margin (symbol + address)
@@ -330,7 +330,7 @@ namespace Mesen.Debugger.Controls
 
 				if(showByteCode) {
 					//Draw byte code
-					text = FormatText(line.GetByteCode(styleProvider.ByteCodeSize), ColorHelper.GetBrush(Colors.Gray));
+					text = FormatText(line.GetByteCode(styleProvider.ByteCodeStringLength), ColorHelper.GetBrush(Colors.Gray));
 					context.DrawText(text, new Point(x + LetterSize.Width / 2, y));
 					x += byteCodeMargin;
 				}
@@ -662,7 +662,7 @@ namespace Mesen.Debugger.Controls
 	public interface ILineStyleProvider
 	{
 		int AddressSize { get; }
-		int ByteCodeSize { get; }
+		int ByteCodeStringLength { get; }
 
 		LineProperties GetLineStyle(CodeLineData lineData, int lineIndex);
 

--- a/UI/Debugger/Disassembly/BaseStyleProvider.cs
+++ b/UI/Debugger/Disassembly/BaseStyleProvider.cs
@@ -15,14 +15,14 @@ namespace Mesen.Debugger.Disassembly
 	public class BaseStyleProvider : ILineStyleProvider
 	{
 		public int AddressSize { get; }
-		public int ByteCodeSize { get; }
+		public int ByteCodeStringLength { get; }
 		public CpuType CpuType { get; }
 
 		public BaseStyleProvider(CpuType cpuType)
 		{
 			CpuType = cpuType;
 			AddressSize = cpuType.GetAddressSize();
-			ByteCodeSize = cpuType.GetByteCodeSize();
+			ByteCodeStringLength = cpuType.GetByteCodeStringLength();
 		}
 
 		private void ConfigureActiveStatement(LineProperties props)

--- a/UI/Debugger/Disassembly/CodeLineData.cs
+++ b/UI/Debugger/Disassembly/CodeLineData.cs
@@ -31,11 +31,18 @@ namespace Mesen.Debugger
 			get
 			{
 				if(OpSize > 0 && _byteCodeString == "") {
+					string format = ConfigManager.Config.Debug.Debugger.UseLowerCaseDisassembly ? "x2" : "X2";
 					string output = "";
-					for(int i = 0; i < OpSize && i < ByteCode.Length; i++) {
-						output += ByteCode[i].ToString("X2") + " ";
+					if(CpuType.GetByteCodeFormat() == ByteCodeFormat.HexValue) {
+						for(int i = OpSize - 1; i >= 0; i--) {
+							output += ByteCode[i].ToString(format);
+						}
+					} else {
+						for(int i = 0; i < OpSize && i < ByteCode.Length; i++) {
+							output += ByteCode[i].ToString(format) + " ";
+						}
 					}
-					_byteCodeString = output;
+					_byteCodeString = output.TrimEnd();
 				}
 
 				return _byteCodeString;
@@ -146,10 +153,10 @@ namespace Mesen.Debugger
 			return "$" + this.Address.ToString("X6") + "  " + this.ByteCodeStr?.PadRight(12) + "  " + this.Text;
 		}
 
-		public string GetByteCode(int byteCodeSize)
+		public string GetByteCode(int byteCodeStrLen)
 		{
-			if(ByteCodeStr.Length > byteCodeSize * 3) {
-				return ByteCodeStr.Substring(0, (byteCodeSize - 1) * 3) + "..";
+			if(ByteCodeStr.Length > byteCodeStrLen) {
+				return ByteCodeStr.Substring(0, byteCodeStrLen - 2) + "..";
 			}
 			return ByteCodeStr;
 		}

--- a/UI/Debugger/Utilities/OpCodeHelper.cs
+++ b/UI/Debugger/Utilities/OpCodeHelper.cs
@@ -152,6 +152,8 @@ public static class OpCodeHelper
 		//TODOGBA add missing descriptions, etc.
 		InitDocumentation(CpuType.Gba, ReadDocumentationFile("GbaDocumentation.json"));
 
+		string[] conditions = { "eq", "ne", "cs", "cc", "mi", "pl", "vs", "vc", "hi", "ls", "ge", "lt", "gt", "le", "al" };
+
 		Func<Dictionary<string, OpCodeDesc>, string, CodeSegmentInfo, bool, OpCodeDesc?> parseOp = (dict, opName, codeSegment, checkSetFlags) => {
 			OpCodeDesc? desc = null;
 			bool updateFlags = false;
@@ -170,14 +172,10 @@ public static class OpCodeHelper
 					desc = desc.Clone();
 
 					if(byteSize) {
-						desc.Name += " (byte)";
-					}
-
-					if(halfWordSize) {
-						desc.Name += " (half-word)";
-					}
-
-					if(signed) {
+						desc.Name += signed ? " (byte, signed)" : " (byte)";
+					} else if(halfWordSize) {
+						desc.Name += signed ? " (half-word, signed)" : " (half-word)";
+					} else if(signed) {
 						desc.Name += " (signed)";
 					}
 
@@ -216,7 +214,8 @@ public static class OpCodeHelper
 				return desc;
 			}
 
-			if(checkSetFlags && opName.EndsWith("s")) {
+			string? condition = conditions.FirstOrDefault(opName.EndsWith);
+			if((condition == null || opName.Length == 4) && checkSetFlags && opName.EndsWith("s")) {
 				updateFlags = true;
 				opName = opName.Substring(0, opName.Length - 1);
 			}
@@ -263,13 +262,12 @@ public static class OpCodeHelper
 				return desc;
 			}
 
-			if(opName != "mrs" && opName.EndsWith("s")) {
+			if((byteSize || halfWordSize) && opName.EndsWith("s")) {
 				signed = true;
 				opName = opName.Substring(0, opName.Length - 1);
 			}
 
-			string[] conditions = { "eq", "ne", "cs", "cc", "mi", "pl", "vs", "vc", "hi", "ls", "ge", "lt", "gt", "le", "al" };
-			string? condition = conditions.FirstOrDefault(opName.EndsWith);
+			condition = conditions.FirstOrDefault(opName.EndsWith);
 			if(condition != null) {
 				condHint = condition switch {
 					"eq" => "Equal (Zero Set)",
@@ -291,6 +289,15 @@ public static class OpCodeHelper
 				};
 
 				opName = opName.Substring(0, opName.Length - 2);
+			}
+
+			if(tryParseOp()) {
+				return desc;
+			}
+
+			if(opName != "mrs" && opName.EndsWith("s")) {
+				signed = true;
+				opName = opName.Substring(0, opName.Length - 1);
 			}
 
 			if(tryParseOp()) {

--- a/UI/Debugger/ViewModels/TraceLoggerViewModel.cs
+++ b/UI/Debugger/ViewModels/TraceLoggerViewModel.cs
@@ -716,7 +716,7 @@ namespace Mesen.Debugger.ViewModels
 		}
 
 		public int AddressSize { get; private set; } = 6;
-		public int ByteCodeSize { get; private set; } = 4;
+		public int ByteCodeStringLength { get; private set; } = 4;
 		private LineProperties GetMainCpuStyle() { return new LineProperties() { AddressColor = null, LineBgColor = null }; }
 		private LineProperties GetSecondaryCpuStyle() { return new LineProperties() { AddressColor = Color.FromRgb(30, 145, 30), LineBgColor = Color.FromRgb(230, 245, 230) }; }
 		private LineProperties GetCoprocessorStyle() { return new LineProperties() { AddressColor = Color.FromRgb(30, 30, 145), LineBgColor = Color.FromRgb(230, 230, 245) }; }
@@ -748,8 +748,7 @@ namespace Mesen.Debugger.ViewModels
 		{
 			_consoleType = consoleType;
 			AddressSize = consoleType.GetMainCpuType().GetAddressSize();
-			ByteCodeSize = consoleType.GetMainCpuType().GetByteCodeSize();
+			ByteCodeStringLength = consoleType.GetMainCpuType().GetByteCodeStringLength();
 		}
 	}
-
 }

--- a/UI/Interop/CpuTypeExtensions.cs
+++ b/UI/Interop/CpuTypeExtensions.cs
@@ -132,6 +132,28 @@ namespace Mesen.Interop
 			};
 		}
 
+		public static int GetByteCodeStringLength(this CpuType cpuType)
+		{
+			int size = cpuType.GetByteCodeSize();
+
+			//Return the number of characters used:
+			//Bytes is shown as 00 11 22 33 (3 chars per byte, minus 1)
+			//HexValue is shown as 33221100 (2 chars per byte)
+			return cpuType.GetByteCodeFormat() switch {
+				ByteCodeFormat.Bytes => size * 3 - 1,
+				ByteCodeFormat.HexValue => size * 2,
+				_ => throw new Exception("Invalid byte code format"),
+			};
+		}
+
+		public static ByteCodeFormat GetByteCodeFormat(this CpuType type)
+		{
+			return type switch {
+				CpuType.St018 or CpuType.Gba => ByteCodeFormat.HexValue,
+				_ => ByteCodeFormat.Bytes
+			};
+		}
+
 		public static DebuggerFlags GetDebuggerFlag(this CpuType cpuType)
 		{
 			return cpuType switch {

--- a/UI/Interop/EmuApi.cs
+++ b/UI/Interop/EmuApi.cs
@@ -194,6 +194,12 @@ namespace Mesen.Interop
 		Ws = 6,
 	}
 
+	public enum ByteCodeFormat
+	{
+		Bytes,
+		HexValue
+	}
+
 	public struct InteropDipSwitchInfo
 	{
 		public UInt32 DatabaseId;


### PR DESCRIPTION
Misc fixes:
-Fixed issues with the opcode tooltip not appearing for some GBA instructions (esp. when the condition code ends with an 's', e.g: rsbcs, movls, subcs)
-Fixed byte code not being lower case when the "use lower case" option is enabled