### PR TITLE
UI: Fix setup wizard centering for windows

### DIFF
--- a/UI/Windows/SetupWizardWindow.axaml.cs
+++ b/UI/Windows/SetupWizardWindow.axaml.cs
@@ -30,18 +30,18 @@ namespace Mesen.Windows
 		protected override void OnOpened(EventArgs e)
 		{
 			base.OnOpened(e);
-			if(!OperatingSystem.IsLinux()) {
-				return;
-			}
+
 			//Manually center the window (Avalonia on Linux doesn't seem to
 			//work with "CenterScreen" as startup location
-			Screen? screen = Screens.ScreenFromVisual(this);
-			if(screen != null) {
-				PixelPoint pos = new PixelPoint(
-					(int)((screen.Bounds.Width - Bounds.Width) / 2),
-					(int)((screen.Bounds.Height - Bounds.Height) / 2)
-				);
-				Position = pos;
+			if(OperatingSystem.IsLinux()) {
+				Screen? screen = Screens.ScreenFromVisual(this);
+				if(screen != null) {
+					PixelPoint pos = new PixelPoint(
+						(int)((screen.Bounds.Width - Bounds.Width) / 2),
+						(int)((screen.Bounds.Height - Bounds.Height) / 2)
+					);
+					Position = pos;
+				}
 			}
 		}
 

--- a/UI/Windows/SetupWizardWindow.axaml.cs
+++ b/UI/Windows/SetupWizardWindow.axaml.cs
@@ -30,7 +30,9 @@ namespace Mesen.Windows
 		protected override void OnOpened(EventArgs e)
 		{
 			base.OnOpened(e);
-
+			if(!OperatingSystem.IsLinux()) {
+				return;
+			}
 			//Manually center the window (Avalonia on Linux doesn't seem to
 			//work with "CenterScreen" as startup location
 			Screen? screen = Screens.ScreenFromVisual(this);


### PR DESCRIPTION
<img width="470" height="390" alt="Screenshot Mesen" src="https://github.com/user-attachments/assets/2a059390-ec19-4442-b90c-7d64b186dee0" />

During the first run of Mesen.exe on my Windows desktop, the configuration window is not centered and is cut off in the bottom right of the screen as shown in the screenshot. I found that the solution was having the screen centering code that is run in the OnOpened function be exclusive to Linux. After making this change and building the solution, the issue is fixed on Windows and the configuration screen becomes centered. 

The Linux path remains unchanged, and while hypothetically this should not effect Linux, I did not test this change on Linux.