### PR TITLE
Lua: Misc. fixes & improvements

### DIFF
--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -32,6 +32,7 @@
     <ClInclude Include="Shared\Movies\BizHawkMovie.h" />
     <ClInclude Include="Shared\Utilities\S3511ARtc.h" />
     <ClInclude Include="Shared\Video\BlendFilter.h" />
+    <ClInclude Include="Shared\Video\DrawPixelsCommand.h" />
     <ClInclude Include="SNES\Input\AsciiTurboFileTwinStf.h" />
     <ClInclude Include="SNES\Input\AsciiTurboFileTwinTf2.h" />
     <ClInclude Include="Shared\Utilities\AvMergeUtilities.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -3018,6 +3018,9 @@
     <ClInclude Include="Shared\Video\BlendFilter.h">
       <Filter>Shared\Video</Filter>
     </ClInclude>
+    <ClInclude Include="Shared\Video\DrawPixelsCommand.h">
+      <Filter>Shared\Video</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Shared\Video\RotateFilter.cpp">

--- a/Core/Debugger/LuaApi.cpp
+++ b/Core/Debugger/LuaApi.cpp
@@ -112,6 +112,7 @@ int LuaApi::GetLibrary(lua_State* lua)
 		{ "drawString", LuaApi::DrawString },
 
 		{ "drawPixel", LuaApi::DrawPixel },
+		{ "drawPixels", LuaApi::DrawPixels },
 		{ "drawLine", LuaApi::DrawLine },
 		{ "drawRectangle", LuaApi::DrawRectangle },
 		{ "clearScreen", LuaApi::ClearScreen },
@@ -600,6 +601,39 @@ int LuaApi::DrawPixel(lua_State* lua)
 
 	int startFrame = _emu->GetFrameCount() + displayDelay;
 	GetHud()->DrawPixel(x, y, color, frameCount, startFrame);
+
+	return l.ReturnCount();
+}
+
+int LuaApi::DrawPixels(lua_State* lua)
+{
+	LuaCallHelper l(lua);
+	l.ForceParamCount(7);
+	int displayDelay = l.ReadInteger(0);
+	int frameCount = l.ReadInteger(1);
+	l.SkipParam();
+	int x = l.ReadIntegerFromIndex(1);
+	int y = l.ReadIntegerFromIndex(2);
+	int width = l.ReadIntegerFromIndex(3);
+	int height = l.ReadIntegerFromIndex(4);
+	checkminparams(5);
+
+	luaL_checktype(lua, -1, LUA_TTABLE);
+
+	uint32_t* data = new uint32_t[width * height];
+	std::fill(data, data + width * height, 0xFF000000);
+
+	for(int i = 0, len = width * height; i < len; i++) {
+		if(lua_rawgeti(lua, -1, i + 1) != LUA_TNIL) {
+			data[i] = (uint32_t)lua_tointeger(lua, -1);
+		}
+		lua_pop(lua, 1);
+	}
+
+	lua_pop(lua, 5);
+
+	int startFrame = _emu->GetFrameCount() + displayDelay;
+	GetHud()->DrawPixels(data, x, y, width, height, frameCount, startFrame);
 
 	return l.ReturnCount();
 }

--- a/Core/Debugger/LuaApi.cpp
+++ b/Core/Debugger/LuaApi.cpp
@@ -1001,8 +1001,7 @@ int LuaApi::GetAccessCounters(lua_State* lua)
 	checkparams();
 
 	uint32_t size = _memoryDumper->GetMemorySize(memoryType);
-	vector<AddressCounters> counts;
-	counts.resize(size, {});
+	vector<AddressCounters> counts(size);
 	_debugger->GetMemoryAccessCounter()->GetAccessCounts(0, size, memoryType, counts.data());
 
 	auto getValue = [&](AddressCounters& counter) -> uint64_t {
@@ -1046,8 +1045,7 @@ int LuaApi::GetCdlData(lua_State* lua)
 	}
 
 	uint32_t size = _memoryDumper->GetMemorySize(memoryType);
-	vector<uint8_t> cdlData;
-	cdlData.resize(size, {});
+	vector<uint8_t> cdlData(size);
 	_debugger->GetCdlManager()->GetCdlData(0, size, memoryType, cdlData.data());
 
 	lua_newtable(lua);
