### PR TITLE
GBA: Fixed REG_KEYCNT reading byte swapped

### DIFF
--- a/Core/GBA/GbaControlManager.cpp
+++ b/Core/GBA/GbaControlManager.cpp
@@ -92,9 +92,9 @@ uint8_t GbaControlManager::ReadInputPort(uint32_t addr)
 {
 	if(addr & 0x02) {
 		if(addr & 0x01) {
-			return BitUtilities::GetBits<0>(_state.KeyControl);
-		} else {
 			return BitUtilities::GetBits<8>(_state.KeyControl);
+		} else {
+			return BitUtilities::GetBits<0>(_state.KeyControl);
 		}
 	} else {
 		SetInputReadFlag();


### PR DESCRIPTION
IO port 0x04000133 contains the most significant byte of KEYCNT, not the least significant one.

The attached test ROM sets REG_KEYCNT to 0x43FF, then reads the register again and displays the value. It displays `43FF` on my GBA SP, but `FF43` on Mesen (before applying this commit).
[keycnt-testrom.zip](https://github.com/user-attachments/files/31700926/keycnt-testrom.zip)
