### PR TITLE
Debugger: Profiler - Keep track of cycles executed while the CPU is halted

### DIFF
--- a/Core/Debugger/CallstackManager.cpp
+++ b/Core/Debugger/CallstackManager.cpp
@@ -78,6 +78,22 @@ void CallstackManager::Pop(AddressInfo& dest, uint32_t destAddress, uint32_t sta
 	}
 }
 
+void CallstackManager::PushHalted()
+{
+	if(_callstack.empty() || _callstack.back().Flags != StackFrameFlags::Halt) {
+		AddressInfo addr { 0, MemoryType::None };
+		Push(addr, 0, addr, 0, addr, 0, 0, StackFrameFlags::Halt);
+	}
+}
+
+void CallstackManager::PopHalted()
+{
+	if(!_callstack.empty() && _callstack.back().Flags == StackFrameFlags::Halt) {
+		_callstack.pop_back();
+		_profiler->UnstackFunction();
+	}
+}
+
 void CallstackManager::GetCallstack(StackFrameInfo* callstackArray, uint32_t& callstackSize)
 {
 	DebugBreakHelper helper(_debugger);

--- a/Core/Debugger/CallstackManager.h
+++ b/Core/Debugger/CallstackManager.h
@@ -20,6 +20,9 @@ public:
 	void Push(AddressInfo& src, uint32_t srcAddr, AddressInfo& dest, uint32_t destAddr, AddressInfo& ret, uint32_t returnAddress, uint32_t returnStackPointer, StackFrameFlags flags);
 	void Pop(AddressInfo& dest, uint32_t destAddr, uint32_t stackPointer);
 
+	void PushHalted();
+	void PopHalted();
+
 	__forceinline bool IsReturnAddrMatch(uint32_t destAddr)
 	{
 		if(_callstack.empty()) {

--- a/Core/Debugger/DebugTypes.h
+++ b/Core/Debugger/DebugTypes.h
@@ -279,7 +279,8 @@ enum class StackFrameFlags
 {
 	None = 0,
 	Nmi = 1,
-	Irq = 2
+	Irq = 2,
+	Halt = 4
 };
 
 struct StackFrameInfo

--- a/Core/Debugger/Debugger.cpp
+++ b/Core/Debugger/Debugger.cpp
@@ -14,6 +14,7 @@
 #include "Debugger/ScriptManager.h"
 #include "Debugger/ScriptHost.h"
 #include "Debugger/CallstackManager.h"
+#include "Debugger/Profiler.h"
 #include "Debugger/ExpressionEvaluator.h"
 #include "Debugger/BaseEventManager.h"
 #include "Debugger/TraceLogFileSaver.h"
@@ -46,16 +47,12 @@
 #include "WS/WsTypes.h"
 #include "Shared/BaseControlManager.h"
 #include "Shared/EmuSettings.h"
-#include "Shared/Audio/SoundMixer.h"
 #include "Shared/NotificationManager.h"
 #include "Shared/BaseState.h"
 #include "Shared/Emulator.h"
 #include "Shared/Interfaces/IConsole.h"
 #include "Shared/MemoryOperationType.h"
 #include "Shared/EventType.h"
-#include "Utilities/HexUtilities.h"
-#include "Utilities/FolderUtilities.h"
-#include "Utilities/Patches/IpsPatcher.h"
 #include "Utilities/PlatformUtilities.h"
 
 uint64_t ITraceLogger::NextRowId = 0;
@@ -606,6 +603,11 @@ void Debugger::ProcessEvent(EventType type, std::optional<CpuType> cpuTypeOpt)
 			if(evtMgr) {
 				evtMgr->ClearFrameEvents();
 			}
+
+			CallstackManager* manager = GetCallstackManager(evtCpuType);
+			if(manager) {
+				manager->GetProfiler()->UpdateCpuUsage();
+			}
 			break;
 		}
 
@@ -627,6 +629,22 @@ void Debugger::ProcessEvent(EventType type, std::optional<CpuType> cpuTypeOpt)
 				}
 			}
 			break;
+
+		case EventType::HaltStarted: {
+			CallstackManager* manager = GetCallstackManager(evtCpuType);
+			if(manager) {
+				manager->PushHalted();
+			}
+			break;
+		}
+
+		case EventType::HaltEnded: {
+			CallstackManager* manager = GetCallstackManager(evtCpuType);
+			if(manager) {
+				manager->PopHalted();
+			}
+			break;
+		}
 	}
 }
 
