### PR TITLE
Lua: Fixed address value in memory callbacks when using memory types other than the default cpu memory type

### DIFF
--- a/Core/Debugger/ScriptingContext.cpp
+++ b/Core/Debugger/ScriptingContext.cpp
@@ -341,14 +341,18 @@ void ScriptingContext::InternalCallMemoryCallback(AddressInfo relAddr, T& value,
 			continue;
 		}
 
+		int32_t address;
 		if(DebugUtilities::IsRelativeMemory(callback.MemType)) {
 			if(!IsAddressMatch(callback, relAddr)) {
 				continue;
 			}
+			address = relAddr.Address;
 		} else {
-			if(!IsAddressMatch(callback, _debugger->GetAbsoluteAddress(relAddr))) {
+			AddressInfo absAddr = _debugger->GetAbsoluteAddress(relAddr);
+			if(!IsAddressMatch(callback, absAddr)) {
 				continue;
 			}
+			address = absAddr.Address;
 		}
 
 		if(needTimerReset) {
@@ -358,7 +362,7 @@ void ScriptingContext::InternalCallMemoryCallback(AddressInfo relAddr, T& value,
 
 		int top = lua_gettop(_lua);
 		lua_rawgeti(_lua, LUA_REGISTRYINDEX, callback.Reference);
-		lua_pushinteger(_lua, relAddr.Address);
+		lua_pushinteger(_lua, address);
 		lua_pushinteger(_lua, value);
 		if(lua_pcall(_lua, 2, LUA_MULTRET, 0) != 0) {
 			ProcessLuaError();

--- a/Core/Gameboy/GbPpu.cpp
+++ b/Core/Gameboy/GbPpu.cpp
@@ -1198,11 +1198,11 @@ void GbPpu::WriteOam(uint8_t addr, uint8_t value, bool forDma)
 	//On the DMG, there is a 4 clock gap (80 to 83) between OAM evaluation & rendering where writing is allowed
 	if(addr < 0xA0) {
 		if(forDma) {
-			_oam[addr] = value;
 			_emu->ProcessPpuWrite<CpuType::Gameboy>(addr, value, MemoryType::GbSpriteRam);
+			_oam[addr] = value;
 		} else if(IsOamWriteAllowed()) {
-			_oam[addr] = value;
 			_emu->ProcessPpuWrite<CpuType::Gameboy>(addr, value, MemoryType::GbSpriteRam);
+			_oam[addr] = value;
 		} else {
 			_emu->BreakIfDebugging(CpuType::Gameboy, BreakSource::GbInvalidOamAccess);
 		}

--- a/Core/NES/NesPpu.cpp
+++ b/Core/NES/NesPpu.cpp
@@ -462,8 +462,8 @@ template<class T> void NesPpu<T>::WriteRam(uint16_t addr, uint8_t value)
 					//"The three unimplemented bits of each sprite's byte 2 do not exist in the PPU and always read back as 0 on PPU revisions that allow reading PPU OAM through OAMDATA ($2004)"
 					value &= 0xE3;
 				}
-				WriteSpriteRam(_spriteRamAddr, value);
 				_emu->ProcessPpuWrite<CpuType::Nes>(_spriteRamAddr, value, MemoryType::NesSpriteRam);
+				WriteSpriteRam(_spriteRamAddr, value);
 				if(_region == ConsoleRegion::Ntsc || _scanline < _palSpriteEvalScanline || ((_cycle & 1) && (_cycle != 339))) {
 					_spriteRamAddr++;
 				}
@@ -1605,8 +1605,9 @@ template<class T> void NesPpu<T>::UpdateState()
 		_ppuMemoryDataWriteStateMachine--;
 		if(_ppuMemoryDataWriteStateMachine == 0) {
 			if((_ppuBusAddress & 0x3FFF) >= 0x3F00) {
-				WritePaletteRam(_ppuBusAddress, _ppuMemoryDataWriteLatch);
-				_emu->ProcessPpuWrite<CpuType::Nes>(_ppuBusAddress, _ppuMemoryDataWriteLatch, MemoryType::NesPpuMemory);
+				uint8_t value = _ppuMemoryDataWriteLatch;
+				_emu->ProcessPpuWrite<CpuType::Nes>(_ppuBusAddress, value, MemoryType::NesPpuMemory);
+				WritePaletteRam(_ppuBusAddress, value);
 			} else {
 				if(_scanline >= 240 || !IsRenderingEnabled()) {
 					_mapper->WriteVram(_ppuBusAddress & 0x3FFF, _ppuMemoryDataWriteLatch);

--- a/UI/Debugger/Documentation/LuaDocumentation.json
+++ b/UI/Debugger/Documentation/LuaDocumentation.json
@@ -331,7 +331,7 @@
 	"parameters": [
 		{ "name": "address", "type": "Int", "description": "Address to read from" },
 		{ "name": "memoryType", "type": "Enum", "enumName": "memType", "description": "Memory type to read from" },
-		{ "name": "signed", "type": "Bool", "description": "When true, the return value is an 8-bit signed value." }
+		{ "name": "signed", "type": "Bool", "description": "When true, the return value is an 8-bit signed value.", "defaultValue": "false" }
 	],
 	"returnValue": { "type": "Int", "description": "An 8-bit (signed or unsigned) value." }
 },
@@ -342,7 +342,7 @@
 	"parameters": [
 		{ "name": "address", "type": "Int", "description": "Address to read from" },
 		{ "name": "memoryType", "type": "Enum", "enumName": "memType", "description": "Memory type to read from" },
-		{ "name": "signed", "type": "Bool", "description": "When true, the return value is a 16-bit signed value." }
+		{ "name": "signed", "type": "Bool", "description": "When true, the return value is a 16-bit signed value.", "defaultValue": "false" }
 	],
 	"returnValue": { "type": "Int", "description": "A 16-bit (signed or unsigned) value." }
 },
@@ -353,7 +353,7 @@
 	"parameters": [
 		{ "name": "address", "type": "Int", "description": "Address to read from" },
 		{ "name": "memoryType", "type": "Enum", "enumName": "memType", "description": "Memory type to read from" },
-		{ "name": "signed", "type": "Bool", "description": "When true, the return value is a 32-bit signed value." }
+		{ "name": "signed", "type": "Bool", "description": "When true, the return value is a 32-bit signed value.", "defaultValue": "false" }
 	],
 	"returnValue": { "type": "Int", "description": "A 32-bit (signed or unsigned) value." }
 },


### PR DESCRIPTION
Also fixed a few scenarios where the PPU memory write callbacks did not allow the Lua script to change the value about to be written (because the callback was called too late)