### PR TITLE
Debugger: GSU - Added profiler support

### DIFF
--- a/Core/Debugger/Profiler.cpp
+++ b/Core/Debugger/Profiler.cpp
@@ -101,6 +101,32 @@ void Profiler::UnstackFunction()
 	}
 }
 
+void Profiler::RecordSample(AddressInfo addr)
+{
+	//Used by the GSU to behave as if the current function changes
+	//every time the program counter crosses a 16-byte boundary,
+	//which allows using the profiler with the GSU even though
+	//the GSU doesn't actually ever call "functions"
+	if(addr.Address >= 0) {
+		uint32_t key = addr.Address | ((uint8_t)addr.Type << 24);
+		if(_functions.find(key) == _functions.end()) {
+			_functions[key] = ProfiledFunction();
+			_functions[key].Address = addr;
+		}
+
+		uint64_t masterClock = _cpuDebugger->GetCpuCycleCount(true);
+		uint64_t clockGap = masterClock - _prevMasterClock;
+
+		ProfiledFunction& func = _functions[_currentFunction];
+		func.InclusiveCycles += clockGap;
+		func.ExclusiveCycles += clockGap;
+		func.CallCount++;
+
+		_prevMasterClock = masterClock;
+		_currentFunction = key;
+	}
+}
+
 void Profiler::Reset()
 {
 	DebugBreakHelper helper(_debugger);

--- a/Core/Debugger/Profiler.h
+++ b/Core/Debugger/Profiler.h
@@ -46,6 +46,8 @@ public:
 	void StackFunction(AddressInfo& addr, StackFrameFlags stackFlag);
 	void UnstackFunction();
 
+	void RecordSample(AddressInfo addr);
+
 	void UpdateCpuUsage();
 
 	void Reset();

--- a/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.Instructions.cpp
@@ -211,10 +211,10 @@ void Gsu::MERGE()
 		_state.SFR.Overflow = (value & 0xC0C0) != 0;
 		_state.SFR.Sign = (value & 0x8080) != 0;
 		_state.SFR.Zero = (value & 0xF0F0) != 0;
-		ResetFlags();
 	} else {
 		ProcessCommandFx3();
 	}
+	ResetFlags();
 }
 
 void Gsu::SWAP()

--- a/Core/SNES/Coprocessors/GSU/Gsu.cpp
+++ b/Core/SNES/Coprocessors/GSU/Gsu.cpp
@@ -8,6 +8,7 @@
 #include "SNES/BaseCartridge.h"
 #include "SNES/RamHandler.h"
 #include "Shared/Emulator.h"
+#include "Shared/EventType.h"
 #include "Shared/EmuSettings.h"
 #include "Shared/MessageManager.h"
 #include "Shared/BatteryManager.h"
@@ -410,6 +411,7 @@ void Gsu::WaitForRomAccess()
 	if(!_state.GsuRomAccess) {
 		_waitForRomAccess = true;
 		_stopped = true;
+		_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gsu);
 	}
 }
 
@@ -418,12 +420,19 @@ void Gsu::WaitForRamAccess()
 	if(!_state.GsuRamAccess) {
 		_waitForRamAccess = true;
 		_stopped = true;
+		_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gsu);
 	}
 }
 
 void Gsu::UpdateRunningState()
 {
+	bool stopped = _stopped;
 	_stopped = !_state.SFR.Running || _waitForRamAccess || _waitForRomAccess;
+	if(_stopped && !stopped) {
+		_emu->ProcessEvent(EventType::HaltEnded, CpuType::Gsu);
+	} else if(stopped && !_stopped) {
+		_emu->ProcessEvent(EventType::HaltStarted, CpuType::Gsu);
+	}
 }
 
 uint8_t Gsu::ReadRomBuffer()

--- a/Core/SNES/Debugger/GsuDebugger.cpp
+++ b/Core/SNES/Debugger/GsuDebugger.cpp
@@ -10,8 +10,8 @@
 #include "Debugger/DisassemblyInfo.h"
 #include "Debugger/Disassembler.h"
 #include "Debugger/CallstackManager.h"
