### PR TITLE
NES: Rainbow mapper updates

### DIFF
--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -12,6 +12,8 @@
 #include "Utilities/HexUtilities.h"
 #include "Utilities/Patches/IpsPatcher.h"
 
+#define MAPPER_VERSION 0x21
+
 Rainbow::Rainbow()
 {
 }
@@ -553,7 +555,7 @@ uint8_t Rainbow::ReadRegister(uint16_t addr)
 			return value;
 		}
 
-		case 0x4160: return 0x20;
+		case 0x4160: return MAPPER_VERSION;
 		case 0x4161:
 			return (
 				(uint8_t)_wifiIrqPending |
@@ -879,7 +881,7 @@ vector<MapperStateEntry> Rainbow::GetMapperStateEntries()
 	entries.push_back(MapperStateEntry("$415C/D", "Address", _fpgaRamAddr, MapperStateValueType::Number16));
 	entries.push_back(MapperStateEntry("$415E", "Increment", _fpgaRamInc, MapperStateValueType::Number8));
 
-	entries.push_back(MapperStateEntry("$4160", "Mapper Version", 0x20, MapperStateValueType::Number8));
+	entries.push_back(MapperStateEntry("$4160", "Mapper Version", MAPPER_VERSION, MapperStateValueType::Number8));
 	entries.push_back(MapperStateEntry("$4161.0", "Wi-Fi IRQ Pending", _wifiIrqPending));
 	entries.push_back(MapperStateEntry("$4161.6", "CPU IRQ Pending", _cpuIrqPending));
 	entries.push_back(MapperStateEntry("$4161.7", "Scanline IRQ Pending", _slIrqPending));

--- a/Core/NES/Mappers/Homebrew/Rainbow.cpp
+++ b/Core/NES/Mappers/Homebrew/Rainbow.cpp
@@ -77,7 +77,7 @@ void Rainbow::Reset(bool softReset)
 	WriteRegister(0x415A, 0x00);
 	WriteRegister(0x416B, 0x00);
 	WriteRegister(0x4190, 0x00);
-	WriteRegister(0x41A9, 0x03);
+	WriteRegister(0x41A9, 0x00);
 	WriteRegister(0x41AA, 0x0F);
 }
 


### PR DESCRIPTION
- updated mapper version ([details here](https://github.com/BrokeStudio/rainbow-net/blob/master/NES/mapper-doc.md#mapper-version-4160-read-only))
- updated $41A9 register reset value (EXP6/9 now disabled)