@@ -1280,6 +1298,7 @@ template void Debugger::ProcessIdleCycle<CpuType::Pce>();
 
 template void Debugger::ProcessHaltedCpu<CpuType::Snes>();
 template void Debugger::ProcessHaltedCpu<CpuType::Spc>();
+template void Debugger::ProcessHaltedCpu<CpuType::Sa1>();
 template void Debugger::ProcessHaltedCpu<CpuType::Gameboy>();
 template void Debugger::ProcessHaltedCpu<CpuType::Sms>();
 template void Debugger::ProcessHaltedCpu<CpuType::Gba>();

--- a/Core/Debugger/Profiler.cpp
+++ b/Core/Debugger/Profiler.cpp
@@ -6,6 +6,7 @@
 #include "Debugger/DebugTypes.h"
 
 static constexpr int32_t ResetFunctionIndex = -1;
+static constexpr int32_t HaltFunctionIndex = (uint8_t)MemoryType::None << 24;
 
 Profiler::Profiler(Debugger* debugger, IDebugger* cpuDebugger)
 {
@@ -114,6 +115,10 @@ void Profiler::ResetState()
 	_stackFlags.clear();
 	_cycleCountStack.clear();
 	_currentFunction = ResetFunctionIndex;
+
+	_prevCpuUsage = 0;
+	_prevUsageCycleCount = 0;
+	_prevUsageHaltedCycles = 0;
 }
 
 void Profiler::InternalReset()
@@ -139,5 +144,26 @@ void Profiler::GetProfilerData(ProfiledFunction* profilerData, uint32_t& functio
 		if(functionCount >= 100000) {
 			break;
 		}
+	}
+}
+
+void Profiler::UpdateCpuUsage()
+{
+	DebugBreakHelper helper(_debugger);
+	UpdateCycles();
+
+	auto result = _functions.find(HaltFunctionIndex);
+	if(result != _functions.end()) {
+		uint64_t cycleCount = _cpuDebugger->GetCpuCycleCount(true);
+		uint64_t haltedCycles = result->second.ExclusiveCycles;
+
+		uint64_t elapsed = cycleCount - _prevUsageCycleCount;
+		uint64_t halted = haltedCycles - _prevUsageHaltedCycles;
+
+		_prevCpuUsage = ((double)(elapsed - halted) / elapsed * 100) + 1;
+		_prevUsageCycleCount = cycleCount;
+		_prevUsageHaltedCycles = result->second.ExclusiveCycles;
+	} else {
+		_prevCpuUsage = 0;
 	}
 }

--- a/Core/Debugger/Profiler.h
+++ b/Core/Debugger/Profiler.h
@@ -32,6 +32,10 @@ private:
 	uint64_t _prevMasterClock = 0;
 	int32_t _currentFunction = -1;
 
+	uint64_t _prevUsageCycleCount = 0;
+	uint64_t _prevUsageHaltedCycles = 0;
+	uint32_t _prevCpuUsage = 0;
+
 	void InternalReset();
 	void UpdateCycles();
 
@@ -42,7 +46,11 @@ public:
 	void StackFunction(AddressInfo& addr, StackFrameFlags stackFlag);
 	void UnstackFunction();
 
+	void UpdateCpuUsage();
+
 	void Reset();
 	void ResetState();
+
 	void GetProfilerData(ProfiledFunction* profilerData, uint32_t& functionCount);
+	uint32_t GetCpuUsage() { return _prevCpuUsage; }
 };

--- a/Core/GBA/GbaCpu.h
+++ b/Core/GBA/GbaCpu.h
@@ -11,6 +11,7 @@
 	#include "Shared/Emulator.h"
 	#include "Debugger/DebugTypes.h"
 	#include "Utilities/ISerializable.h"
+	#include "Shared/EventType.h"
 
 class GbaMemoryManager;
 class GbaRomPrefetch;
@@ -214,6 +215,11 @@ public:
 		if(isHaltOver) {
 			_memoryManager->ProcessIdleCycle();
 			_state.Stopped = _state.Frozen;
+	#ifndef DUMMYCPU
+			if(!_state.Stopped) {
+				_emu->ProcessEvent(EventType::HaltEnded, CpuType::Gba);
+			}
+	#endif
 			return false;
 		} else {
 			return true;
@@ -291,6 +297,12 @@ public:
 	{
 		_state.Stopped = true;
 		_state.Frozen = freeze;
+
+	#ifndef DUMMYCPU
+		if(!freeze) {
+			_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gba);
+		}
+	#endif
 	}
 
 	void ClearSequentialFlag() { _state.Pipeline.Mode &= ~GbaAccessMode::Sequential; }