@@ -1163,9 +1161,11 @@ int LuaApi::GetState(lua_State* lua)
 	uint32_t frameCount = _emu->GetFrameCount();
 	uint32_t masterClock = _emu->GetMasterClock();
 	uint32_t clockRate = _emu->GetMasterClockRate();
+	double fps = _emu->GetConsole()->GetFps();
 	string consoleType = string(magic_enum::enum_name<ConsoleType>(_emu->GetConsoleType()));
 	string region = string(magic_enum::enum_name<ConsoleRegion>(_emu->GetRegion()));
 
+	SV(fps);
 	SV(clockRate);
 	SV(consoleType);
 	SV(region);

--- a/Core/Debugger/LuaApi.h
+++ b/Core/Debugger/LuaApi.h
@@ -49,6 +49,7 @@ public:
 
 	static int DrawLine(lua_State* lua);
 	static int DrawPixel(lua_State* lua);
+	static int DrawPixels(lua_State* lua);
 	static int DrawRectangle(lua_State* lua);
 	static int ClearScreen(lua_State* lua);
 

--- a/Core/Debugger/LuaCallHelper.cpp
+++ b/Core/Debugger/LuaCallHelper.cpp
@@ -18,13 +18,19 @@ bool LuaCallHelper::CheckParamCount(int minParamCount)
 	if(minParamCount >= 0 && _stackSize < _paramCount && _stackSize >= minParamCount) {
 		return true;
 	}
-	return CheckSpecificParamCount(_paramCount);
+	return CheckSpecificParamCount(_paramCount, minParamCount);
 }
 
-bool LuaCallHelper::CheckSpecificParamCount(int count)
+bool LuaCallHelper::CheckSpecificParamCount(int count, int minParamCount)
 {
 	if(_stackSize != count) {
-		string message = string("too ") + (_stackSize < count ? "few" : "many") + " parameters.  expected " + std::to_string(count) + " got " + std::to_string(_stackSize);
+		string message = string("too ") + (_stackSize < count ? "few" : "many") + " parameters. expected ";
+		if(minParamCount >= 0) {
+			message += std::to_string(minParamCount) + " to " + std::to_string(count);
+		} else {
+			message += std::to_string(count);
+		}
+		message += ", got " + std::to_string(_stackSize);
 		luaL_error(_lua, message.c_str());
 		return false;
 	}
@@ -83,6 +89,18 @@ Nullable<int32_t> LuaCallHelper::ReadOptionalInteger()
 	}
 	lua_pop(_lua, 1);
 	return result;
+}
+
+uint32_t LuaCallHelper::ReadIntegerFromIndex(int32_t index)
+{
+	_paramCount++;
+	uint32_t value = 0;
+	if(lua_isinteger(_lua, index)) {
+		value = (uint32_t)lua_tointeger(_lua, index);
+	} else if(lua_isnumber(_lua, -1)) {
+		value = (uint32_t)lua_tonumber(_lua, index);
+	}
+	return value;
 }
 
 uint32_t LuaCallHelper::ReadInteger(uint32_t defaultValue)

--- a/Core/Debugger/LuaCallHelper.h
+++ b/Core/Debugger/LuaCallHelper.h
@@ -22,11 +22,14 @@ public:
 
 	void ForceParamCount(int paramCount);
 	bool CheckParamCount(int minParamCount = -1);
-	bool CheckSpecificParamCount(int count);
+	bool CheckSpecificParamCount(int count, int minParamCount = -1);
+
+	void SkipParam() { _paramCount++; }
 
 	double ReadDouble();
 	bool ReadBool(bool defaultValue = false);
 	uint32_t ReadInteger(uint32_t defaultValue = 0);
+	uint32_t ReadIntegerFromIndex(int32_t index);
 	string ReadString();
 	int GetReference();
 

--- a/Core/Debugger/ScriptingContext.cpp
+++ b/Core/Debugger/ScriptingContext.cpp
@@ -12,7 +12,6 @@
 #include "Shared/Emulator.h"
 #include "Shared/EmuSettings.h"
 #include "Shared/EventType.h"
-#include "Shared/SaveStateManager.h"
 #include "Utilities/magic_enum.hpp"
 #include "Utilities/StringUtilities.h"
 