+#include "Debugger/Profiler.h"
 #include "Debugger/BreakpointManager.h"
-#include "Debugger/ExpressionEvaluator.h"
 #include "Debugger/Debugger.h"
 #include "Debugger/MemoryAccessCounter.h"
 #include "Debugger/CodeDataLogger.h"
@@ -33,6 +33,7 @@ GsuDebugger::GsuDebugger(Debugger* debugger) : IDebugger(debugger->GetEmulator()
 
 	_traceLogger.reset(new GsuTraceLogger(debugger, this, console->GetPpu(), _memoryManager));
 
+	_callstackManager.reset(new CallstackManager(debugger, this));
 	_breakpointManager.reset(new BreakpointManager(debugger, this, CpuType::Gsu, debugger->GetEventManager(CpuType::Snes)));
 	_step.reset(new StepRequest());
 }
@@ -57,6 +58,12 @@ void GsuDebugger::ProcessInstruction()
 
 	if(_settings->CheckDebuggerFlag(DebuggerFlags::GsuDebuggerEnabled)) {
 		_disassembler->BuildCache(addressInfo, state.SFR.GetFlagsHigh() & 0x13, CpuType::Gsu);
+	}
+
+	if((_prevProgramCounter & ~0x0F) != (addr & ~0x0F)) {
+		//To get data in the profiler, pretend that the code is split into 16-byte long functions
+		AddressInfo dst = _gsu->GetMemoryMappings()->GetAbsoluteAddress(addr & ~0x0F);
+		_callstackManager->GetProfiler()->RecordSample(dst);
 	}
 
 	_prevOpCode = state.ProgramReadBuffer;
@@ -172,7 +179,7 @@ BreakpointManager* GsuDebugger::GetBreakpointManager()
 
 CallstackManager* GsuDebugger::GetCallstackManager()
 {
-	return nullptr;
+	return _callstackManager.get();
 }
 
 IAssembler* GsuDebugger::GetAssembler()

--- a/Core/SNES/Debugger/GsuDebugger.h
+++ b/Core/SNES/Debugger/GsuDebugger.h
@@ -25,6 +25,7 @@ class GsuDebugger final : public IDebugger
 	Gsu* _gsu;
 	EmuSettings* _settings;
 
+	unique_ptr<CallstackManager> _callstackManager;
 	unique_ptr<BreakpointManager> _breakpointManager;
 	unique_ptr<GsuTraceLogger> _traceLogger;
 

--- a/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
+++ b/UI/Debugger/ViewModels/ProfilerWindowViewModel.cs
@@ -109,12 +109,10 @@ namespace Mesen.Debugger.ViewModels
 		{
 			List<ProfilerTab> tabs = new();
 			foreach(CpuType type in EmuApi.GetRomInfo().CpuTypes) {
-				if(type.SupportsCallStack()) {
-					tabs.Add(new ProfilerTab() {
-						TabName = ResourceHelper.GetEnumText(type),
-						CpuType = type
-					});
-				}
+				tabs.Add(new ProfilerTab() {
+					TabName = ResourceHelper.GetEnumText(type),
+					CpuType = type
+				});
 			}
 
 			ProfilerTabs = tabs;

--- a/UI/Interop/CpuTypeExtensions.cs
+++ b/UI/Interop/CpuTypeExtensions.cs
@@ -228,17 +228,6 @@ namespace Mesen.Interop
 			}
 		}
 
-		public static bool SupportsCallStack(this CpuType cpuType)
-		{
-			switch(cpuType) {
-				case CpuType.Gsu:
-					return false;
-
-				default:
-					return true;
-			}
-		}
-
 		public static bool SupportsMemoryMappings(this CpuType cpuType)
 		{
 			switch(cpuType) {


### PR DESCRIPTION
This is implemented by pretending every 16 bytes in ROM is a different function, allowing the profiler to display cycle counts for each individual "function" in the UI
Also fixes a missing call to ResetFlags for the merge opcode for FX3