### PR TITLE
UI: Preserve memory viewer address on type change

### DIFF
--- a/UI/Debugger/ViewModels/MemoryToolsViewModel.cs
+++ b/UI/Debugger/ViewModels/MemoryToolsViewModel.cs
@@ -98,7 +98,12 @@ namespace Mesen.Debugger.ViewModels
 
 			AddDisposable(this.ObserveProp(nameof(TblConverter), () => UpdateDataProvider()));
 
-			AddDisposable(Config.ObserveProp([nameof(Config.MemoryType), nameof(Config.BytesPerRow)], () => {
+			AddDisposable(Config.ObserveProp(nameof(Config.MemoryType), () => {
+				MaxScrollValue = (DebugApi.GetMemorySize(Config.MemoryType) / Config.BytesPerRow) - 1;
+				_editor.SetCursorPosition(_editor.SelectionStart);
+			}));
+
+			AddDisposable(Config.ObserveProp(nameof(Config.BytesPerRow), () => {
 				MaxScrollValue = (DebugApi.GetMemorySize(Config.MemoryType) / Config.BytesPerRow) - 1;
 				_editor.SetCursorPosition(0, false, true);
 			}));


### PR DESCRIPTION
  ## Summary

  - Preserve the selected address when changing the memory type in the memory viewer.
  - Clamp the selected address to the last valid byte when the new memory type is smaller.
  - Keep the existing reset-to-zero behavior when changing bytes per row.

  ## Verification

  - Built Release x64 locally.
  - Manually verified memory-type address preservation.