@@ -181,9 +180,34 @@ void ScriptingContext::LuaOpenLibs(lua_State* L, bool allowIoOsAccess)
 void ScriptingContext::Log(string message)
 {
 	auto lock = _logLock.AcquireSafe();
-	_logRows.push_back(message);
-	if(_logRows.size() > 500) {
-		_logRows.pop_front();
+	size_t start = 0;
+
+	if(message.size() <= 200) {
+		_logRows.push_back(message);
+		if(_logRows.size() > 500) {
+			_logRows.pop_front();
+		}
+	} else {
+		//Split large strings into several separate lines
+		//This is needed to prevent performance issues in the UI
+		//when a single line is several thousand characters long.
+		while(start < message.size()) {
+			size_t pos = message.find_first_of(',', start + 200);
+
+			if(pos == string::npos) {
+				pos = message.find_first_of(' ', start + 200);
+				if(pos == string::npos) {
+					pos = std::min<size_t>(message.size() - 1, start + 300);
+				}
+			}
+
+			_logRows.push_back(message.substr(start, pos - start + 1));
+			start = pos + 1;
+
+			if(_logRows.size() > 500) {
+				_logRows.pop_front();
+			}
+		}
 	}
 }
 

--- a/Core/Shared/Video/DebugHud.cpp
+++ b/Core/Shared/Video/DebugHud.cpp
@@ -4,9 +4,9 @@
 #include "Shared/Video/DrawCommand.h"
 #include "Shared/Video/DrawLineCommand.h"
 #include "Shared/Video/DrawPixelCommand.h"
+#include "Shared/Video/DrawPixelsCommand.h"
 #include "Shared/Video/DrawRectangleCommand.h"
 #include "Shared/Video/DrawStringCommand.h"
-#include "Shared/Video/DrawScreenBufferCommand.h"
 
 DebugHud::DebugHud()
 {
@@ -77,6 +77,11 @@ bool DebugHud::Draw(uint32_t* argbBuffer, FrameInfo frameInfo, OverscanDimension
 void DebugHud::DrawPixel(int x, int y, int color, int frameCount, int startFrame)
 {
 	AddCommand(unique_ptr<DrawCommand>(new DrawPixelCommand(x, y, color, frameCount, startFrame)));
+}
+
+void DebugHud::DrawPixels(uint32_t* data, int x, int y, int width, int height, int frameCount, int startFrame)
+{
+	AddCommand(unique_ptr<DrawCommand>(new DrawPixelsCommand(data, x, y, width, height, frameCount, startFrame)));
 }
 
 void DebugHud::DrawLine(int x, int y, int x2, int y2, int color, int frameCount, int startFrame)

--- a/Core/Shared/Video/DebugHud.h
+++ b/Core/Shared/Video/DebugHud.h
@@ -23,6 +23,7 @@ public:
 	void ClearScreen();
 
 	void DrawPixel(int x, int y, int color, int frameCount, int startFrame = -1);
+	void DrawPixels(uint32_t* data, int x, int y, int width, int height, int frameCount, int startFrame = -1);
 	void DrawLine(int x, int y, int x2, int y2, int color, int frameCount, int startFrame = -1);
 	void DrawRectangle(int x, int y, int width, int height, int color, bool fill, int frameCount, int startFrame = -1);
 	void DrawString(int x, int y, string text, int color, int backColor, int frameCount, int startFrame = -1, int maxWidth = 0, bool overwritePixels = false);

--- a/Core/Shared/Video/DrawPixelsCommand.h
+++ b/Core/Shared/Video/DrawPixelsCommand.h
@@ -5,7 +5,7 @@
 class DrawPixelsCommand : public DrawCommand
 {
 private:
-	int _x, _y, _height, _width;
+	int _x, _y, _width, _height;
 	uint32_t* _data = nullptr;
 
 protected:

--- a/Core/Shared/Video/DrawPixelsCommand.h
+++ b/Core/Shared/Video/DrawPixelsCommand.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "pch.h"
+#include "Shared/Video/DrawCommand.h"
+
+class DrawPixelsCommand : public DrawCommand
+{
+private:
+	int _x, _y, _height, _width;
+	uint32_t* _data = nullptr;
+
+protected:
+	void InternalDraw()
+	{
+		int pos = 0;
+		for(int i = 0; i < _height; i++) {
+			for(int j = 0; j < _width; j++) {
+				DrawPixel(_x + j, _y + i, _data[pos] ^ 0xFF000000);
+				pos++;
+			}
+		}
+	}
+
+public:
+	DrawPixelsCommand(uint32_t* data, int x, int y, int width, int height, int frameCount, int startFrame) : DrawCommand(startFrame, frameCount), _x(x), _y(y), _width(width), _height(height)
+	{
+		_data = data;
+	}
+
+	~DrawPixelsCommand()
+	{
+		delete[] _data;
+	}
+};

--- a/UI/Config/Debugger/ScriptWindowConfig.cs
+++ b/UI/Config/Debugger/ScriptWindowConfig.cs
@@ -1,12 +1,7 @@
-﻿using Avalonia;
-using Avalonia.Media;
-using Mesen.Interop;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Mesen.Config
 {
@@ -29,7 +24,7 @@ namespace Mesen.Config
 		[ObservableProperty] public partial bool AllowIoOsAccess { get; set; } = false;
 		[ObservableProperty] public partial bool AllowNetworkAccess { get; set; } = false;
 
-		[ObservableProperty] public partial bool ShowLineNumbers { get; set; } = false;
+		[ObservableProperty] public partial bool ShowLineNumbers { get; set; } = true;
 
 		[ObservableProperty] public partial UInt32 ScriptTimeout { get; set; } = 1;
 

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -138,8 +138,8 @@
 	"subcategory": "AccessCounters",
 	"description": "Returns an array of access counters for the specified memory and operation types.",
 	"parameters": [
-		{ "name": "counterType", "type": "Enum", "enumName": "counterType", "description": "Counter type" },
-		{ "name": "memoryType", "type": "Enum", "enumName": "memType", "description": "Memory type" }
+		{ "name": "memoryType", "type": "Enum", "enumName": "memType", "description": "Memory type" },
+		{ "name": "counterType", "type": "Enum", "enumName": "counterType", "description": "Counter type" }
 	],
 	"returnValue": { "type": "Array", "description": "Array of ints" }
 },

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -103,6 +103,20 @@
 	]
 },
 {
+	"name": "drawPixels",
+	"category": "Drawing",
+	"description": "Draws a block of pixels at the specified (x, y) coordinates.",
+	"parameters": [
+		{ "name": "x", "type": "Int", "description": "X position" },
+		{ "name": "y", "type": "Int", "description": "Y position" },
+		{ "name": "width", "type": "Int", "description": "Width" },
+		{ "name": "height", "type": "Int", "description": "Height" },
+		{ "name": "pixelData", "type": "Table", "description": "Array of integers in ARGB format (first pixel at index 1)" },
+		{ "name": "duration", "type": "Int", "description": "Number of frames to display", "defaultValue": "1" },
+		{ "name": "delay", "type": "Int", "description": "Number of frames to wait before drawing", "defaultValue": "0" }
+	]
+},
+{
 	"name": "drawRectangle",
 	"category": "Drawing",
 	"description": "Draws a rectangle between (x, y) to (x+width, y+height) using the specified color for a specific number of frames. If fill is false, only the rectangle's outline will be drawn.",

--- a/UI/Debugger/ViewModels/ScriptWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ScriptWindowViewModel.cs
@@ -20,7 +20,7 @@ using System.Threading.Tasks;
 
 namespace Mesen.Debugger.ViewModels
 {
-	public partial class ScriptWindowViewModel : ViewModelBase
+	public partial class ScriptWindowViewModel : DisposableViewModel
 	{
 		public ScriptWindowConfig Config { get; } = ConfigManager.Config.Debug.ScriptWindow;
 
@@ -46,14 +46,14 @@ namespace Mesen.Debugger.ViewModels
 
 		public ScriptWindowViewModel(ScriptStartupBehavior? behavior)
 		{
-			this.ObserveProp(nameof(ScriptName), () => {
+			this.AddDisposable(this.ObserveProp(nameof(ScriptName), () => {
 				string wndTitle = ResourceHelper.GetViewLabel(nameof(ScriptWindow), "wndTitle");
 				if(!string.IsNullOrWhiteSpace(ScriptName)) {
 					WindowTitle = wndTitle + " - " + ScriptName;
 				} else {
 					WindowTitle = wndTitle;
 				}
-			});
+			}));
 
 			switch(behavior ?? Config.ScriptStartupBehavior) {
 				case ScriptStartupBehavior.ShowBlankWindow: break;
@@ -66,15 +66,21 @@ namespace Mesen.Debugger.ViewModels
 			}
 		}
 
+		protected override void DisposeView()
+		{
+			base.DisposeView();
+			_fileWatcher.Dispose();
+		}
+
 		public void InitActions(ScriptWindow wnd)
 		{
 			_wnd = wnd;
 
-			ScriptMenuActions = GetScriptMenuActions();
-			ToolbarActions = GetToolbarActions();
+			ScriptMenuActions = AddDisposables(GetScriptMenuActions());
+			ToolbarActions = AddDisposables(GetToolbarActions());
 
-			FileMenuActions = GetSharedFileActions();
-			FileMenuActions.AddRange(new List<ContextMenuAction>() {
+			FileMenuActions = AddDisposables(GetSharedFileActions());
+			FileMenuActions.AddRange(AddDisposables(new List<ContextMenuAction>() {
 				new ContextMenuAction() {
 					ActionType = ActionType.SaveAs,
 					OnClick = async () => await SaveAs(Path.GetFileName(FilePath))
@@ -105,9 +111,9 @@ namespace Mesen.Debugger.ViewModels
 					ActionType = ActionType.Exit,
 					OnClick = () => _wnd?.Close()
 				}
-			});
+			}));
 
-			HelpMenuActions = new() {
+			HelpMenuActions = AddDisposables(new List<ContextMenuAction>() {
 				new ContextMenuAction() {
 					ActionType = ActionType.HelpApiReference,
 					OnClick = () => {
@@ -117,7 +123,7 @@ namespace Mesen.Debugger.ViewModels
 						}
 					}
 				}
-			};
+			});
 
 			DebugShortcutManager.RegisterActions(_wnd, ScriptMenuActions);
 			DebugShortcutManager.RegisterActions(_wnd, FileMenuActions);
@@ -315,7 +321,7 @@ namespace Mesen.Debugger.ViewModels
 			FilePath = filename;
 			ScriptName = Path.GetFileName(filename);
 
-			_fileWatcher.EnableRaisingEvents = false;
+			_fileWatcher.Dispose();
 
 			_fileWatcher = new(Path.GetDirectoryName(FilePath) ?? "", Path.GetFileName(FilePath));
 			_fileWatcher.Changed += (s, e) => {
@@ -346,10 +352,15 @@ namespace Mesen.Debugger.ViewModels
 		{
 			if(!string.IsNullOrWhiteSpace(FilePath)) {
 				if(_originalText != Code) {
-					if(FileHelper.WriteAllText(FilePath, Code, Encoding.UTF8)) {
-						_originalText = Code;
-					} else {
-						return false;
+					_fileWatcher.EnableRaisingEvents = false;
+					try {
+						if(FileHelper.WriteAllText(FilePath, Code, Encoding.UTF8)) {
+							_originalText = Code;
+						} else {
+							return false;
+						}
+					} finally {
+						_fileWatcher.EnableRaisingEvents = true;
 					}
 				}
 				return true;

--- a/UI/Interop/DebugApi.cs
+++ b/UI/Interop/DebugApi.cs
@@ -187,9 +187,9 @@ namespace Mesen.Interop
 		[DllImport(DllPath, EntryPoint = "GetScriptLog")] private static extern void GetScriptLogWrapper(Int32 scriptId, IntPtr outScriptLog, Int32 maxLength);
 		public unsafe static string GetScriptLog(Int32 scriptId)
 		{
-			byte[] outScriptLog = new byte[100000];
+			byte[] outScriptLog = new byte[200000];
 			fixed(byte* ptr = outScriptLog) {
-				DebugApi.GetScriptLogWrapper(scriptId, (IntPtr)ptr, outScriptLog.Length);
+				DebugApi.GetScriptLogWrapper(scriptId, (IntPtr)ptr, outScriptLog.Length - 1);
 				return Utf8Utilities.PtrToStringUtf8((IntPtr)ptr);
 			}
 		}


### PR DESCRIPTION
-Fixed getAccessCounters documentation (swapped param order)
-Fixed file watcher not being disabled properly when closing the script window, causing the script to run if changed on the disk, even if the script window is closed
-Prevent file watcher from triggering from writes done by the script window itself (which caused the script to be reloaded 2 or 3 times in a row)
-Fixed UI freezes when using emu.log() on a large table
-Fixed crash when 100k character limit (in the last 500 lines) for script log was reached (out of bounds read/write)
-Added "fps" value to "getState"
-Slightly improved getAccessCounters/getCdlData performance
-Added a new emu.drawPixels API to improve performance when a script needs to draw a lot of individual pixels