### PR TITLE
Debugger: Profiler/Trace logger/Watch - Fixed empty window/missing options for all consoles/games with a single CPU

### DIFF
--- a/UI/Debugger/Windows/DebuggerWindow.axaml
+++ b/UI/Debugger/Windows/DebuggerWindow.axaml
@@ -32,9 +32,6 @@
 	</Design.DataContext>
 
 	<Window.Styles>
-		<Style Selector="TabStrip:singleitem">
-			<Setter Property="IsVisible" Value="False" />
-		</Style>
 		<Style Selector="idc|ToolChromeControl">
 			<Setter Property="Margin" Value="0 0 1 0" />
 		</Style>

--- a/UI/Debugger/Windows/MemoryToolsWindow.axaml
+++ b/UI/Debugger/Windows/MemoryToolsWindow.axaml
@@ -24,12 +24,6 @@
 		<dvm:MemoryToolsViewModel />
 	</Design.DataContext>
 
-	<Window.Styles>
-		<Style Selector="TabStrip:singleitem">
-			<Setter Property="IsVisible" Value="False" />
-		</Style>
-	</Window.Styles>
-
 	<DockPanel>
 		<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">
 			<MenuItem Header="{l:Translate mnuFile}" ItemsSource="{Binding FileMenuItems}" />

--- a/UI/Debugger/Windows/ProfilerWindow.axaml
+++ b/UI/Debugger/Windows/ProfilerWindow.axaml
@@ -26,7 +26,8 @@
 
 	<Window.Styles>
 		<Style Selector="TabControl:singleitem > TabItem">
-			<Setter Property="IsVisible" Value="False" />
+			<Setter Property="Height" Value="0" />
+			<Setter Property="MinHeight" Value="0" />
 		</Style>
 	</Window.Styles>
 

--- a/UI/Debugger/Windows/TilemapViewerWindow.axaml
+++ b/UI/Debugger/Windows/TilemapViewerWindow.axaml
@@ -24,12 +24,6 @@
 		<dvm:TilemapViewerViewModel />
 	</Design.DataContext>
 
-	<Window.Styles>
-		<Style Selector="TabStrip:singleitem">
-			<Setter Property="IsVisible" Value="False" />
-		</Style>		
-	</Window.Styles>
-
 	<DockPanel>
 		<Panel DockPanel.Dock="Top">
 			<c:MesenMenu DockPanel.Dock="Top" Name="ActionMenu">

--- a/UI/Debugger/Windows/TraceLoggerWindow.axaml
+++ b/UI/Debugger/Windows/TraceLoggerWindow.axaml
@@ -30,7 +30,8 @@
 			<Setter Property="Background" Value="#28808080" />
 		</Style>
 		<Style Selector="TabControl:singleitem > TabItem">
-			<Setter Property="IsVisible" Value="False" />
+			<Setter Property="Height" Value="0" />
+			<Setter Property="MinHeight" Value="0" />
 		</Style>
 	</Window.Styles>
 

--- a/UI/Debugger/Windows/WatchWindow.axaml
+++ b/UI/Debugger/Windows/WatchWindow.axaml
@@ -27,7 +27,8 @@
 
 	<Window.Styles>
 		<Style Selector="TabControl:singleitem > TabItem">
-			<Setter Property="IsVisible" Value="False" />
+			<Setter Property="Height" Value="0" />
+			<Setter Property="MinHeight" Value="0" />
 		</Style>
 	</Window.Styles>
 	


### PR DESCRIPTION
This was caused by the Avalonia 12.1 upgrade