--- a/Core/GBA/GbaPpu.h
+++ b/Core/GBA/GbaPpu.h
@@ -2,6 +2,7 @@
 #include "pch.h"
 #include "GBA/GbaTypes.h"
 #include "Shared/Emulator.h"
+#include "Shared/EventType.h"
 #include "Utilities/Timer.h"
 #include "Utilities/ISerializable.h"
 
@@ -263,6 +264,7 @@ public:
 				SendFrame();
 			} else if(_state.Scanline > 227) {
 				_state.Scanline = 0;
+				_emu->ProcessEvent(EventType::StartFrame, CpuType::Gba);
 			}
 		}
 		_emu->ProcessPpuCycle<CpuType::Gba>();

--- a/Core/Gameboy/GbCpu.cpp
+++ b/Core/Gameboy/GbCpu.cpp
@@ -6,6 +6,7 @@
 #include "Gameboy/GbMemoryManager.h"
 #include "Gameboy/GbControlManager.h"
 #include "Shared/Emulator.h"
+#include "Shared/EventType.h"
 #include "Utilities/Serializer.h"
 
 void GbCpu::Init(Emulator* emu, Gameboy* gameboy, GbMemoryManager* memoryManager)
@@ -888,6 +889,7 @@ void GbCpu::STOP()
 #ifndef DUMMYCPU
 		//Stop for ~33941 cycles - most likely not accurate, but matches speed_switch_timing_stat test rom
 		_state.HaltCounter = 33942;
+		_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gameboy);
 #endif
 	} else {
 		_state.Stopped = true;
@@ -907,6 +909,10 @@ void GbCpu::HALT()
 		_state.HaltCounter = 1;
 		_state.HaltBug = true;
 	}
+
+#ifndef DUMMYCPU
+	_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gameboy);
+#endif
 }
 
 // cpl              2F         4 -11- A = A xor FF

--- a/Core/Gameboy/GbMemoryManager.cpp
+++ b/Core/Gameboy/GbMemoryManager.cpp
@@ -11,6 +11,7 @@
 #include "Gameboy/GbControlManager.h"
 #include "Shared/Emulator.h"
 #include "Shared/CheatManager.h"
+#include "Shared/EventType.h"
 #include "Shared/MessageManager.h"
 #include "Utilities/Serializer.h"
 #include "Utilities/HexUtilities.h"
@@ -561,6 +562,7 @@ uint8_t GbMemoryManager::ProcessIrqRequests()
 
 void GbMemoryManager::ProcessHaltEnd()
 {
+	_emu->ProcessEvent(EventType::HaltEnded, CpuType::Gameboy);
 	_dmaController->ProcessHdma();
 }
 

--- a/Core/SMS/SmsCpu.cpp
+++ b/Core/SMS/SmsCpu.cpp
@@ -5,7 +5,7 @@
 #include "SMS/SmsMemoryManager.h"
 #include "Shared/Emulator.h"
 #include "Shared/MemoryOperationType.h"
-#include "Utilities/HexUtilities.h"
+#include "Shared/EventType.h"
 #include "Utilities/Serializer.h"
 
 SmsCpuParityTable SmsCpu::_parity = {};
