### PR TITLE
PCE: Fixed crash in Spriggan Mark 2

### DIFF
--- a/Core/PCE/CdRom/PceCdAudioPlayer.cpp
+++ b/Core/PCE/CdRom/PceCdAudioPlayer.cpp
@@ -47,6 +47,16 @@ void PceCdAudioPlayer::SetEndPosition(uint32_t endSector, CdPlayEndBehavior endB
 	_state.Status = CdAudioStatus::Playing;
 }
 
+void PceCdAudioPlayer::SetIdle()
+{
+	_state.Status = CdAudioStatus::Inactive;
+
+	//Games can start playing a track and then start loading data on the disk instead, which should cancel
+	//any incomplete seek operation. Without this, a "good" status gets sent, which breaks the SCSI bus'
+	//current state (and can break games, e.g Spriggan Mark 2)
+	_seekDelay = 0;
+}
+
 void PceCdAudioPlayer::PlaySample()
 {
 	if(_state.Status == CdAudioStatus::Playing) {

--- a/Core/PCE/CdRom/PceCdAudioPlayer.h
+++ b/Core/PCE/CdRom/PceCdAudioPlayer.h
@@ -39,7 +39,7 @@ public:
 	void SetEndPosition(uint32_t endSector, CdPlayEndBehavior endBehavior);
 	void Stop() { _state.Status = CdAudioStatus::Stopped; }
 	void Pause() { _state.Status = CdAudioStatus::Paused; }
-	void SetIdle() { _state.Status = CdAudioStatus::Inactive; }
+	void SetIdle();
 
 	PceCdAudioPlayerState& GetState() { return _state; }
 


### PR DESCRIPTION
The game starts trying to play an audio track, but then cancels it before the seek operation completes and starts loading data instead. This triggered a bug where the cancelled play/seek operation would send a SCSI "good" status message, breaking the SCSI bus' state and causing the game to freeze.