### PR TITLE
UI: Removed old unneeded patch used to center setup window on Linux

### DIFF
--- a/UI/Windows/SetupWizardWindow.axaml.cs
+++ b/UI/Windows/SetupWizardWindow.axaml.cs
@@ -27,22 +27,6 @@ namespace Mesen.Windows
 			AvaloniaXamlLoader.Load(this);
 		}
 
-		protected override void OnOpened(EventArgs e)
-		{
-			base.OnOpened(e);
-
-			//Manually center the window (Avalonia on Linux doesn't seem to
-			//work with "CenterScreen" as startup location
-			Screen? screen = Screens.ScreenFromVisual(this);
-			if(screen != null) {
-				PixelPoint pos = new PixelPoint(
-					(int)((screen.Bounds.Width - Bounds.Width) / 2),
-					(int)((screen.Bounds.Height - Bounds.Height) / 2)
-				);
-				Position = pos;
-			}
-		}
-
 		private void BtnOk_OnClick(object? sender, RoutedEventArgs e)
 		{
 			if(_model.Confirm(this)) {


### PR DESCRIPTION
This doesn't appear to be needed anymore (WindowStartupLocation = CenterScreen seems to work on Linux), and it looks like in some scenarios this could cause the setup window to appear in the wrong location on Windows