@@ -46,7 +46,12 @@ void SmsCpu::Exec()
 	}
 
 	if(_state.NmiPending) {
-		_state.Halted = false;
+		if(_state.Halted) {
+			_state.Halted = false;
+#ifndef DUMMYCPU
+			_emu->ProcessEvent(EventType::HaltEnded, CpuType::Sms);
+#endif
+		}
 		_state.NmiPending = false;
 		_state.IFF1 = false;
 		ExecCycles(4);
@@ -56,7 +61,12 @@ void SmsCpu::Exec()
 		_emu->ProcessInterrupt<CpuType::Sms>(originalPc, _state.PC, true);
 	} else if(_state.IFF1 && _state.ActiveIrqs && opCode != 0xFB) {
 		//Process IRQs if enabled, but not if the previous op was EI (0xFB)
-		_state.Halted = false;
+		if(_state.Halted) {
+			_state.Halted = false;
+#ifndef DUMMYCPU
+			_emu->ProcessEvent(EventType::HaltEnded, CpuType::Sms);
+#endif
+		}
 		_state.IFF1 = false;
 		_state.IFF2 = false;
 		ExecCycles(6);
@@ -1290,6 +1300,10 @@ void SmsCpu::NOP()
 void SmsCpu::HALT()
 {
 	_state.Halted = true;
+
+#ifndef DUMMYCPU
+	_emu->ProcessEvent(EventType::HaltStarted, CpuType::Sms);
+#endif
 }
 
 void SmsCpu::CPL()

--- a/Core/SNES/Coprocessors/SA1/Sa1Cpu.cpp
+++ b/Core/SNES/Coprocessors/SA1/Sa1Cpu.cpp
@@ -9,8 +9,10 @@
 #include "Shared/EventType.h"
 
 #define SnesCpu Sa1Cpu
+#define SA1
 #include "SNES/SnesCpu.Instructions.h"
 #include "SNES/SnesCpu.Shared.h"
+#undef SA1
 #undef SnesCpu
 
 Sa1Cpu::Sa1Cpu(Sa1* sa1, Emulator* emu)
@@ -54,6 +56,10 @@ void Sa1Cpu::CheckForInterrupts()
 
 void Sa1Cpu::ProcessHaltedState()
 {
+#ifndef DUMMYCPU
+	_emu->ProcessHaltedCpu<CpuType::Sa1>();
+#endif
+
 	if(_state.StopState == SnesCpuStopState::Stopped) {
 		//STP was executed, CPU no longer executes any code
 		_state.CycleCount++;
@@ -63,6 +69,9 @@ void Sa1Cpu::ProcessHaltedState()
 		Idle();
 		if(over) {
 			_state.StopState = SnesCpuStopState::Running;
+#ifndef DUMMYCPU
+			_emu->ProcessEvent(EventType::HaltEnded, CpuType::Sa1);
+#endif
 			CheckForInterrupts();
 		}
 	}

--- a/Core/SNES/SnesCpu.Instructions.h
+++ b/Core/SNES/SnesCpu.Instructions.h
@@ -1,3 +1,5 @@
+#include "Shared/EventType.h"
+
 /************************
 Add/subtract operations
 *************************/
@@ -1181,6 +1183,14 @@ void SnesCpu::WAI()
 	//Wait for interrupt
 	_state.StopState = SnesCpuStopState::WaitingForIrq;
 	_waiOver = false;
+
+#ifndef DUMMYCPU
+	#ifdef SA1
+	_emu->ProcessEvent(EventType::HaltStarted, CpuType::Sa1);
+	#else
+	_emu->ProcessEvent(EventType::HaltStarted, CpuType::Snes);
+	#endif
+#endif
 }
 
 /****************

--- a/Core/SNES/SnesCpu.cpp
+++ b/Core/SNES/SnesCpu.cpp
@@ -78,6 +78,9 @@ void SnesCpu::ProcessHaltedState()
 		Idle();
 		if(over) {
 			_state.StopState = SnesCpuStopState::Running;
+#ifndef DUMMYCPU
+			_emu->ProcessEvent(EventType::HaltEnded, CpuType::Snes);
+#endif
 			CheckForInterrupts();
 		}
 	}

--- a/Core/Shared/EventType.h
+++ b/Core/Shared/EventType.h
@@ -12,6 +12,7 @@ enum class EventType
 	StateLoaded,
 	StateSaved,
 	CodeBreak,
-
+	HaltStarted,
+	HaltEnded,
 	LastValue
 };

--- a/Core/WS/WsCpu.cpp
+++ b/Core/WS/WsCpu.cpp
@@ -3,8 +3,8 @@
 #include "WS/WsConsole.h"
 #include "WS/WsMemoryManager.h"
 #include "Shared/Emulator.h"
+#include "Shared/EventType.h"
 #include "Shared/MessageManager.h"
-#include "Utilities/HexUtilities.h"
 #include "Utilities/Serializer.h"
 
 WsCpuParityTable WsCpu::_parity = {};
@@ -51,7 +51,11 @@ void WsCpu::Exec()
 	}
 
 	if(irqPending) {
-		_state.Halted = false;
+		if(_state.Halted) {
+			_state.Halted = false;
+			_emu->ProcessEvent(EventType::HaltEnded, CpuType::Ws);
+		}
+
 		if(_state.Flags.Irq && _suppressIrqClock != _state.CycleCount) {
 			Interrupt(_memoryManager->GetIrqVector(), true);
 		}
@@ -862,6 +866,10 @@ void WsCpu::Halt()
 	if(_memoryManager->IsPowerOffRequested()) {
 		MessageManager::DisplayMessage("WS", "Power off.");
 		_state.PowerOff = true;
+	} else {
+#ifndef DUMMYCPU
+		_emu->ProcessEvent(EventType::HaltStarted, CpuType::Ws);
+#endif
 	}
 }
 

--- a/InteropDLL/DebugApiWrapper.cpp
+++ b/InteropDLL/DebugApiWrapper.cpp
@@ -173,6 +173,11 @@ extern "C"
 		WithToolVoid(GetCallstackManager(cpuType), GetProfiler()->Reset());
 	}
 
+	DllExport int32_t __stdcall GetProfilerCpuUsage(CpuType cpuType)
+	{
+		return WithTool(int32_t, GetCallstackManager(cpuType), GetProfiler()->GetCpuUsage());
+	}
+
 	DllExport void __stdcall GetConsoleState(BaseState& state, ConsoleType consoleType)
 	{
 		WithDebugger(void, GetConsoleState(state, consoleType));

--- a/UI/Debugger/ViewModels/CallStackViewModel.cs
+++ b/UI/Debugger/ViewModels/CallStackViewModel.cs
@@ -3,6 +3,7 @@ using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Controls.Selection;
 using Avalonia.Media;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Mesen.Config;
 using Mesen.Debugger.Labels;
 using Mesen.Debugger.Utilities;
@@ -10,7 +11,6 @@ using Mesen.Debugger.Windows;
 using Mesen.Interop;
 using Mesen.Utilities;
 using Mesen.ViewModels;
-using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -83,6 +83,9 @@ namespace Mesen.Debugger.ViewModels
 			}
 
 			StackFrameInfo entry = stackFrame.Value;
+			if(entry.Flags == StackFrameFlags.Halt) {
+				return "[halted]";
+			}
 
 			string format = "X" + CpuType.GetAddressSize();
 			CodeLabel? label = entry.AbsTarget.Address >= 0 ? LabelManager.GetLabel(entry.AbsTarget) : null;

--- a/UI/Debugger/ViewModels/DebuggerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/DebuggerWindowViewModel.cs
@@ -62,6 +62,9 @@ namespace Mesen.Debugger.ViewModels
 		[ObservableProperty] public partial List<ContextMenuAction> SearchMenuItems { get; private set; } = new();
 		[ObservableProperty] public partial List<ContextMenuAction> OptionMenuItems { get; private set; } = new();
 
+		[ObservableProperty] public partial bool ShowCpuUsage { get; private set; }
+		[ObservableProperty] public partial int CpuUsage { get; private set; }
+
 		public CpuType CpuType { get; private set; }
 		private UInt64 _masterClock = 0;
 
@@ -280,6 +283,7 @@ namespace Mesen.Debugger.ViewModels
 				UpdateStatusBar(evt);
 			}
 
+			UpdateCpuUsage();
 			UpdateDisassembly(forBreak);
 			MemoryMappings?.Refresh();
 			BreakpointList.RefreshBreakpointList();
@@ -293,6 +297,7 @@ namespace Mesen.Debugger.ViewModels
 		{
 			ConsoleStatus?.UpdateUiState(true);
 			MemoryMappings?.Refresh();
+			UpdateCpuUsage();
 			UpdateCdlStats();
 			if(refreshWatch) {
 				WatchList.UpdateWatch();
@@ -361,6 +366,13 @@ namespace Mesen.Debugger.ViewModels
 				}
 			}
 			CdlStats = statsString;
+		}
+
+		public void UpdateCpuUsage()
+		{
+			int cpuUsage = DebugApi.GetProfilerCpuUsage(CpuType);
+			ShowCpuUsage = cpuUsage > 0;
+			CpuUsage = Math.Min(cpuUsage - 1, 100);
 		}
 
 		public void UpdateActiveAddress(bool scrollToAddress)

--- a/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
@@ -234,7 +234,7 @@ namespace Mesen.Debugger.ViewModels
 			string functionName;
 
 			if(func.Address.Address == -1) {
-				functionName = "[Reset]";
+				functionName = "[reset]";
 			} else {
 				CodeLabel? label = LabelManager.GetLabel((UInt32)func.Address.Address, func.Address.Type);
 
@@ -249,6 +249,8 @@ namespace Mesen.Debugger.ViewModels
 				functionName = "[irq] " + functionName;
 			} else if(func.Flags.HasFlag(StackFrameFlags.Nmi)) {
 				functionName = "[nmi] " + functionName;
+			} else if(func.Flags.HasFlag(StackFrameFlags.Halt)) {
+				functionName = "[halted]";
 			}
 
 			return functionName;

--- a/UI/Debugger/Windows/DebuggerWindow.axaml
+++ b/UI/Debugger/Windows/DebuggerWindow.axaml
@@ -149,6 +149,22 @@
 				Click="OnSettingsClick"
 				Icon="Assets/Settings.png"
 			/>
+			<ProgressBar
+				Value="{Binding CpuUsage}"
+				Width="80"
+				MinWidth="80"
+				Height="15"
+				Margin="0 0 5 0"
+				ShowProgressText="True" 
+				ProgressTextFormat="CPU: {0}%"
+				DockPanel.Dock="Right"
+				Background="#444"
+				IsVisible="{Binding ShowCpuUsage}"
+			>
+				<ProgressBar.Resources>
+					<SolidColorBrush x:Key="SystemControlForegroundBaseHighBrush" Color="#FFF" />
+				</ProgressBar.Resources>
+			</ProgressBar>
 			<StackPanel Orientation="Horizontal">
 				<dc:ActionToolbar Items="{Binding ToolbarItems}" />
 			</StackPanel>

--- a/UI/Debugger/Windows/DebuggerWindow.axaml.cs
+++ b/UI/Debugger/Windows/DebuggerWindow.axaml.cs
@@ -14,6 +14,7 @@ using Mesen.Utilities;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -29,6 +30,7 @@ namespace Mesen.Debugger.Windows
 		private int? _scrollToAddress = null;
 		private bool _suppressBringToFront = false;
 		private bool _autoResumePending = false;
+		private Stopwatch _cpuUsageTimer = new();
 
 		[Obsolete("For designer only")]
 		public DebuggerWindow() : this(null, null) { }
@@ -40,6 +42,7 @@ namespace Mesen.Debugger.Windows
 			_model = new DebuggerWindowViewModel(cpuType);
 			_scrollToAddress = scrollToAddress;
 			DataContext = _model;
+			_cpuUsageTimer.Start();
 
 			_model.InitializeMenu(this);
 
@@ -209,6 +212,13 @@ namespace Mesen.Debugger.Windows
 								bool updatingWatchEntry = TopLevel.GetTopLevel(this)?.FocusManager?.GetFocusedElement() is TextBox txt && txt.FindAncestorOfType<WatchListView>() != null;
 								_model.PartialRefresh(!updatingWatchEntry);
 							}
+						});
+					}
+
+					if(_cpuUsageTimer.ElapsedMilliseconds > 100) {
+						_cpuUsageTimer.Restart();
+						Dispatcher.UIThread.Post(() => {
+							_model.UpdateCpuUsage();
 						});
 					}
 					break;

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -438,6 +438,7 @@ namespace Mesen.Interop
 			return callstack;
 		}
 
+		[DllImport(DllPath)] public static extern int GetProfilerCpuUsage(CpuType type);
 		[DllImport(DllPath)] public static extern void ResetProfiler(CpuType type);
 		[DllImport(DllPath, EntryPoint = "GetProfilerData")] private static extern void GetProfilerDataWrapper(CpuType type, IntPtr profilerData, ref UInt32 functionCount);
 		public static unsafe int GetProfilerData(CpuType type, ref ProfiledFunction[] profilerData)
@@ -1524,11 +1525,13 @@ namespace Mesen.Interop
 		public StackFrameFlags Flags;
 	};
 
+	[Flags]
 	public enum StackFrameFlags
 	{
 		None = 0,
 		Nmi = 1,
-		Irq = 2
+		Irq = 2,
+		Halt = 4
 	}
 
 	public enum CpuType : byte


### PR DESCRIPTION
Also adds a "cpu usage" meter in the debugger window which appears when software makes uses of halt/wai/etc.